### PR TITLE
Pythonモジュールの追加: `python`クレートを追加

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 members = [
     "core",
     "wasm",
-    "tests",
     "python",
+    "tests",
 ]
 resolver = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 members = [
     "core",
     "wasm",
-    "tests"
+    "tests",
+    "python",
 ]
 resolver = "2"
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "python"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -9,5 +9,10 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[lib]
+name = "japanese_address_parser_py"
+path = "src/lib.rs"
+crate-type = ["cdylib"]
+
 [dependencies]
 pyo3 = { version = "0.21.0", features = ["abi3-py37"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -10,3 +10,4 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+pyo3 = { version = "0.21.0", features = ["abi3-py37"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -15,4 +15,5 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+japanese-address-parser = { path = "../core" }
 pyo3 = { version = "0.21.0", features = ["abi3-py37"] }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["maturin>=1.5,<2.0"]
+build-backend = "maturin"
+
+[project]
+name = "japanese-address-parser-py"
+
+[tool.maturin]
+features = ["pyo3/extension-module"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "japanese-address-parser-py"
+keywords = ["converter", "utility", "geo", "rust"]
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,0 +1,17 @@
+use pyo3::prelude::*;
+use std::collections::HashMap;
+
+#[pyclass(name = "ParseResult")]
+struct PyParseResult {
+    #[pyo3(get)]
+    address: HashMap<String, String>,
+    #[pyo3(get)]
+    error: HashMap<String, String>,
+}
+
+#[pymodule]
+#[pyo3(name = "japanese_address_parser_py")]
+fn python_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PyParseResult>()?;
+    Ok(())
+}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,4 +1,6 @@
+use japanese_address_parser::api::{BlockingApi, BlockingApiImpl};
 use japanese_address_parser::entity::ParseResult;
+use japanese_address_parser::parser::parse_blocking;
 use pyo3::prelude::*;
 use std::collections::HashMap;
 
@@ -26,9 +28,16 @@ impl From<ParseResult> for PyParseResult {
     }
 }
 
+#[pyfunction]
+fn parse(address: &str) -> PyParseResult {
+    let api = BlockingApiImpl::new();
+    parse_blocking(api, address).into()
+}
+
 #[pymodule]
 #[pyo3(name = "japanese_address_parser_py")]
 fn python_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyParseResult>()?;
+    m.add_function(wrap_pyfunction!(parse, m)?)?;
     Ok(())
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,3 +1,4 @@
+use japanese_address_parser::entity::ParseResult;
 use pyo3::prelude::*;
 use std::collections::HashMap;
 
@@ -7,6 +8,22 @@ struct PyParseResult {
     address: HashMap<String, String>,
     #[pyo3(get)]
     error: HashMap<String, String>,
+}
+
+impl From<ParseResult> for PyParseResult {
+    fn from(value: ParseResult) -> Self {
+        let mut address = HashMap::new();
+        address.insert(String::from("prefecture"), value.address.prefecture);
+        address.insert(String::from("city"), value.address.city);
+        address.insert(String::from("town"), value.address.town);
+        address.insert(String::from("rest"), value.address.rest);
+        let mut error = HashMap::new();
+        if let Some(err) = value.error {
+            error.insert(String::from("error_type"), err.error_type);
+            error.insert(String::from("error_message"), err.error_message);
+        }
+        Self { address, error }
+    }
 }
 
 #[pymodule]


### PR DESCRIPTION
### 変更点
- `python`クレートを追加
- `pyo3`クレートを使用し、Rustで書いた処理をPythonから呼び出せるようにした
- `maturin develop`でビルドができる

### ビルド・インストール手順
```bash
# ビルド
cargo install --locked maturin
maturin build --release --out dist --find-interpreter
# インストール
python3 -m venv .venv
pip3 install dist/japanese_address_parser_py-0.1.0b10-cp37-abi3-macosx_10_12_x86_64.whl
```

### 使用方法
```bash
python3
Python 3.7.9 (v3.7.9:13c94747c7, Aug 15 2020, 01:31:08)
[Clang 6.0 (clang-600.0.57)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import japanese_address_parser_py
>>> parse_result = japanese_address_parser_py.parse("東京都千代田区丸の内1-1-1")
>>> print(parse_result.address)
{'city': '千代田区', 'town': '丸の内一丁目', 'prefecture': '東京都', 'rest': '1-1'}
```

### 確認すべき項目
- [x] `cargo fmt`
- [x] `cargo test`
- [x] 既存の他のモジュールに影響を与える変更ではないこと

### 備考
- #176 
