### PR TITLE
Pythonモジュールの追加: pythonモジュールをビルドしpypi.orgにアップロードするためのワークフローを追加

### DIFF
--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -122,6 +122,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    environment: pypi
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, windows, macos, sdist]
     steps:
@@ -129,7 +130,8 @@ jobs:
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }} # ${{ secrets.PYPI_API_TOKEN }}
+          MATURIN_REPOSITORY: "testpypi" # "pypi"
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -29,9 +29,6 @@ jobs:
             target: s390x
           - runner: ubuntu-latest
             target: ppc64le
-    defaults:
-      run:
-        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -42,6 +39,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --zig
+          working-directory: python
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -59,9 +57,6 @@ jobs:
             target: x64
           - runner: windows-latest
             target: x86
-    defaults:
-      run:
-        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -73,6 +68,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
+          working-directory: python
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -89,9 +85,6 @@ jobs:
             target: x86_64
           - runner: macos-14
             target: aarch64
-    defaults:
-      run:
-        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -102,6 +95,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
+          working-directory: python
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -111,9 +105,6 @@ jobs:
 
   sdist:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - name: Build sdist
@@ -121,6 +112,7 @@ jobs:
         with:
           command: sdist
           args: --out dist
+          working-directory: python
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -123,7 +123,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     environment: pypi
-    if: "startsWith(github.ref, 'refs/tags/')"
+    if: true # "startsWith(github.ref, 'refs/tags/')" # TODO: 動作確認用に設定している。`test.pypi.org`へのアップロードの確認が完了したら元に戻す
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -1,0 +1,135 @@
+name: Upload artifact to pypi.org
+
+on:
+  push:
+    tags:
+      - 'v*'
+    # TODO: 動作確認用に設定している。不要になったら削除する。
+    branches:
+      - feature/python-module/*
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: python
+
+jobs:
+  linux:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: ubuntu-latest
+            target: x86_64
+          - runner: ubuntu-latest
+            target: x86
+          - runner: ubuntu-latest
+            target: aarch64
+          - runner: ubuntu-latest
+            target: armv7
+          - runner: ubuntu-latest
+            target: s390x
+          - runner: ubuntu-latest
+            target: ppc64le
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --zig
+          sccache: 'true'
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux-${{ matrix.platform.target }}
+          path: dist
+
+  windows:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: windows-latest
+            target: x64
+          - runner: windows-latest
+            target: x86
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+          architecture: ${{ matrix.platform.target }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-windows-${{ matrix.platform.target }}
+          path: dist
+
+  macos:
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      matrix:
+        platform:
+          - runner: macos-latest
+            target: x86_64
+          - runner: macos-14
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.8'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist
+          sccache: 'true'
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: dist
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/')"
+    needs: [linux, windows, macos, sdist]
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Publish to PyPI
+        uses: PyO3/maturin-action@v1
+        env:
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        with:
+          command: upload
+          args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    working-directory: python
+
 jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}

--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -89,7 +89,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.10'
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -11,10 +11,6 @@ on:
 permissions:
   contents: read
 
-defaults:
-  run:
-    working-directory: python
-
 jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}
@@ -50,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-linux-${{ matrix.platform.target }}
-          path: dist
+          path: python/dist
 
   windows:
     runs-on: ${{ matrix.platform.runner }}
@@ -78,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-windows-${{ matrix.platform.target }}
-          path: dist
+          path: python/dist
 
   macos:
     runs-on: ${{ matrix.platform.runner }}
@@ -105,7 +101,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-macos-${{ matrix.platform.target }}
-          path: dist
+          path: python/dist
 
   sdist:
     runs-on: ubuntu-latest
@@ -121,7 +117,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheels-sdist
-          path: dist
+          path: python/dist
 
   release:
     name: Release

--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -11,10 +11,6 @@ on:
 permissions:
   contents: read
 
-defaults:
-  run:
-    working-directory: python
-
 jobs:
   linux:
     runs-on: ${{ matrix.platform.runner }}
@@ -33,6 +29,9 @@ jobs:
             target: s390x
           - runner: ubuntu-latest
             target: ppc64le
+    defaults:
+      run:
+        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -60,6 +59,9 @@ jobs:
             target: x64
           - runner: windows-latest
             target: x86
+    defaults:
+      run:
+        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -87,6 +89,9 @@ jobs:
             target: x86_64
           - runner: macos-14
             target: aarch64
+    defaults:
+      run:
+        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -106,6 +111,9 @@ jobs:
 
   sdist:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - name: Build sdist

--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -4,9 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-    # TODO: 動作確認用に設定している。不要になったら削除する。
-    branches:
-      - feature/python-module/*
 
 permissions:
   contents: read
@@ -123,15 +120,15 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     environment: pypi
-    if: true # "startsWith(github.ref, 'refs/tags/')" # TODO: 動作確認用に設定している。`test.pypi.org`へのアップロードの確認が完了したら元に戻す
+    if: "startsWith(github.ref, 'refs/tags/')"
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }} # ${{ secrets.PYPI_API_TOKEN }}
-          MATURIN_REPOSITORY: "testpypi" # "pypi"
+          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          MATURIN_REPOSITORY: "pypi" # test.pypi.orgにアップロードする際は"testpypi"を設定する
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
### 変更点
- pythonクレートを`maturin`を使ってビルドし、PyPIにアップロードするためのGitHubActionsワークフローを追加
- ワークフローはコマンド`maturin generate-ci github --platform linux windows macos --zig`で生成したものを元にカスタマイズを加えている
- tagをpushしたときに動かす予定だが、動作確認用にコミットをpushした際もCIが走るように設定している
  - ~~動作確認が完了したら設定を削除する~~ 
    - 削除済み

### 確認すべき項目
- [x] 各OS・各アーキテクチャでビルドが成功すること
- [x] `test.pypi.org`へのアップロードに成功すること
- [x] 動作確認のための設定が除却されていること

### 備考
- #176 
