### PR TITLE
漢数字変換処理のクラッシュ: `util::converter::JapaneseNumber`の修正

### DIFF
--- a/src/util/converter.rs
+++ b/src/util/converter.rs
@@ -8,21 +8,20 @@ impl JapaneseNumber for i8 {
             return None;
         }
         let first_digit = self % 10;
-        let second_digit = (self - self % 10) / 10;
-        let result = match (second_digit, first_digit) {
-            (0, 0) => return None,
-            (0, f) => associate_arabic_number_to_japanese_number(f)?.to_string(),
-            (1, f) => format!(
-                "十{}",
-                associate_arabic_number_to_japanese_number(f).unwrap_or("")
-            ),
-            (s, f) => format!(
-                "{}十{}",
-                associate_arabic_number_to_japanese_number(s)?,
-                associate_arabic_number_to_japanese_number(f).unwrap_or("")
-            )
-        };
-        Some(result)
+        let second_digit = (self / 10) % 10;
+        Some(format!(
+            "{third_digit}{second_digit}{first_digit}",
+            third_digit = if self >= 100 { "百" } else { "" },
+            second_digit = match associate_arabic_number_to_japanese_number(second_digit) {
+                Some('一') => "十".to_string(),
+                Some(character) => format!("{}十", character),
+                None => "".to_string(),
+            },
+            first_digit = match associate_arabic_number_to_japanese_number(first_digit) {
+                Some(character) => character.to_string(),
+                None => "".to_string(),
+            }
+        ))
     }
 }
 


### PR DESCRIPTION
### 変更点
- 3桁の数字(100〜127)も漢数字に変換できるように整備
- 内部的な処理を変更

### 備考
- #142 