### PR TITLE
郡の省略への対応: `VagueExpressionAdapter`を作成&既存処理で市町村名の判別ができない場合は`VagueExpressionAdapter`を使用する

### DIFF
--- a/core/src/parser/adapter.rs
+++ b/core/src/parser/adapter.rs
@@ -1,1 +1,2 @@
 pub mod orthographical_variant_adapter;
+pub mod vague_expression_adapter;

--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -1,0 +1,29 @@
+use crate::util::sequence_matcher::SequenceMatcher;
+use nom::bytes::complete::{is_a, is_not};
+use nom::combinator::rest;
+use nom::error::Error;
+use nom::sequence::tuple;
+
+pub struct VagueExpressionAdapter;
+
+impl VagueExpressionAdapter {
+    pub fn apply(self, input: &str, region_name_list: &Vec<String>) -> Option<(String, String)> {
+        match SequenceMatcher::get_most_similar_match(input, region_name_list, None) {
+            Ok(highest_match) => {
+                match tuple((
+                    is_not::<&str, &str, Error<&str>>("町村"),
+                    is_a("町村"),
+                    rest,
+                ))(input)
+                {
+                    Ok((_, separated)) => {
+                        let (_, _, rest) = separated;
+                        Some((rest.to_string(), highest_match))
+                    }
+                    Err(..) => None,
+                }
+            }
+            Err(..) => None,
+        }
+    }
+}

--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -8,23 +8,19 @@ pub struct VagueExpressionAdapter;
 
 impl VagueExpressionAdapter {
     pub fn apply(self, input: &str, region_name_list: &Vec<String>) -> Option<(String, String)> {
-        match SequenceMatcher::get_most_similar_match(input, region_name_list, None) {
-            Ok(highest_match) => {
-                match tuple((
-                    is_not::<&str, &str, Error<&str>>("町村"),
-                    is_a("町村"),
-                    rest,
-                ))(input)
-                {
-                    Ok((_, separated)) => {
-                        let (_, _, rest) = separated;
-                        Some((rest.to_string(), highest_match))
-                    }
-                    Err(..) => None,
-                }
+        if let Ok(highest_match) =
+            SequenceMatcher::get_most_similar_match(input, region_name_list, None)
+        {
+            if let Ok((_, (_, _, rest))) = tuple((
+                is_not::<&str, &str, Error<&str>>("町村"),
+                is_a("町村"),
+                rest,
+            ))(input)
+            {
+                return Some((rest.to_string(), highest_match));
             }
-            Err(..) => None,
         }
+        None
     }
 }
 

--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -11,12 +11,12 @@ impl VagueExpressionAdapter {
         if let Ok(highest_match) =
             SequenceMatcher::get_most_similar_match(input, region_name_list, None)
         {
-            if let Ok((_, (_, _, rest))) = tuple((
+            let mut parser = tuple((
                 is_not::<&str, &str, Error<&str>>("町村"),
-                is_a("町村"),
+                is_a::<&str, &str, Error<&str>>("町村"),
                 rest,
-            ))(input)
-            {
+            ));
+            if let Ok((_, (_, _, rest))) = parser(input) {
                 return Some((rest.to_string(), highest_match));
             }
         }

--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -27,3 +27,57 @@ impl VagueExpressionAdapter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::adapter::vague_expression_adapter::VagueExpressionAdapter;
+
+    #[test]
+    fn 郡名が省略されている場合_吉田郡永平寺町() {
+        let (rest, city_name) = VagueExpressionAdapter {}
+            .apply("永平寺町志比５－５", &provide_city_name_list())
+            .unwrap();
+        assert_eq!(rest, "志比５－５");
+        assert_eq!(city_name, "吉田郡永平寺町");
+    }
+
+    #[test]
+    fn 郡名が省略されている場合_今立郡池田町() {
+        let (rest, city_name) = VagueExpressionAdapter {}
+            .apply("池田町稲荷２８－７", &provide_city_name_list())
+            .unwrap();
+        assert_eq!(rest, "稲荷２８－７");
+        assert_eq!(city_name, "今立郡池田町");
+    }
+
+    #[test]
+    fn 郡名が省略されている場合_南条郡南越前町() {
+        let (rest, city_name) = VagueExpressionAdapter {}
+            .apply("南越前町今庄７４－７－１", &provide_city_name_list())
+            .unwrap();
+        assert_eq!(rest, "今庄７４－７－１");
+        assert_eq!(city_name, "南条郡南越前町");
+    }
+
+    fn provide_city_name_list() -> Vec<String> {
+        vec![
+            "福井市".to_string(),
+            "敦賀市".to_string(),
+            "小浜市".to_string(),
+            "大野市".to_string(),
+            "勝山市".to_string(),
+            "鯖江市".to_string(),
+            "あわら市".to_string(),
+            "越前市".to_string(),
+            "坂井市".to_string(),
+            "吉田郡永平寺町".to_string(),
+            "今立郡池田町".to_string(),
+            "南条郡南越前町".to_string(),
+            "丹生郡越前町".to_string(),
+            "三方郡美浜町".to_string(),
+            "大飯郡高浜町".to_string(),
+            "大飯郡おおい町".to_string(),
+            "三方上中郡若狭町".to_string(),
+        ]
+    }
+}

--- a/core/src/parser/read_city.rs
+++ b/core/src/parser/read_city.rs
@@ -52,6 +52,8 @@ mod tests {
     #[test_case("茨城県", "龍ケ崎市佐貫町647", "龍ヶ崎市"; "success_龍ケ崎市_表記ゆれ")]
     #[test_case("茨城県", "竜ヶ崎市佐貫町647", "龍ヶ崎市"; "success_竜ヶ崎市_表記ゆれ")]
     #[test_case("茨城県", "竜ケ崎市佐貫町647", "龍ヶ崎市"; "success_竜ケ崎市_表記ゆれ")]
+    #[test_case("群馬県", "みなかみ町後閑318", "利根郡みなかみ町"; "success_利根郡みなかみ町_郡名が省略されている")]
+    #[test_case("埼玉県", "東秩父村大字御堂634番地", "秩父郡東秩父村"; "success_秩父郡東秩父村_郡名が省略されている")]
     fn test_read_city(prefecture_name: &str, input: &str, expected: &str) {
         let api = BlockingApiImpl::new();
         let prefecture = api.get_prefecture_master(prefecture_name).unwrap();


### PR DESCRIPTION
### 変更点
- `read_city()`において既存処理で市町村名の判別ができない場合は、`VagueExpressionAdapter`を使用して市町村名の推測を行なうようにした。
- `VagueExpressionAdapter`では`SequenceMatcher`を用いて入力値と市町村名リストを照合し、類似度が一番高いものを推薦する。
- ただ、テキストの類似度を用いる方法は機械的であり、意図しない結果を表示することもあるため、将来的にはON/OFFの切り替えができるようにするかもしれない。

### 確認すべき項目
- [x] `cargo fmt`
- [x] `cargo test`
- [x] `cargo clippy`

### 備考
- #150 
