### PR TITLE
Pythonモジュールの追加: PullRequest作成時に`python`モジュールのビルドチェックを行なうようにする

### DIFF
--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -1,0 +1,66 @@
+name: Python module build check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x86_64
+          args: --release --out dist --zig
+          working-directory: python
+          sccache: 'true'
+          manylinux: auto
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          architecture: x64
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: x64
+          args: --release --out dist
+          working-directory: python
+          sccache: 'true'
+
+  macos:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: aarch64
+          args: --release --out dist
+          working-directory: python
+          sccache: 'true'
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+          working-directory: python


### PR DESCRIPTION
### 変更点
- 基本的には`core`モジュールに破壊的な変更が入らなければ`python`モジュールは壊れない認識だが、PR作成時に主要アーキテクチャでビルドチェックを行なうことで、`python`モジュールが壊れていることを早い段階で気づけるようにする

### 確認すべき項目
- [x] ビルドチェックが通ること

### 備考
- #176 
