### PR TITLE
parserのリファクタリング: 古いインターフェースを使っている箇所を`Parser`ベースに書き換えた

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,5 @@
 use csv::ReaderBuilder;
-use japanese_address_parser::api::AsyncApi;
-use japanese_address_parser::parser::parse;
+use japanese_address_parser::parser::Parser;
 use serde::Deserialize;
 use std::fs::File;
 use std::panic;
@@ -28,9 +27,9 @@ fn read_test_data_from_csv(file_path: &str) -> Result<Vec<Record>, &str> {
 pub async fn run_data_driven_tests(file_path: &str) {
     let records = read_test_data_from_csv(file_path).unwrap();
     let mut success_count = 0;
+    let parser = Parser::new();
     for record in &records {
-        let api = AsyncApi::new();
-        let result = parse(api.into(), &record.address).await;
+        let result = parser.parse(&record.address).await;
 
         let test_result = panic::catch_unwind(|| {
             assert_eq!(result.address.prefecture, record.prefecture);

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,5 +1,6 @@
 use japanese_address_parser::api::AsyncApi;
 use japanese_address_parser::parser;
+use std::sync::Arc;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
@@ -30,20 +31,23 @@ export class Parser {
 }"#;
 
 #[wasm_bindgen(skip_typescript)]
-pub struct Parser();
+pub struct Parser {
+    async_api: Arc<AsyncApi>,
+}
 
 #[wasm_bindgen]
 impl Parser {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        Parser {}
+        Parser {
+            async_api: Arc::new(AsyncApi::new()),
+        }
     }
 
     pub async fn parse(&self, address: &str) -> JsValue {
         #[cfg(feature = "debug")]
         console_error_panic_hook::set_once();
-        let api = AsyncApi::new();
-        let result = parser::parse(api.into(), address).await;
+        let result = parser::parse(self.async_api.clone(), address).await;
         serde_wasm_bindgen::to_value(&result).unwrap()
     }
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -39,14 +39,14 @@ pub struct Parser {
 impl Parser {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
+        #[cfg(feature = "debug")]
+        console_error_panic_hook::set_once();
         Parser {
             async_api: Arc::new(AsyncApi::new()),
         }
     }
 
     pub async fn parse(&self, address: &str) -> JsValue {
-        #[cfg(feature = "debug")]
-        console_error_panic_hook::set_once();
         let result = parser::parse(self.async_api.clone(), address).await;
         serde_wasm_bindgen::to_value(&result).unwrap()
     }


### PR DESCRIPTION
### 変更点
- `wasm`モジュール、`test`モジュールで古い書き方になっている箇所を、新しく追加した`Parser`を用いた書き方に書き直した。