### PR TITLE
`SequenceMatcher::get_most_similar_match()`がクラッシュする問題を修正をrelease/v0.1.0-beta.15にマージ

### DIFF
--- a/core/src/util/sequence_matcher.rs
+++ b/core/src/util/sequence_matcher.rs
@@ -11,7 +11,7 @@ pub enum Error {
 impl SequenceMatcher {
     pub fn get_most_similar_match(
         input: &str,
-        possibilities: &Vec<String>,
+        possibilities: &[String],
         threshold: Option<f64>,
     ) -> Result<String, Error> {
         let mut highest_similarity: f64 = 0.0;
@@ -37,7 +37,7 @@ impl SequenceMatcher {
         }
     }
 
-    fn get_length_of_longest_one(text_list: &Vec<String>) -> Option<usize> {
+    fn get_length_of_longest_one(text_list: &[String]) -> Option<usize> {
         text_list.iter().map(|x| x.chars().count()).max()
     }
 

--- a/core/src/util/sequence_matcher.rs
+++ b/core/src/util/sequence_matcher.rs
@@ -63,6 +63,24 @@ mod tests {
     use crate::util::sequence_matcher::SequenceMatcher;
 
     #[test]
+    fn get_length_of_longest_one() {
+        assert_eq!(SequenceMatcher::get_length_of_longest_one(&vec![]), None);
+        assert_eq!(
+            SequenceMatcher::get_length_of_longest_one(&generate_city_name_list()),
+            Some(8)
+        );
+    }
+
+    #[test]
+    fn cut_text() {
+        let city_name = "南会津郡檜枝岐村";
+        assert_eq!(SequenceMatcher::cut_text(city_name, 0), "");
+        assert_eq!(SequenceMatcher::cut_text(city_name, 1), "南");
+        assert_eq!(SequenceMatcher::cut_text(city_name, 8), "南会津郡檜枝岐村");
+        assert_eq!(SequenceMatcher::cut_text(city_name, 9), "南会津郡檜枝岐村");
+    }
+
+    #[test]
     fn evaluate_match_ratio_一致度100() {
         assert_eq!(
             SequenceMatcher::evaluate_match_ratio("相馬郡新地町", "相馬郡新地町"),
@@ -88,7 +106,58 @@ mod tests {
 
     #[test]
     fn get_most_similar_match() {
-        let possibilities = vec![
+        let possibilities = generate_city_name_list();
+        let result = SequenceMatcher::get_most_similar_match(
+            "西郷村大字熊倉字折口原40番地",
+            &possibilities,
+            None,
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "西白河郡西郷村");
+        let result = SequenceMatcher::get_most_similar_match(
+            "小野町大字小野新町字舘廻",
+            &possibilities,
+            None,
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "田村郡小野町");
+        let result = SequenceMatcher::get_most_similar_match(
+            "桑折町大字谷地字道下22番地7",
+            &possibilities,
+            None,
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "伊達郡桑折町");
+    }
+
+    #[test]
+    fn get_most_similar_match_類似度が同じものが複数ある場合() {
+        let possibilities = vec!["周智郡森町".to_string(), "茅部郡森町".to_string()];
+        assert_eq!(
+            SequenceMatcher::evaluate_match_ratio("森町", &possibilities[0]),
+            SequenceMatcher::evaluate_match_ratio("森町", &possibilities[1])
+        );
+        let result = SequenceMatcher::get_most_similar_match("森町", &possibilities, None);
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap(),
+            MoreThanOneCandidateExist(vec!["周智郡森町".to_string(), "茅部郡森町".to_string()])
+        );
+    }
+
+    #[test]
+    fn get_most_similar_match_マッチ候補が一つもない場合() {
+        let result = SequenceMatcher::get_most_similar_match(
+            "上町",
+            &vec!["上村".to_string(), "下町".to_string()],
+            Some(0.9),
+        );
+        assert!(result.is_err());
+        assert_eq!(result.err().unwrap(), NoCandidateExist);
+    }
+
+    fn generate_city_name_list() -> Vec<String> {
+        vec![
             "福島市".to_string(),
             "会津若松市".to_string(),
             "郡山市".to_string(),
@@ -148,53 +217,6 @@ mod tests {
             "双葉郡葛尾村".to_string(),
             "相馬郡新地町".to_string(),
             "相馬郡飯舘村".to_string(),
-        ];
-        let result = SequenceMatcher::get_most_similar_match(
-            "西郷村大字熊倉字折口原40番地",
-            &possibilities,
-            None,
-        );
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "西白河郡西郷村");
-        let result = SequenceMatcher::get_most_similar_match(
-            "小野町大字小野新町字舘廻",
-            &possibilities,
-            None,
-        );
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "田村郡小野町");
-        let result = SequenceMatcher::get_most_similar_match(
-            "桑折町大字谷地字道下22番地7",
-            &possibilities,
-            None,
-        );
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "伊達郡桑折町");
-    }
-
-    #[test]
-    fn get_most_similar_match_類似度が同じものが複数ある場合() {
-        let possibilities = vec!["周智郡森町".to_string(), "茅部郡森町".to_string()];
-        assert_eq!(
-            SequenceMatcher::evaluate_match_ratio("森町", &possibilities[0]),
-            SequenceMatcher::evaluate_match_ratio("森町", &possibilities[1])
-        );
-        let result = SequenceMatcher::get_most_similar_match("森町", &possibilities, None);
-        assert!(result.is_err());
-        assert_eq!(
-            result.err().unwrap(),
-            MoreThanOneCandidateExist(vec!["周智郡森町".to_string(), "茅部郡森町".to_string()])
-        );
-    }
-
-    #[test]
-    fn get_most_similar_match_マッチ候補が一つもない場合() {
-        let result = SequenceMatcher::get_most_similar_match(
-            "上町",
-            &vec!["上村".to_string(), "下町".to_string()],
-            Some(0.9),
-        );
-        assert!(result.is_err());
-        assert_eq!(result.err().unwrap(), NoCandidateExist);
+        ]
     }
 }

--- a/core/src/util/sequence_matcher.rs
+++ b/core/src/util/sequence_matcher.rs
@@ -16,16 +16,10 @@ impl SequenceMatcher {
     ) -> Result<String, Error> {
         let mut highest_similarity: f64 = 0.0;
         let mut highest_matches: Vec<String> = vec![];
-        let length_of_longest_possibility = possibilities.iter().map(|x| x.len()).max().unwrap();
+        let length_of_longest_possibility = Self::get_length_of_longest_one(possibilities).unwrap();
+        let input = Self::cut_text(input, length_of_longest_possibility);
         for possibility in possibilities {
-            let similarity = Self::evaluate_match_ratio(
-                possibility,
-                if input.len() > length_of_longest_possibility {
-                    input.get(0..length_of_longest_possibility).unwrap()
-                } else {
-                    input
-                },
-            );
+            let similarity = Self::evaluate_match_ratio(possibility, &input);
             if similarity >= highest_similarity {
                 if similarity > highest_similarity {
                     highest_matches.clear();
@@ -40,6 +34,18 @@ impl SequenceMatcher {
             0 => Err(Error::NoCandidateExist),
             1 => Ok(highest_matches.first().unwrap().clone()),
             _ => Err(Error::MoreThanOneCandidateExist(highest_matches)),
+        }
+    }
+
+    fn get_length_of_longest_one(text_list: &Vec<String>) -> Option<usize> {
+        text_list.iter().map(|x| x.chars().count()).max()
+    }
+
+    fn cut_text(input: &str, length: usize) -> String {
+        if input.chars().count() > length {
+            input.chars().take(length).collect::<String>()
+        } else {
+            input.to_string()
         }
     }
 


### PR DESCRIPTION
### 変更点
- `v0.1.0-beta.14`で追加された`SequenceMatcher::get_most_similar_match()`にバグがあったので修正。

### 確認すべき項目
- [x] `cargo fmt`
- [x] `cargo test`

### 備考
- #236 
