### PR TITLE
依存ライブラリの更新: reqwest

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,7 +18,7 @@ itertools = "0.12.0"
 js-sys = "0.3.67"
 nom = "7.1.3"
 regex = "1.10.2"
-reqwest = { version = "0.11.23", default-features = false, features = ["json", "rustls-tls", "blocking"] }
+reqwest = { version = "0.12.3", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { version = "1.0.192", features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
### 変更点
- coreモジュールで使用している`reqwest`のバージョンを更新
  - 0.11.23 -> 0.12.3

### 確認すべき項目
- [x] `cargo build`
- [x] `cargo test`
- [x] `wasm-pack test`
- [x] wasmモジュールで`wasm-pack build`を実行

### 備考
- リリースノート
  - https://github.com/seanmonstar/reqwest/releases
