### PR TITLE
parserモジュールのエンハンス: wasm32向けにビルドする際の警告を解除

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,6 @@
-use crate::api::{Api, BlockingApi};
+use crate::api::Api;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::api::BlockingApi;
 use crate::entity::{Address, ParseResult};
 use crate::err::{Error, ParseErrorKind};
 use crate::parser::read_city::read_city;


### PR DESCRIPTION
### 変更点
- wasm32向けにビルドする際に、`BlockingApi`を使わない関係で、unused importの警告が出るため、wasm32向けのビルド時には読み込まないよう設定

### 備考
- #90 