### PR TITLE
秘密鍵の管理方法の変更をrelease/v0.1.0-beta.11にマージ

### DIFF
--- a/.github/workflows/upload-cratesio.yaml
+++ b/.github/workflows/upload-cratesio.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: crates-io
     defaults:
       run:
         working-directory: core

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npmjs
     defaults:
       run:
         working-directory: wasm
@@ -49,4 +50,4 @@ jobs:
           cd pkg
           npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_COM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_REGISTRY_TOKEN }}


### PR DESCRIPTION
### 変更点
- crates.io、npmjs.comにパッケージをアップロードする際に使用している秘密鍵の保管場所を各々新規作成した`environment`に変更した

### 備考
- #204 
