### PR TITLE
crates.ioにアップロードする際、`tests`以下は含めないようにする

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/YuukiToriyama/japanese-address-parser"
 license = "MIT"
 exclude = [
     "public/*",
+    "tests/*",
     ".github/*",
 ]
 


### PR DESCRIPTION
### 概要
`./tests`以下の結合テストは開発が進むにつれて肥大化していくおそれがあるので、crates.ioにアップロードする時には含めないように修正

### 変更点
#### 修正前
```terminal
cargo package --list
```

```text
.cargo_vcs_info.json
.gitignore
Cargo.toml
Cargo.toml.orig
LICENSE
README.md
rust-toolchain.toml
src/api/blocking.rs
src/api/client.rs
src/api/mock.rs
src/api.rs
src/entity.rs
src/err.rs
src/lib.rs
src/parser/adapter/orthographical_variant_adapter.rs
src/parser/adapter.rs
src/parser/read_city.rs
src/parser/read_prefecture.rs
src/parser/read_town.rs
src/parser.rs
tests/common/mod.rs
tests/integration_tests.rs
tests/test_data/異字体旧字体への対応.csv
tests/test_data/県庁所在地の住所データ.csv
```

#### 修正後
```terminal
cargo package --list
```

```text
.cargo_vcs_info.json
.gitignore
Cargo.toml
Cargo.toml.orig
LICENSE
README.md
rust-toolchain.toml
src/api/blocking.rs
src/api/client.rs
src/api/mock.rs
src/api.rs
src/entity.rs
src/err.rs
src/lib.rs
src/parser/adapter/orthographical_variant_adapter.rs
src/parser/adapter.rs
src/parser/read_city.rs
src/parser/read_prefecture.rs
src/parser/read_town.rs
src/parser.rs
```
