### PR TITLE
Cargo.tomlの修正をrelease/v0.1.0-beta.13にマージ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0-beta.12"
 edition = "2021"
-description = "A Rust Library to parse japanses addresses."
+description = "A Rust Library to parse japanese addresses."
 repository = "https://github.com/YuukiToriyama/japanese-address-parser"
 authors = ["Yuuki Toriyama <github@toriyama.dev>"]
 license = "MIT"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,6 +11,6 @@ path = "integration_tests.rs"
 
 [dev-dependencies]
 csv = "1.3.0"
-japanese-address-parser = { path = "../core"}
+japanese-address-parser = { path = "../core" }
 serde = { version = "1.0.197", features = ["derive"] }
 tokio = { version = "1.37.0", features = ["rt", "macros"] }


### PR DESCRIPTION
### 変更点
- `package.description`のtypoを修正
