### PR TITLE
返り値の変更: テストコードを修正

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -28,13 +28,13 @@ impl From<ParseResult> for JsValue {
 }
 
 #[cfg(test)]
-mod integration_tests {
+mod parser_tests {
     use crate::entity::{Address, ParseResult};
     use crate::err::{Error, ParseErrorKind};
     use crate::wasm::Parser;
 
     #[tokio::test]
-    async fn parse_success() {
+    async fn parse_成功_実在する住所() {
         let parser = Parser();
         assert_eq!(
             parser.parse("岩手県盛岡市内丸10番1号").await,
@@ -46,7 +46,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn parse_fail_unknown_town_name() {
+    async fn parse_失敗_実在しない町名() {
         let parser = Parser();
         assert_eq!(
             parser.parse("東京都中央区銀座九丁目").await,


### PR DESCRIPTION
### 変更点
- `wasm_bindgen_test`から`tokio::test`に変更
- テスト関数の名前を変更

### 備考
- #34 