### PR TITLE
parserのリファクタリング: `Api`トレイトを削除し実装をそのまま用いるように変更

### DIFF
--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -5,28 +5,14 @@ use crate::api::city_master_api::CityMasterApi;
 use crate::api::prefecture_master_api::PrefectureMasterApi;
 use crate::entity::{City, Prefecture};
 use crate::err::Error;
-use std::future::Future;
-
-pub trait Api {
-    fn new() -> Self;
-    fn get_prefecture_master(
-        &self,
-        prefecture_name: &str,
-    ) -> impl Future<Output = Result<Prefecture, Error>>;
-    fn get_city_master(
-        &self,
-        prefecture_name: &str,
-        city_name: &str,
-    ) -> impl Future<Output = Result<City, Error>>;
-}
 
 pub struct ApiImpl {
     pub prefecture_master_api: PrefectureMasterApi,
     pub city_master_api: CityMasterApi,
 }
 
-impl Api for ApiImpl {
-    fn new() -> Self {
+impl ApiImpl {
+    pub fn new() -> Self {
         ApiImpl {
             prefecture_master_api: PrefectureMasterApi {
                 server_url:
@@ -38,19 +24,16 @@ impl Api for ApiImpl {
         }
     }
 
-    fn get_prefecture_master(
-        &self,
-        prefecture_name: &str,
-    ) -> impl Future<Output = Result<Prefecture, Error>> {
-        self.prefecture_master_api.get(prefecture_name)
+    pub async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
+        self.prefecture_master_api.get(prefecture_name).await
     }
 
-    fn get_city_master(
+    pub async fn get_city_master(
         &self,
         prefecture_name: &str,
         city_name: &str,
-    ) -> impl Future<Output = Result<City, Error>> {
-        self.city_master_api.get(prefecture_name, city_name)
+    ) -> Result<City, Error> {
+        self.city_master_api.get(prefecture_name, city_name).await
     }
 }
 

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -6,14 +6,14 @@ use crate::api::prefecture_master_api::PrefectureMasterApi;
 use crate::entity::{City, Prefecture};
 use crate::err::Error;
 
-pub struct ApiImpl {
+pub struct AsyncApi {
     pub prefecture_master_api: PrefectureMasterApi,
     pub city_master_api: CityMasterApi,
 }
 
-impl ApiImpl {
+impl AsyncApi {
     pub fn new() -> Self {
-        ApiImpl {
+        AsyncApi {
             prefecture_master_api: PrefectureMasterApi {
                 server_url:
                     "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::api::ApiImpl;
+use crate::api::AsyncApi;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::api::BlockingApi;
 use crate::entity::{Address, ParseResult};
@@ -14,7 +14,7 @@ mod read_house_number;
 mod read_prefecture;
 mod read_town;
 
-pub async fn parse(api: ApiImpl, input: &str) -> ParseResult {
+pub async fn parse(api: AsyncApi, input: &str) -> ParseResult {
     // 都道府県を特定
     let (rest, prefecture_name) = if let Some(result) = read_prefecture(input) {
         result
@@ -73,14 +73,14 @@ pub async fn parse(api: ApiImpl, input: &str) -> ParseResult {
 mod non_blocking_tests {
     use crate::api::city_master_api::CityMasterApi;
     use crate::api::prefecture_master_api::PrefectureMasterApi;
-    use crate::api::ApiImpl;
+    use crate::api::AsyncApi;
     use crate::err::ParseErrorKind;
     use crate::parser::parse;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     #[tokio::test]
     async fn 都道府県名が誤っている場合() {
-        let api = ApiImpl::new();
+        let api = AsyncApi::new();
         let result = parse(api, "青盛県青森市長島１丁目１−１").await;
         assert_eq!(result.address.prefecture, "");
         assert_eq!(result.address.city, "");
@@ -95,7 +95,7 @@ mod non_blocking_tests {
 
     #[tokio::test]
     async fn 都道府県マスタが取得できない場合() {
-        let mut api = ApiImpl::new();
+        let mut api = AsyncApi::new();
         api.prefecture_master_api = PrefectureMasterApi {
             server_url: "https://example.com/invalid_url/api/",
         };
@@ -110,7 +110,7 @@ mod non_blocking_tests {
 
     #[tokio::test]
     async fn 市区町村名が誤っている場合() {
-        let api = ApiImpl::new();
+        let api = AsyncApi::new();
         let result = parse(api, "青森県青盛市長島１丁目１−１").await;
         assert_eq!(result.address.prefecture, "青森県");
         assert_eq!(result.address.city, "");
@@ -125,7 +125,7 @@ mod non_blocking_tests {
 
     #[tokio::test]
     async fn 市区町村マスタが取得できない場合() {
-        let mut api = ApiImpl::new();
+        let mut api = AsyncApi::new();
         api.city_master_api = CityMasterApi {
             server_url: "https://example.com/invalid_url/api/",
         };
@@ -140,7 +140,7 @@ mod non_blocking_tests {
 
     #[tokio::test]
     async fn 町名が誤っている場合() {
-        let api = ApiImpl::new();
+        let api = AsyncApi::new();
         let result = parse(api, "青森県青森市永嶋１丁目１−１").await;
         assert_eq!(result.address.prefecture, "青森県");
         assert_eq!(result.address.city, "青森市");
@@ -157,7 +157,7 @@ mod non_blocking_tests {
 
     #[wasm_bindgen_test]
     async fn parse_wasm_success() {
-        let api = ApiImpl::new();
+        let api = AsyncApi::new();
         let result = parse(api, "兵庫県淡路市生穂新島8番地").await;
         assert_eq!(result.address.prefecture, "兵庫県".to_string());
         assert_eq!(result.address.city, "淡路市".to_string());

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::api::Api;
+use crate::api::ApiImpl;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::api::BlockingApi;
 use crate::entity::{Address, ParseResult};
@@ -14,7 +14,7 @@ mod read_house_number;
 mod read_prefecture;
 mod read_town;
 
-pub async fn parse<T: Api>(api: T, input: &str) -> ParseResult {
+pub async fn parse(api: ApiImpl, input: &str) -> ParseResult {
     // 都道府県を特定
     let (rest, prefecture_name) = if let Some(result) = read_prefecture(input) {
         result
@@ -73,7 +73,7 @@ pub async fn parse<T: Api>(api: T, input: &str) -> ParseResult {
 mod non_blocking_tests {
     use crate::api::city_master_api::CityMasterApi;
     use crate::api::prefecture_master_api::PrefectureMasterApi;
-    use crate::api::{Api, ApiImpl};
+    use crate::api::ApiImpl;
     use crate::err::ParseErrorKind;
     use crate::parser::parse;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use csv::ReaderBuilder;
-use japanese_address_parser::api::{Api, ApiImpl};
+use japanese_address_parser::api::ApiImpl;
 use japanese_address_parser::parser::parse;
 use serde::Deserialize;
 use std::fs::File;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
 use csv::ReaderBuilder;
-use japanese_address_parser::api::ApiImpl;
+use japanese_address_parser::api::AsyncApi;
 use japanese_address_parser::parser::parse;
 use serde::Deserialize;
 use std::fs::File;
@@ -29,7 +29,7 @@ pub async fn run_data_driven_tests(file_path: &str) {
     let records = read_test_data_from_csv(file_path).unwrap();
     let mut success_count = 0;
     for record in &records {
-        let api = ApiImpl::new();
+        let api = AsyncApi::new();
         let result = parse(api, &record.address).await;
 
         let test_result = panic::catch_unwind(|| {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use japanese_address_parser::api::{Api, ApiImpl};
+use japanese_address_parser::api::ApiImpl;
 use japanese_address_parser::parser;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,4 +1,4 @@
-use japanese_address_parser::api::ApiImpl;
+use japanese_address_parser::api::AsyncApi;
 use japanese_address_parser::parser;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
@@ -42,7 +42,7 @@ impl Parser {
     pub async fn parse(&self, address: &str) -> JsValue {
         #[cfg(feature = "debug")]
         console_error_panic_hook::set_once();
-        let api = ApiImpl::new();
+        let api = AsyncApi::new();
         let result = parser::parse(api, address).await;
         serde_wasm_bindgen::to_value(&result).unwrap()
     }


### PR DESCRIPTION
### 変更点
- トレイト`Api`を定義し、それを`ApiImpl`で実装する作りになっていたが、抽象化の必要がないのでトレイトを削除。
- `ApiImpl`を`AsyncApi`にリネーム。
