### PR TITLE
Wasmパッケージをnpmjsにアップロードするためのワークフローを追加

### DIFF
--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -1,0 +1,32 @@
+name: Upload wasm to npmjs.com
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@toriyama'
+
+      - name: Setup wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build wasm module
+        run: wasm-pack build --release --target web --scope toriyama
+
+      - name: Upload wasm to npmjs.com
+        run: |
+          cd pkg
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_COM_TOKEN }}


### PR DESCRIPTION
### 変更点
- タグがpushされた時に、`wasm-pack build`の生成物をnpmjsにアップロードするようにワークフローを設定

### 備考
- #70 