### PR TITLE
マルチモジュール化: `wasm`モジュールを作成

### DIFF
--- a/.github/scripts/free_test.js
+++ b/.github/scripts/free_test.js
@@ -1,4 +1,4 @@
-const {Parser} = require("../../pkg");
+const {Parser} = require("../../wasm/pkg");
 const readline = require("readline");
 const fs = require("fs");
 

--- a/.github/workflows/free-test.yaml
+++ b/.github/workflows/free-test.yaml
@@ -26,8 +26,10 @@ jobs:
             return commit.data.object.sha
 
       - name: Install wasm-pack
+        working-directory: wasm
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build wasm module
+        working-directory: wasm
         run: wasm-pack build --target nodejs --scope toriyama
 
       - name: Setup Node.js

--- a/.github/workflows/ghpages.yaml
+++ b/.github/workflows/ghpages.yaml
@@ -2,7 +2,7 @@ name: Deploy demo page to GitHub Pages
 
 on:
   push:
-    branches: ["main", "feature/cargo-workspace/*" ] # 動作確認用
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -28,15 +28,7 @@ jobs:
           rm ./wasm/pkg/.gitignore
           mv ./wasm/pkg ./publish
           mv ./public ./publish
-      # 動作確認用に生成物をアップロードしている
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ghpages-publish-dir
-          path: |
-            publish
       - name: Deploy to GitHub Pages
-        if: ${{ false }} # 動作確認用
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ghpages.yaml
+++ b/.github/workflows/ghpages.yaml
@@ -21,7 +21,7 @@ jobs:
         run: wasm-pack test --firefox --headless
       - name: Build wasm module
         working-directory: wasm
-        run: wasm-pack build --target web --scope toriyama --features debug
+        run: wasm-pack build --target web --scope toriyama --out-name japanese_address_parser --features debug
       - name: Move files
         run: |
           mkdir ./publish

--- a/.github/workflows/ghpages.yaml
+++ b/.github/workflows/ghpages.yaml
@@ -17,16 +17,16 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Unit Testing for Wasm module
-        working-directory: core
+        working-directory: wasm
         run: wasm-pack test --firefox --headless
       - name: Build wasm module
-        working-directory: core
+        working-directory: wasm
         run: wasm-pack build --target web --scope toriyama --features debug
       - name: Move files
         run: |
           mkdir ./publish
