### PR TITLE
CIの改善: `build`ステップを4つのステップに分割

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -34,7 +34,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-  test:
+  unit-test:
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
#98 