### PR TITLE
表記ゆれへの対応: 町名についても「ケ」「ヶ」「が」の表記のゆれを考慮するように修正

### DIFF
--- a/src/parser/read_town.rs
+++ b/src/parser/read_town.rs
@@ -17,6 +17,11 @@ pub fn read_town(input: &str, city: City) -> Option<(String, String)> {
         if let Some(result) = adapt_variety_of_spelling(input, &town.name, vec!["ツ", "ッ"]) {
             return Some(result);
         }
+        // 「ケ」「ヶ」「が」の表記ゆれに対応する
+        if let Some(result) = adapt_variety_of_spelling(input, &town.name, vec!["ケ", "ヶ", "が"])
+        {
+            return Some(result);
+        }
     }
     None
 }


### PR DESCRIPTION
### 概要
町名の解析においても、「ケ」「ヶ」「が」の表記のゆれを考慮するように修正
- 「松ヶ崎杉ヶ海道町」「松ケ崎杉ケ海道町」

### その他
- #5 
- #6 
- 「松ケ崎杉ヶ海道町」や「松ヶ崎杉ケ海道町」のような入力を与えると解析に失敗するが、こちらについては別途対応とする