### PR TITLE
JS側のRegExpを使用する: `read_house_number.rs`

### DIFF
--- a/src/parser/read_house_number.rs
+++ b/src/parser/read_house_number.rs
@@ -47,3 +47,22 @@ mod tests {
         assert_eq!(rest, "2");
     }
 }
+
+#[cfg(all(test, target_arch = "wasm32"))]
+mod wasm_tests {
+    use crate::parser::read_house_number::read_house_number_with_js_sys_regexp;
+    use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+    wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn read_house_number_with_js_sys_regexp_success() {
+        let (rest, house_number) = read_house_number_with_js_sys_regexp("1").unwrap();
+        assert_eq!(house_number, "1番");
+        assert_eq!(rest, "");
+
+        let (rest, house_number) = read_house_number_with_js_sys_regexp("3-2").unwrap();
+        assert_eq!(house_number, "3番");
+        assert_eq!(rest, "2");
+    }
+}


### PR DESCRIPTION
### 変更点
- `read_house_number.rs`で`regex::Regex`使用している関数があるが、`js_sys::RegExp`使用版を用意した

### 備考
- #126 