### PR TITLE
マルチモジュール化: `Parser`の使用箇所を削除

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,34 +32,3 @@ impl From<ParseResult> for JsValue {
         serde_wasm_bindgen::to_value(&value).unwrap()
     }
 }
-
-#[cfg(test)]
-mod parser_tests {
-    use crate::entity::{Address, ParseResult};
-    use crate::err::{Error, ParseErrorKind};
-    use crate::Parser;
-
-    #[tokio::test]
-    async fn parse_成功_実在する住所() {
-        let parser = Parser();
-        assert_eq!(
-            parser.parse("岩手県盛岡市内丸10番1号").await,
-            ParseResult {
-                address: Address::new("岩手県", "盛岡市", "内丸", "10番1号"),
-                error: None,
-            }
-        )
-    }
-
-    #[tokio::test]
-    async fn parse_失敗_実在しない町名() {
-        let parser = Parser();
-        assert_eq!(
-            parser.parse("東京都中央区銀座九丁目").await,
-            ParseResult {
-                address: Address::new("東京都", "中央区", "", "銀座九丁目"),
-                error: Some(Error::new_parse_error(ParseErrorKind::Town)),
-            }
-        )
-    }
-}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use csv::ReaderBuilder;
-use japanese_address_parser::Parser;
+use japanese_address_parser::api::{Api, ApiImpl};
+use japanese_address_parser::parser::parse;
 use serde::Deserialize;
 use std::fs::File;
 use std::panic;
@@ -28,8 +29,8 @@ pub async fn run_data_driven_tests(file_path: &str) {
     let records = read_test_data_from_csv(file_path).unwrap();
     let mut success_count = 0;
     for record in &records {
-        let parser = Parser();
-        let result = parser.parse(&record.address).await;
+        let api = ApiImpl::new();
+        let result = parse(api, &record.address).await;
 
         let test_result = panic::catch_unwind(|| {
             assert_eq!(result.address.prefecture, record.prefecture);


### PR DESCRIPTION
### 変更点
- `core/lib.rs`に定義している構造体`Parser`の使用箇所を削除した
- 削除したい理由は以下である
  - WebAssemblyのためのコードをwasmモジュールとして切り出したいが、coreモジュール内で参照されている箇所があるため

### 備考
- #178 