### PR TITLE
マルチモジュール化: `wasm`モジュールの作成

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ authors = ["Yuuki Toriyama <github@toriyama.dev>"]
 license = "MIT"
 keywords = ["parser", "geo", "wasm"]
 categories = ["parser-implementations", "wasm"]
+
+[workspace.dependencies]
+wasm-bindgen = "0.2.89"
+wasm-bindgen-futures = "0.4.39"
+wasm-bindgen-test = "0.3.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "core",
+    "wasm",
     "tests"
 ]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,9 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0-beta.8"
 edition = "2021"
+description = "A Rust Library to parse japanses addresses."
 repository = "https://github.com/YuukiToriyama/japanese-address-parser"
 authors = ["Yuuki Toriyama <github@toriyama.dev>"]
+license = "MIT"
+keywords = ["parser", "geo", "wasm"]
+categories = ["parser-implementations", "wasm"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,10 +25,10 @@ reqwest = { version = "0.11.23", default-features = false, features = ["json", "
 serde = { version = "1.0.192", features = ["derive"] }
 serde-wasm-bindgen = "0.6.1"
 tsify = { version = "0.4.5", features = ["js"] }
-wasm-bindgen = "0.2.89"
-wasm-bindgen-futures = "0.4.39"
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]
 test-case = "3.3.1"
 tokio = { version = "1.35.1", features = ["rt", "macros"] }
-wasm-bindgen-test = "0.3.38"
+wasm-bindgen-test = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,9 +12,6 @@ categories.workspace = true
 [lib]
 crate-type = ["rlib", "cdylib"]
 
-[features]
-debug = []
-
 [dependencies]
 itertools = "0.12.0"
 js-sys = "0.3.67"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,12 +2,12 @@
 name = "japanese-address-parser"
 version.workspace = true
 edition.workspace = true
-description = "A Rust Library to parse japanses addresses."
-repository = "https://github.com/YuukiToriyama/japanese-address-parser"
+description.workspace = true
+repository.workspace = true
 authors.workspace = true
-license = "MIT"
-keywords = ["parser", "geo", "wasm"]
-categories = ["parser-implementations", "wasm"]
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,6 @@ crate-type = ["rlib", "cdylib"]
 debug = []
 
 [dependencies]
-console_error_panic_hook = "0.1.7"
 itertools = "0.12.0"
 js-sys = "0.3.67"
 nom = "7.1.3"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ mod err;
 pub mod parser;
 mod util;
 
+// TODO: wasmクレートをビルドするのに必要なため残してあるが、削除できるならば削除したい
 impl From<ParseResult> for JsValue {
     fn from(value: ParseResult) -> Self {
         serde_wasm_bindgen::to_value(&value).unwrap()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,4 @@
-use crate::api::{Api, ApiImpl};
 use crate::entity::ParseResult;
-use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
 pub mod api;
@@ -8,24 +6,6 @@ pub mod entity;
 mod err;
 pub mod parser;
 mod util;
-
-#[wasm_bindgen]
-pub struct Parser();
-
-#[wasm_bindgen]
-impl Parser {
-    #[wasm_bindgen(constructor)]
-    pub fn new() -> Self {
-        Parser {}
-    }
-
-    pub async fn parse(&self, address: &str) -> ParseResult {
-        #[cfg(feature = "debug")]
-        console_error_panic_hook::set_once();
-        let api = ApiImpl::new();
-        parser::parse(api, address).await
-    }
-}
 
 impl From<ParseResult> for JsValue {
     fn from(value: ParseResult) -> Self {

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "wasm"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -11,3 +11,12 @@ categories.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
+
+[features]
+debug = []
+
+[dependencies]
+console_error_panic_hook = "0.1.7"
+japanese-address-parser = { path = "../core" }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,22 @@
+use japanese_address_parser::api::{Api, ApiImpl};
+use japanese_address_parser::entity::ParseResult;
+use japanese_address_parser::parser;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen]
+pub struct Parser();
+
+#[wasm_bindgen]
+impl Parser {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Parser {}
+    }
+
+    pub async fn parse(&self, address: &str) -> ParseResult {
+        #[cfg(feature = "debug")]
+        console_error_panic_hook::set_once();
+        let api = ApiImpl::new();
+        parser::parse(api, address).await
+    }
+}


### PR DESCRIPTION
### 変更点
- `wasm`モジュールを作成
- `core/lib.rs`に定義していた`Parser`を`wasm/lib.rs`に移動させた

### 備考
- #178 
- `wasm-pack build`によって生成されるパッケージの名称が`@toriyama/japanese-address-parser`から`@toriyama/wasm`に変わっているが、こちらは後続のPRで対応予定