### PR TITLE
漢数字変換処理のクラッシュ: i32ではなくi8としてパースする

### DIFF
--- a/src/parser/filter/invalid_town_name_format.rs
+++ b/src/parser/filter/invalid_town_name_format.rs
@@ -25,11 +25,7 @@ fn extract_town_name_with_regex(input: &str) -> Option<String> {
         return None;
     };
     let block_number = if let Some(matched) = captures.name("block_number") {
-        matched
-            .as_str()
-            .parse::<i32>()
-            .unwrap()
-            .to_japanese_form()?
+        matched.as_str().parse::<i8>().unwrap().to_japanese_form()?
     } else {
         return None;
     };
@@ -49,7 +45,7 @@ fn extract_town_name_with_js_sys_regexp(input: &str) -> Option<String> {
     let block_number = captures
         .get(2)
         .as_string()?
-        .parse::<i32>()
+        .parse::<i8>()
         .ok()?
         .to_japanese_form()?;
     let rest = captures

--- a/src/parser/filter/non_kanji_block_number.rs
+++ b/src/parser/filter/non_kanji_block_number.rs
@@ -20,7 +20,7 @@ fn filter_with_regex(input: String) -> String {
     match expression.captures(&input) {
         Some(captures) => {
             let capture_block_number = &captures.name("block_number").unwrap().as_str();
-            let block_number = match capture_block_number.parse::<i32>() {
+            let block_number = match capture_block_number.parse::<i8>() {
                 Ok(x) => x,
                 Err(_) => return input,
             };
@@ -43,7 +43,7 @@ fn filter_with_js_sys_regexp(input: String) -> String {
                 Some(x) => x,
                 None => return input,
             };
-            let block_number = match capture_block_number.parse::<i32>() {
+            let block_number = match capture_block_number.parse::<i8>() {
                 Ok(x) => x,
                 Err(_) => return input,
             };

--- a/src/util/converter.rs
+++ b/src/util/converter.rs
@@ -2,7 +2,7 @@ pub trait JapaneseNumber {
     fn to_japanese_form(self) -> Option<String>;
 }
 
-impl JapaneseNumber for i32 {
+impl JapaneseNumber for i8 {
     fn to_japanese_form(self) -> Option<String> {
         let first_digit = self % 10;
         let second_digit = (self - self % 10) / 10;
@@ -31,7 +31,7 @@ impl JapaneseNumber for i32 {
     }
 }
 
-fn associate_arabic_number_to_japanese_number(input: i32) -> Option<&'static str> {
+fn associate_arabic_number_to_japanese_number(input: i8) -> Option<&'static str> {
     match input {
         1 => Some("一"),
         2 => Some("二"),


### PR DESCRIPTION
### 変更点
正規表現を用いて「○○N丁目」または「〇〇N-M-L」のNを取得する際、これまでi32としてパースする処理を書いていたが、Nは高々42を超えないため、i32ではオーバースペックのためi8としてパースするように変更

### 備考
- #142 