### PR TITLE
返り値の変更: `serde_json`を依存関係から削除

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ nom = "7.1.3"
 reqwest = { version = "0.11.22", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { version = "1.0.192", features = ["derive"] }
 serde-wasm-bindgen = "0.6.1"
-serde_json = "1.0.108"
 tsify = { version = "0.4.5", features = ["js"] }
 wasm-bindgen = "0.2.88"
 wasm-bindgen-futures = "0.4.38"


### PR DESCRIPTION
### 変更点
- 間接的には使用しているが、直接は参照しなくなったため依存関係から削除する

### 備考
- #34 