### PR TITLE
ワークフローの修正: `wasm-pack test`を実行するディレクトリが誤っていたので修正

### DIFF
--- a/.github/workflows/ghpages.yaml
+++ b/.github/workflows/ghpages.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Unit Testing for Wasm module
-        working-directory: wasm
+        working-directory: core
         run: wasm-pack test --firefox --headless
       - name: Build wasm module
         working-directory: wasm

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Unit Testing for wasm module
+      - name: Unit test for core module
         working-directory: core
         run: wasm-pack test --firefox --headless
       - name: Build test for wasm module

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -8,14 +8,13 @@ on:
 jobs:
   wasm-pack:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: wasm
     steps:
       - uses: actions/checkout@v4
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build wasm module
+        working-directory: wasm
         run: wasm-pack build --target web --scope toriyama
       - name: Unit Testing for Wasm module
+        working-directory: core
         run: wasm-pack test --firefox --headless

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Build wasm module
-        working-directory: wasm
-        run: wasm-pack build --target web --scope toriyama
-      - name: Unit Testing for Wasm module
+      - name: Unit Testing for wasm module
         working-directory: core
         run: wasm-pack test --firefox --headless
+      - name: Build test for wasm module
+        working-directory: wasm
+        run: wasm-pack build --target web --scope toriyama


### PR DESCRIPTION
### 変更点
- `wasm-pack test`を`wasm`モジュールに対して実行していたが、`wasm`モジュールにはテストがないため、テストが記述されている`core`モジュールで実行するようにワークフローを修正した

### 確認すべき項目
- [x] [wasm-pack-test.yaml](https://github.com/YuukiToriyama/japanese-address-parser/actions/workflows/wasm-pack-test.yaml)が成功すること

### 備考
- #216 
