### PR TITLE
表記ゆれアダプタのエンハンス: 表記ゆれパターンを定数化

### DIFF
--- a/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/src/parser/adapter/orthographical_variant_adapter.rs
@@ -3,7 +3,27 @@ use nom::bytes::complete::tag;
 use nom::error::VerboseError;
 use nom::Parser;
 
-type Variant = &'static [&'static str];
+pub type Variant = &'static [&'static str];
+
+pub trait OrthographicalVariants {
+    const の: Variant;
+    const ツ: Variant;
+    const ケ: Variant;
+    const 薮: Variant;
+    const 崎: Variant;
+    const 檜: Variant;
+    const 龍: Variant;
+}
+
+impl OrthographicalVariants for Variant {
+    const の: Variant = &["の", "ノ"];
+    const ツ: Variant = &["ツ", "ッ"];
+    const ケ: Variant = &["ケ", "ヶ", "が", "ガ"];
+    const 薮: Variant = &["薮", "藪", "籔"];
+    const 崎: Variant = &["崎", "﨑"];
+    const 檜: Variant = &["桧", "檜"];
+    const 龍: Variant = &["龍", "竜"];
+}
 
 pub struct OrthographicalVariantAdapter {
     pub variant_list: Vec<Variant>,

--- a/src/parser/read_city.rs
+++ b/src/parser/read_city.rs
@@ -1,5 +1,7 @@
 use crate::entity::Prefecture;
-use crate::parser::adapter::orthographical_variant_adapter::OrthographicalVariantAdapter;
+use crate::parser::adapter::orthographical_variant_adapter::{
+    OrthographicalVariantAdapter, OrthographicalVariants, Variant,
+};
 use nom::bytes::complete::tag;
 use nom::error::VerboseError;
 use nom::Parser;
@@ -12,7 +14,7 @@ pub fn read_city(input: &str, prefecture: Prefecture) -> Option<(String, String)
             return Some((rest.to_string(), city_name.to_string()));
         }
         let adapter = OrthographicalVariantAdapter {
-            variant_list: vec![&["ケ", "ヶ", "が"], &["龍", "竜"], &["檜", "桧"]],
+            variant_list: vec![Variant::ケ, Variant::龍, Variant::檜],
         };
         if let Some(result) = adapter.apply(input, &city_name) {
             return Some(result);

--- a/src/parser/read_town.rs
+++ b/src/parser/read_town.rs
@@ -3,7 +3,9 @@ use nom::error::VerboseError;
 use nom::Parser;
 
 use crate::entity::City;
-use crate::parser::adapter::orthographical_variant_adapter::OrthographicalVariantAdapter;
+use crate::parser::adapter::orthographical_variant_adapter::{
+    OrthographicalVariantAdapter, OrthographicalVariants, Variant,
+};
 use crate::parser::filter::fullwidth_character::FullwidthCharacterFilter;
 use crate::parser::filter::invalid_town_name_format::InvalidTownNameFormatFilter;
 use crate::parser::filter::non_kanji_block_number::NonKanjiBlockNumberFilter;
@@ -38,12 +40,12 @@ fn find_town(input: &String, city: &City) -> Option<(String, String)> {
         }
         let adapter = OrthographicalVariantAdapter {
             variant_list: vec![
-                &["の", "ノ"],
-                &["ツ", "ッ"],
-                &["ケ", "ヶ", "が", "ガ"],
-                &["薮", "藪", "籔"],
-                &["崎", "﨑"],
-                &["桧", "檜"],
+                Variant::の,
+                Variant::ツ,
+                Variant::ケ,
+                Variant::薮,
+                Variant::崎,
+                Variant::檜,
             ],
         };
         if let Some(result) = adapter.apply(input, &town.name) {


### PR DESCRIPTION
### 変更点
- `vec!["檜", "桧"]`のような表記ゆれパターンを`OrthographicalVariant`として定数化

### 備考
- #161 