### PR TITLE
依存ライブラリの更新: tokio

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,5 +23,5 @@ serde = { version = "1.0.192", features = ["derive"] }
 
 [dev-dependencies]
 test-case = "3.3.1"
-tokio = { version = "1.35.1", features = ["rt", "macros"] }
+tokio = { version = "1.37.0", features = ["rt", "macros"] }
 wasm-bindgen-test = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,4 +13,4 @@ path = "integration_tests.rs"
 csv = "1.3.0"
 japanese-address-parser = { path = "../core"}
 serde = { version = "1.0.197", features = ["derive"] }
-tokio = { version = "1.35.1", features = ["rt", "macros"] }
+tokio = { version = "1.37.0", features = ["rt", "macros"] }


### PR DESCRIPTION
### 変更点
- `tokio`のバージョンを更新
  - 1.53.1 -> 1.37.0

### 確認すべき項目
- [x] `cargo test`

### 備考
- リリースノート
  - https://github.com/tokio-rs/tokio/releases
