### PR TITLE
OpenSSLではなくRustlsを使用する

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["rlib", "cdylib"]
 [dependencies]
 console_error_panic_hook = "0.1.7"
 nom = "7.1.3"
-reqwest = { version = "0.11.22", features = ["json"] }
+reqwest = { version = "0.11.22", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.108"
 wasm-bindgen = "0.2.88"


### PR DESCRIPTION
Android向けにビルドしようとしたとき、OpenSSLのビルドにエラーが発生するため、回避策としてrustlsを使用することにした