-          rm ./core/pkg/.gitignore
-          mv ./core/pkg ./publish
+          rm ./wasm/pkg/.gitignore
+          mv ./wasm/pkg ./publish
           mv ./public ./publish
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ghpages.yaml
+++ b/.github/workflows/ghpages.yaml
@@ -2,7 +2,7 @@ name: Deploy demo page to GitHub Pages
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main", "feature/cargo-workspace/*" ] # 動作確認用
 
 env:
   CARGO_TERM_COLOR: always
@@ -28,7 +28,15 @@ jobs:
           rm ./wasm/pkg/.gitignore
           mv ./wasm/pkg ./publish
           mv ./public ./publish
+      # 動作確認用に生成物をアップロードしている
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ghpages-publish-dir
+          path: |
+            publish
       - name: Deploy to GitHub Pages
+        if: ${{ false }} # 動作確認用
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    branches:
-      - 'feature/cargo-workspace/*'
 
 jobs:
   publish:
@@ -49,6 +47,6 @@ jobs:
       - name: Upload wasm to npmjs.com
         run: |
           cd pkg
-          # npm publish --access public
+          npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_COM_TOKEN }}

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+    branches:
+      - 'feature/cargo-workspace/*'
 
 jobs:
   publish:
@@ -47,6 +49,6 @@ jobs:
       - name: Upload wasm to npmjs.com
         run: |
           cd pkg
-          npm publish --access public
+          # npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_COM_TOKEN }}

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: core
+        working-directory: wasm
     steps:
       - uses: actions/checkout@v4
 
@@ -25,7 +25,24 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build wasm module
-        run: wasm-pack build --release --target web --scope toriyama
+        run: wasm-pack build --release --target web --scope toriyama --out-name japanese_address_parser
+
+      # package.jsonの`name`が`@toriyama/wasm`になっているため、`@toriyama/japanese-address-parser`に書き換える
+      - name: Check if jq command is available
+        run: |
+          which jq
+          jq --version
+
+      - name: Edit package.name
+        run: |
+          cat pkg/package.json | jq '.name = "@toriyama/japanese-address-parser"' > tmp.json
+          mv tmp.json pkg/package.json
+
+      - name: Check if package.name was changed
+        run: |
+          # package.nameが正しく置換されているかを確認している。
+          # 正しく置換されていればJSONファイルを表示し、置換されていなければエラーを返しJobを中断させる。
+          cat pkg/package.json | jq 'if .name == "@toriyama/japanese-address-parser" then . else error("package.nameが正しく置換されていない") end'
 
       - name: Upload wasm to npmjs.com
         run: |

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: core # coreモジュールを作成したことで以下のステップの実行がこけるようになったため追加。あとで整理する。
+        working-directory: wasm
     steps:
       - uses: actions/checkout@v4
       - name: Install wasm-pack

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,8 @@ authors = ["Yuuki Toriyama <github@toriyama.dev>"]
 license = "MIT"
 keywords = ["parser", "geo", "wasm"]
 categories = ["parser-implementations", "wasm"]
+
+[workspace.dependencies]
+wasm-bindgen = "0.2.89"
+wasm-bindgen-futures = "0.4.39"
+wasm-bindgen-test = "0.3.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "core",
+    "wasm",
     "tests"
 ]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,9 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0-beta.9"
 edition = "2021"
+description = "A Rust Library to parse japanses addresses."
 repository = "https://github.com/YuukiToriyama/japanese-address-parser"
 authors = ["Yuuki Toriyama <github@toriyama.dev>"]
+license = "MIT"
+keywords = ["parser", "geo", "wasm"]
+categories = ["parser-implementations", "wasm"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,8 +20,6 @@ nom = "7.1.3"
 regex = "1.10.2"
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { version = "1.0.192", features = ["derive"] }
-wasm-bindgen = { workspace = true }
-wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,18 +13,13 @@ categories.workspace = true
 [lib]
 crate-type = ["rlib", "cdylib"]
 
-[features]
-debug = []
-
 [dependencies]
-console_error_panic_hook = "0.1.7"
 itertools = "0.12.0"
 js-sys = "0.3.67"
 nom = "7.1.3"
 regex = "1.10.2"
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { version = "1.0.192", features = ["derive"] }
-serde-wasm-bindgen = "0.6.1"
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,10 +25,10 @@ regex = "1.10.2"
 reqwest = { version = "0.11.23", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { version = "1.0.192", features = ["derive"] }
 serde-wasm-bindgen = "0.6.1"
-wasm-bindgen = "0.2.89"
-wasm-bindgen-futures = "0.4.39"
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
 
 [dev-dependencies]
 test-case = "3.3.1"
 tokio = { version = "1.35.1", features = ["rt", "macros"] }
-wasm-bindgen-test = "0.3.38"
+wasm-bindgen-test = { workspace = true }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -2,13 +2,13 @@
 name = "japanese-address-parser"
 version.workspace = true
 edition.workspace = true
-description = "A Rust Library to parse japanses addresses."
-repository = "https://github.com/YuukiToriyama/japanese-address-parser"
+description.workspace = true
+repository.workspace = true
 authors.workspace = true
-license = "MIT"
+license.workspace = true
 readme = "../README.md"
-keywords = ["parser", "geo", "wasm"]
-categories = ["parser-implementations", "wasm"]
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,54 +1,5 @@
-use crate::api::{Api, ApiImpl};
-use wasm_bindgen::prelude::wasm_bindgen;
-use wasm_bindgen::JsValue;
-
 pub mod api;
 pub mod entity;
 mod err;
 pub mod parser;
 mod util;
-
-#[wasm_bindgen(typescript_custom_section)]
-const TYPESCRIPT_TYPE: &'static str = r#"
-export interface ParseResult {
-    address: Address;
-    error: Error | undefined;
-}
-export interface Address {
-    prefecture: string;
-    city: string;
-    town: string;
-    rest: string;
-}
-export interface Error {
-    error_type: string;
-    error_message: string;
-}
-export class Parser {
-  free(): void;
-  constructor();
-  /**
-  * @param {string} address
-  * @returns {Promise<ParseResult>}
-  */
-  parse(address: string): Promise<ParseResult>;
-}"#;
-
-#[wasm_bindgen(skip_typescript)]
-pub struct Parser();
-
-#[wasm_bindgen]
-impl Parser {
-    #[wasm_bindgen(constructor)]
-    pub fn new() -> Self {
-        Parser {}
-    }
-
-    pub async fn parse(&self, address: &str) -> JsValue {
-        #[cfg(feature = "debug")]
-        console_error_panic_hook::set_once();
-        let api = ApiImpl::new();
-        let result = parser::parse(api, address).await;
-        serde_wasm_bindgen::to_value(&result).unwrap()
-    }
-}

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "wasm"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[lib]
+crate-type = ["cdylib"]

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -11,3 +11,13 @@ categories.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
+
+[features]
+debug = []
+
+[dependencies]
+console_error_panic_hook = "0.1.7"
+japanese-address-parser = { path = "../core" }
+serde-wasm-bindgen = "0.6.1"
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -6,6 +6,7 @@ description.workspace = true
 repository.workspace = true
 authors.workspace = true
 license.workspace = true
