### PR TITLE
Rust1.75.0対応をrelease/v0.1.0-alpha.8にマージ

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-11-17"
+channel = "1.75"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(async_fn_in_trait)]
-
 use crate::api::client::ApiImpl;
 use crate::entity::ParseResult;
 use wasm_bindgen::prelude::wasm_bindgen;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,5 +1,3 @@
-#![feature(async_closure)]
-
 use crate::common::run_data_driven_tests;
 
 mod common;


### PR DESCRIPTION
### 概要
- Rustの1.75.0がstableになったので、これを用いるように修正

### 備考
- #80 