### PR TITLE
pyiファイルの追加: Pythonパッケージに同梱するための型定義ファイルを追加

### DIFF
--- a/python/japanese_address_parser_py.pyi
+++ b/python/japanese_address_parser_py.pyi
@@ -1,0 +1,31 @@
+class ParseResult:
+    """
+    A class represent parse result.
+
+    パース処理の結果を表すクラスです。
+    """
+
+    address: dict[str, str]
+    """
+    都道府県名、市区町村名、町名、それ以降の文字列をそれぞれ格納する辞書型を返します。
+    
+    {prefecture: str, city: str, town: str, rest: str}
+    """
+
+    error: dict[str, str]
+    """
+    パース処理中にエラーが発生した場合、エラーのタイプとエラーメッセージを格納する辞書型を返します。
+    
+    {error_type: str, error_message: str}
+    """
+
+
+def parse(address: str) -> ParseResult:
+    """
+    Format informal address into formal style
+
+    入力された住所を正式な表記に整形します。
+
+    :param address: 住所
+    :return: ParseResult
+    """

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,7 +7,8 @@ name = "japanese-address-parser-py"
 keywords = ["converter", "utility", "geo", "rust"]
 classifiers = [
     "Topic :: Text Processing",
-    "Programming Language :: Rust"
+    "Programming Language :: Rust",
+    "Typing :: Typed",
 ]
 
 [tool.maturin]


### PR DESCRIPTION
### 変更点
- Rustコードから生成されるPythonバインディングに同梱するための型定義ファイル(pyiファイル)を作成し追加
- `maturin build`を実行すると自動的にパッケージに同梱される

### 確認すべき項目
- [x] 型定義ファイルに記載した内容がコードエディタから確認できること
- [x] 引数にstr以外の型を代入したときコードエディタ上で警告が出ること

### キャプチャ
#### 型定義ファイルに記載した内容がコードエディタから確認できること
![スクリーンショット 2024-04-10 23 15 03](https://github.com/YuukiToriyama/japanese-address-parser/assets/43945424/e83ad366-c2b7-42e7-bf62-0f55bd84cc6c)

#### 引数にstr以外の型を代入したときコードエディタ上で警告が出ること
![スクリーンショット 2024-04-10 23 15 45](https://github.com/YuukiToriyama/japanese-address-parser/assets/43945424/fa61c32a-a41a-4fd9-a3fc-ccd6aec3c165)


### 備考
- #207 
