### PR TITLE
tsifyの除却

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ regex = "1.10.2"
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { version = "1.0.192", features = ["derive"] }
 serde-wasm-bindgen = "0.6.1"
-tsify = { version = "0.4.5", features = ["js"] }
 wasm-bindgen = "0.2.89"
 wasm-bindgen-futures = "0.4.39"
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,6 +1,5 @@
 use crate::err::Error;
 use serde::{Deserialize, Serialize};
-use tsify::Tsify;
 
 #[derive(Deserialize, PartialEq, Debug)]
 pub struct Prefecture {
@@ -46,8 +45,7 @@ impl Town {
     }
 }
 
-#[derive(Serialize, Tsify, PartialEq, Debug)]
-#[tsify(into_wasm_abi)]
+#[derive(Serialize, PartialEq, Debug)]
 pub struct Address {
     pub prefecture: String,
     pub city: String,
@@ -66,8 +64,7 @@ impl Address {
     }
 }
 
-#[derive(Serialize, Tsify, PartialEq, Debug)]
-#[tsify(into_wasm_abi)]
+#[derive(Serialize, PartialEq, Debug)]
 pub struct ParseResult {
     pub address: Address,
     pub error: Option<Error>,

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,10 +1,8 @@
 use std::fmt::{Display, Formatter};
 
 use serde::Serialize;
-use tsify::Tsify;
 
-#[derive(Serialize, Debug, PartialEq, Tsify)]
-#[tsify(into_wasm_abi)]
+#[derive(Serialize, Debug, PartialEq)]
 pub struct Error {
     pub error_type: String,
     pub error_message: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 use crate::api::{Api, ApiImpl};
-use crate::entity::ParseResult;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
@@ -51,11 +50,5 @@ impl Parser {
         let api = ApiImpl::new();
         let result = parser::parse(api, address).await;
         serde_wasm_bindgen::to_value(&result).unwrap()
-    }
-}
-
-impl From<ParseResult> for JsValue {
-    fn from(value: ParseResult) -> Self {
-        serde_wasm_bindgen::to_value(&value).unwrap()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,34 +59,3 @@ impl From<ParseResult> for JsValue {
         serde_wasm_bindgen::to_value(&value).unwrap()
     }
 }
-
-#[cfg(test)]
-mod parser_tests {
-    use crate::entity::{Address, ParseResult};
-    use crate::err::{Error, ParseErrorKind};
-    use crate::Parser;
-
-    #[tokio::test]
-    async fn parse_成功_実在する住所() {
-        let parser = Parser();
-        assert_eq!(
-            parser.parse("岩手県盛岡市内丸10番1号").await,
-            ParseResult {
-                address: Address::new("岩手県", "盛岡市", "内丸", "10番1号"),
-                error: None,
-            }
-        )
-    }
-
-    #[tokio::test]
-    async fn parse_失敗_実在しない町名() {
-        let parser = Parser();
-        assert_eq!(
-            parser.parse("東京都中央区銀座九丁目").await,
-            ParseResult {
-                address: Address::new("東京都", "中央区", "", "銀座九丁目"),
-                error: Some(Error::new_parse_error(ParseErrorKind::Town)),
-            }
-        )
-    }
-}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use csv::ReaderBuilder;
-use japanese_address_parser::Parser;
+use japanese_address_parser::api::{Api, ApiImpl};
+use japanese_address_parser::parser;
 use serde::Deserialize;
 use std::fs::File;
 use std::panic;
@@ -28,8 +29,8 @@ pub async fn run_data_driven_tests(file_path: &str) {
     let records = read_test_data_from_csv(file_path).unwrap();
     let mut success_count = 0;
     for record in &records {
-        let parser = Parser();
-        let result = parser.parse(&record.address).await;
+        let api = ApiImpl::new();
+        let result = parser::parse(api, &record.address).await;
 
         let test_result = panic::catch_unwind(|| {
             assert_eq!(result.address.prefecture, record.prefecture);


### PR DESCRIPTION
### 変更点
- `tsify`というクレートを使用しRustの構造体からTypeScriptの型を生成していたが、生成済みの型定義を同梱すれば十分なため、`tsify`を除却する

### `japanese_address_parser.d.ts`の前後比較
#### 修正前
<details>

```typescript
/* tslint:disable */
/* eslint-disable */
export interface ParseResult {
    address: Address;
    error: Error | undefined;
}

export interface Address {
    prefecture: string;
    city: string;
    town: string;
    rest: string;
}

export interface Error {
    error_type: string;
    error_message: string;
}

/**
*/
export class Parser {
  free(): void;
/**
*/
  constructor();
/**
* @param {string} address
* @returns {Promise<ParseResult>}
*/
  parse(address: string): Promise<ParseResult>;
}

export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;

export interface InitOutput {
  readonly memory: WebAssembly.Memory;
  readonly parser_new: () => number;
  readonly parser_parse: (a: number, b: number, c: number) => number;
  readonly __wbg_parser_free: (a: number) => void;
  readonly __wbindgen_malloc: (a: number, b: number) => number;
  readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
  readonly __wbindgen_export_2: WebAssembly.Table;
  readonly _dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__hbaf384fff87ab5a4: (a: number, b: number, c: number) => void;
  readonly __wbindgen_exn_store: (a: number) => void;
  readonly wasm_bindgen__convert__closures__invoke2_mut__h47cfdb7ec4403c52: (a: number, b: number, c: number, d: number) => void;
}

export type SyncInitInput = BufferSource | WebAssembly.Module;
/**
* Instantiates the given `module`, which can either be bytes or
* a precompiled `WebAssembly.Module`.
*
* @param {SyncInitInput} module
*
* @returns {InitOutput}
*/
export function initSync(module: SyncInitInput): InitOutput;

/**
* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
* for everything else, calls `WebAssembly.instantiate` directly.
*
* @param {InitInput | Promise<InitInput>} module_or_path
*
* @returns {Promise<InitOutput>}
*/
export default function __wbg_init (module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>;

```

</details>

#### 修正後
<details>

```typescript
/* tslint:disable */
/* eslint-disable */

export interface ParseResult {
    address: Address;
    error: Error | undefined;
}
export interface Address {
    prefecture: string;
    city: string;
    town: string;
    rest: string;
}
export interface Error {
    error_type: string;
    error_message: string;
}
export class Parser {
  free(): void;
  constructor();
  /**
  * @param {string} address
  * @returns {Promise<ParseResult>}
  */
  parse(address: string): Promise<ParseResult>;
}


export type InitInput = RequestInfo | URL | Response | BufferSource | WebAssembly.Module;

export interface InitOutput {
  readonly memory: WebAssembly.Memory;
  readonly parser_new: () => number;
  readonly parser_parse: (a: number, b: number, c: number) => number;
  readonly __wbg_parser_free: (a: number) => void;
  readonly __wbindgen_malloc: (a: number, b: number) => number;
  readonly __wbindgen_realloc: (a: number, b: number, c: number, d: number) => number;
  readonly __wbindgen_export_2: WebAssembly.Table;
  readonly _dyn_core__ops__function__FnMut__A____Output___R_as_wasm_bindgen__closure__WasmClosure___describe__invoke__hcc55202fa6f9cdf9: (a: number, b: number, c: number) => void;
  readonly __wbindgen_exn_store: (a: number) => void;
  readonly wasm_bindgen__convert__closures__invoke2_mut__h31b138a8d1955e62: (a: number, b: number, c: number, d: number) => void;
}

export type SyncInitInput = BufferSource | WebAssembly.Module;
/**
* Instantiates the given `module`, which can either be bytes or
* a precompiled `WebAssembly.Module`.
*
* @param {SyncInitInput} module
*
* @returns {InitOutput}
*/
export function initSync(module: SyncInitInput): InitOutput;

/**
* If `module_or_path` is {RequestInfo} or {URL}, makes a request and
* for everything else, calls `WebAssembly.instantiate` directly.
*
* @param {InitInput | Promise<InitInput>} module_or_path
*
* @returns {Promise<InitOutput>}
*/
export default function __wbg_init (module_or_path?: InitInput | Promise<InitInput>): Promise<InitOutput>;

```

</details>
