### PR TITLE
PR作成時やmainブランチへのpush時に走るCIで`cargo fmt`を実行しないよう設定

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -15,19 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Set up rustfmt
-        run: rustup component add rustfmt
-      - name: Code formatting
-        run: |
-          cargo fmt
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
-          git add --update
-          git commit -m "cargo fmt"
-          git push
-        continue-on-error: true
-      - name: Code style check
-        run: cargo fmt --check
       - name: Set up clippy
         run: rustup component add clippy
       - name: Code review with clippy


### PR DESCRIPTION
### 変更点
以下の理由で`.github/workflows/rust.yaml`から`rustfmt`に関するジョブを削除する
- コードの整形は開発中に手元で行なう
- マシンの使用時間を減らしたい