### PR TITLE
MSRVの見直し: 1.75.0 -> 1.64.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docs](https://docs.rs/japanese-address-parser/badge.svg)](https://docs.rs/japanese-address-parser)
 [![Crates.io (latest)](https://img.shields.io/crates/v/japanese-address-parser)](https://crates.io/crates/japanese-address-parser)
-![Rust Version](https://img.shields.io/badge/rust%20version-%3E%3D1.75.0-orange)
+![Rust Version](https://img.shields.io/badge/rust%20version-%3E%3D1.64.0-orange)
 [![Unit test & Code check](https://github.com/YuukiToriyama/japanese-address-parser/actions/workflows/code-check.yaml/badge.svg)](https://github.com/YuukiToriyama/japanese-address-parser/actions/workflows/code-check.yaml)
 
 A Rust Library to parse japanses addresses.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 readme = "../README.md"
 keywords.workspace = true
 categories.workspace = true
+rust-version = "1.64.0"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "1.75"


### PR DESCRIPTION
### 変更点
- 以前はTraitの中でasync関数を定義するために、Rustの最低サポートバージョンを1.75.0としていたが、現在はasync fn in trait機能を使用していないため、最低サポートバージョンを広げられることがわかった
- `core`モジュールで`cargo msrv`を実行したところ、1.64.0が最低バージョンであることがわかったのでこちらに変更する

### 確認すべき項目
- [x] バージョン`1.64.0`で`cargo build`および`cargo test`が通ること
- [x] バージョン`1.77.1`で`cargo build`および`cargo test`が通ること

### 備考
- #208 
