### PR TITLE
parserモジュールのエンハンス: `parser.rs`のリファクタリング

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -72,9 +72,9 @@ pub async fn parse<T: Api>(api: T, input: &str) -> ParseResult {
 #[cfg(test)]
 mod non_blocking_tests {
     use crate::api::client::ApiImpl;
+    use crate::err::ParseErrorKind;
     use crate::parser::parse;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
-    use crate::err::ParseErrorKind;
 
     #[tokio::test]
     async fn 都道府県名が誤っている場合() {
@@ -85,7 +85,10 @@ mod non_blocking_tests {
         assert_eq!(result.address.town, "");
         assert_eq!(result.address.rest, "青盛県青森市長島１丁目１−１");
         assert_eq!(result.error.is_some(), true);
-        assert_eq!(result.error.unwrap().error_message, ParseErrorKind::Prefecture.to_string());
+        assert_eq!(
+            result.error.unwrap().error_message,
+            ParseErrorKind::Prefecture.to_string()
+        );
     }
 
     #[tokio::test]
@@ -97,7 +100,10 @@ mod non_blocking_tests {
         assert_eq!(result.address.town, "");
         assert_eq!(result.address.rest, "青盛市長島１丁目１−１");
         assert_eq!(result.error.is_some(), true);
-        assert_eq!(result.error.unwrap().error_message, ParseErrorKind::City.to_string());
+        assert_eq!(
+            result.error.unwrap().error_message,
+            ParseErrorKind::City.to_string()
+        );
     }
 
     #[tokio::test]
@@ -109,7 +115,10 @@ mod non_blocking_tests {
         assert_eq!(result.address.town, "");
         assert_eq!(result.address.rest, "永嶋１丁目１−１");
         assert_eq!(result.error.is_some(), true);
-        assert_eq!(result.error.unwrap().error_message, ParseErrorKind::Town.to_string());
+        assert_eq!(
+            result.error.unwrap().error_message,
+            ParseErrorKind::Town.to_string()
+        );
     }
 
     wasm_bindgen_test_configure!(run_in_browser);


### PR DESCRIPTION
### 変更点
- リファクタリングのために単体テストを追加
- `read_prefecture()`, `read_city()`, `read_town()`の呼び出し箇所のアンラップ処理を`match`から`if let`に書き換え

### 備考
- #90 
- ` api.get_prefecture_master()`, ` api.get_city_master()`の呼び出し箇所のアンラップ処理も`if let`に書き直したかったが、APIを失敗させるテストが書けないため今回の修正では見送ることにした
  - `mockito`を導入し、Apiモジュールをモックすることができるようになったら対応する
- `parse_blocking()`に対するテストコードの追加、リファクタリングも行なってもよかったが、今回は対応しなかった。