### PR TITLE
表記ゆれアダプタのエンハンス: `read_city()`での表記ゆれ処理を省力化

### DIFF
--- a/src/parser/read_city.rs
+++ b/src/parser/read_city.rs
@@ -13,9 +13,17 @@ pub fn read_city(input: &str, prefecture: Prefecture) -> Option<(String, String)
         {
             return Some((rest.to_string(), city_name.to_string()));
         }
-        let adapter = OrthographicalVariantAdapter {
-            variant_list: vec![Variant::ケ, Variant::龍, Variant::檜],
-        };
+        let mut variant_list = vec![Variant::ケ];
+        match prefecture.name.as_str() {
+            "茨城県" => {
+                variant_list.push(Variant::龍);
+            }
+            "東京都" => {
+                variant_list.push(Variant::檜);
+            }
+            _ => {}
+        }
+        let adapter = OrthographicalVariantAdapter { variant_list };
         if let Some(result) = adapter.apply(input, &city_name) {
             return Some(result);
         }


### PR DESCRIPTION
### 変更点
- これまでは一律に同じ表記ゆれリストを使用していたが、表記ゆれリストが増えれば増えるほど`OrthographicalVariantAdapter`内での処理のステップが大きくなってしまう
- `read_city()`では都道府県名を参照できるので、それを元に都道府県ごとにチューニングした表記ゆれリストを使用するように変更した

### 備考
- #161 