### PR TITLE
update: CIの改善: ビルド時にアセットをキャッシュするように設定

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -15,6 +15,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Set up rustfmt
         run: rustup component add rustfmt
       - name: Code formatting


### PR DESCRIPTION
### 変更点
- `actions/cache@v3`を導入し、ビルド時のアセットをキャッシュするように設定
  - 一度キャッシュが作成されると、次回以降のビルドが高速化される

### 備考
- #98 