### PR TITLE
マルチモジュール化: `core`モジュールを作成したことに伴うGitHubActionsワークフローの修正

### DIFF
--- a/.github/workflows/ghpages.yaml
+++ b/.github/workflows/ghpages.yaml
@@ -17,14 +17,16 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Unit Testing for Wasm module
+        working-directory: core
         run: wasm-pack test --firefox --headless
       - name: Build wasm module
+        working-directory: core
         run: wasm-pack build --target web --scope toriyama --features debug
       - name: Move files
         run: |
           mkdir ./publish
-          rm ./pkg/.gitignore
-          mv ./pkg ./publish
+          rm ./core/pkg/.gitignore
+          mv ./core/pkg ./publish
           mv ./public ./publish
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/upload-cratesio.yaml
+++ b/.github/workflows/upload-cratesio.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -8,11 +8,14 @@ on:
 jobs:
   wasm-pack:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: core # coreモジュールを作成したことで以下のステップの実行がこけるようになったため追加。あとで整理する。
     steps:
       - uses: actions/checkout@v4
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build wasm module
-        run: cd core && wasm-pack build --target web --scope toriyama # coreモジュールを作成したことで以下のステップの実行がこけるようになったため追加。あとで整理する。
+        run: wasm-pack build --target web --scope toriyama
       - name: Unit Testing for Wasm module
-        run: cd core && wasm-pack test --firefox --headless # coreモジュールを作成したことで以下のステップの実行がこけるようになったため追加。あとで整理する。
+        run: wasm-pack test --firefox --headless


### PR DESCRIPTION
### 変更点
- `core`モジュールを作成したことによりソースコードの位置が変わり、動かなくなるワークフローがあったので修正

### 備考
- #178 
- `free-test.yaml`に関しては後続で対応