+readme = "../README.md"
 keywords.workspace = true
 categories.workspace = true
 

--- a/wasm/LICENSE
+++ b/wasm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 ToriChan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,0 +1,49 @@
+use japanese_address_parser::api::{Api, ApiImpl};
+use japanese_address_parser::parser;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TYPESCRIPT_TYPE: &'static str = r#"
+export interface ParseResult {
+    address: Address;
+    error: Error | undefined;
+}
+export interface Address {
+    prefecture: string;
+    city: string;
+    town: string;
+    rest: string;
+}
+export interface Error {
+    error_type: string;
+    error_message: string;
+}
+export class Parser {
+  free(): void;
+  constructor();
+  /**
+  * @param {string} address
+  * @returns {Promise<ParseResult>}
+  */
+  parse(address: string): Promise<ParseResult>;
+}"#;
+
+#[wasm_bindgen(skip_typescript)]
+pub struct Parser();
+
+#[wasm_bindgen]
+impl Parser {
+    #[wasm_bindgen(constructor)]
+    pub fn new() -> Self {
+        Parser {}
+    }
+
+    pub async fn parse(&self, address: &str) -> JsValue {
+        #[cfg(feature = "debug")]
+        console_error_panic_hook::set_once();
+        let api = ApiImpl::new();
+        let result = parser::parse(api, address).await;
+        serde_wasm_bindgen::to_value(&result).unwrap()
+    }
+}


### PR DESCRIPTION
### 変更点
- これまでは`core/src/lib.rs`にWebAssembly用のコードを書いていたが、`core`モジュールを軽量化させたいため、WebAssembly用のコードは`wasm`モジュールとして切り出すことにした。
  - `core`モジュールでは、単体テスト以外では`wasm-bindgen`に依存しないような作りにする
  - crates.ioにアップロードするファイルには`wasm`モジュールの中身は含めない
- `wasm`モジュールは`core`モジュールのラッパーである。
- また、`wasm`モジュールとして切り出したことでGitHub Actionsのいくつかが機能しなくなるので、その修正も含んでいる。

### 単体テスト観点
- [x] JavaScriptから呼び出して実行できること
- [x] フリーテスト機能の実行が成功すること
- [x] `ghpages.yaml`の実行が成功すること
- [x] `upload-npmjs.yaml`の実行が成功すること
  - [x] `package.name`が`@toriyama/wasm`から`@toriyama/japanese-address-parser`に書き換えられていること
  - [x] 生成される`package.json`に差分がないこと
  - [x] 生成されるファイル構成に変更がないこと

### その他
- #178 