### PR TITLE
blocking parserのリファクタリング: トレイト`BlockingApi`を削除

### DIFF
--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -38,14 +38,6 @@ impl AsyncApi {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-#[deprecated]
-pub trait BlockingApi {
-    fn new() -> Self;
-    fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error>;
-    fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error>;
-}
-
-#[cfg(not(target_arch = "wasm32"))]
 pub struct BlockingApiImpl {
     prefecture_master_api: PrefectureMasterApi,
     city_master_api: CityMasterApi,

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -52,8 +52,8 @@ pub struct BlockingApiImpl {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl BlockingApi for BlockingApiImpl {
-    fn new() -> Self {
+impl BlockingApiImpl {
+    pub fn new() -> Self {
         BlockingApiImpl {
             prefecture_master_api: PrefectureMasterApi {
                 server_url:
@@ -65,11 +65,11 @@ impl BlockingApi for BlockingApiImpl {
         }
     }
 
-    fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
+    pub fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         self.prefecture_master_api.get_blocking(prefecture_name)
     }
 
-    fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
+    pub fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
         self.city_master_api
             .get_blocking(prefecture_name, city_name)
     }

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -38,6 +38,7 @@ impl AsyncApi {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[deprecated]
 pub trait BlockingApi {
     fn new() -> Self;
     fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error>;

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -38,15 +38,15 @@ impl AsyncApi {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub struct BlockingApiImpl {
+pub struct BlockingApi {
     prefecture_master_api: PrefectureMasterApi,
     city_master_api: CityMasterApi,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl BlockingApiImpl {
+impl BlockingApi {
     pub fn new() -> Self {
-        BlockingApiImpl {
+        BlockingApi {
             prefecture_master_api: PrefectureMasterApi {
                 server_url:
                     "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::api::AsyncApi;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::api::BlockingApi;
+use crate::api::BlockingApiImpl;
 use crate::entity::{Address, ParseResult};
 use crate::err::{Error, ParseErrorKind};
 use crate::parser::read_city::read_city;
@@ -202,7 +202,7 @@ mod non_blocking_tests {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn parse_blocking<T: BlockingApi>(api: T, input: &str) -> ParseResult {
+pub fn parse_blocking(api: BlockingApiImpl, input: &str) -> ParseResult {
     let (rest, prefecture_name) = match read_prefecture(input) {
         None => {
             return ParseResult {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -257,7 +257,7 @@ pub fn parse_blocking(api: BlockingApiImpl, input: &str) -> ParseResult {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod blocking_tests {
-    use crate::api::{BlockingApi, BlockingApiImpl};
+    use crate::api::BlockingApiImpl;
     use crate::err::ParseErrorKind;
     use crate::parser::parse_blocking;
 

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::api::AsyncApi;
 #[cfg(not(target_arch = "wasm32"))]
-use crate::api::BlockingApiImpl;
+use crate::api::BlockingApi;
 use crate::entity::{Address, ParseResult};
 use crate::err::{Error, ParseErrorKind};
 use crate::parser::read_city::read_city;
@@ -202,7 +202,7 @@ mod non_blocking_tests {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn parse_blocking(api: BlockingApiImpl, input: &str) -> ParseResult {
+pub fn parse_blocking(api: BlockingApi, input: &str) -> ParseResult {
     let (rest, prefecture_name) = match read_prefecture(input) {
         None => {
             return ParseResult {
@@ -257,13 +257,13 @@ pub fn parse_blocking(api: BlockingApiImpl, input: &str) -> ParseResult {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod blocking_tests {
-    use crate::api::BlockingApiImpl;
+    use crate::api::BlockingApi;
     use crate::err::ParseErrorKind;
     use crate::parser::parse_blocking;
 
     #[test]
     fn parse_blocking_success_埼玉県秩父市熊木町8番15号() {
-        let client = BlockingApiImpl::new();
+        let client = BlockingApi::new();
         let result = parse_blocking(client, "埼玉県秩父市熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "秩父市");
@@ -274,7 +274,7 @@ mod blocking_tests {
 
     #[test]
     fn parse_blocking_fail_市町村名が間違っている場合() {
-        let client = BlockingApiImpl::new();
+        let client = BlockingApi::new();
         let result = parse_blocking(client, "埼玉県秩父柿熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "");

--- a/core/src/parser/read_city.rs
+++ b/core/src/parser/read_city.rs
@@ -44,7 +44,7 @@ pub fn read_city(input: &str, prefecture: Prefecture) -> Option<(String, String)
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::api::BlockingApiImpl;
+    use crate::api::BlockingApi;
     use crate::parser::read_city::read_city;
     use test_case::test_case;
 
@@ -62,7 +62,7 @@ mod tests {
     #[test_case("群馬県", "みなかみ町後閑318", "利根郡みなかみ町"; "success_利根郡みなかみ町_郡名が省略されている")]
     #[test_case("埼玉県", "東秩父村大字御堂634番地", "秩父郡東秩父村"; "success_秩父郡東秩父村_郡名が省略されている")]
     fn test_read_city(prefecture_name: &str, input: &str, expected: &str) {
-        let api = BlockingApiImpl::new();
+        let api = BlockingApi::new();
         let prefecture = api.get_prefecture_master(prefecture_name).unwrap();
         let (_, city_name) = read_city(input, prefecture).unwrap();
         assert_eq!(city_name, expected);

--- a/core/src/parser/read_city.rs
+++ b/core/src/parser/read_city.rs
@@ -44,7 +44,7 @@ pub fn read_city(input: &str, prefecture: Prefecture) -> Option<(String, String)
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::api::{BlockingApi, BlockingApiImpl};
+    use crate::api::BlockingApiImpl;
     use crate::parser::read_city::read_city;
     use test_case::test_case;
 

--- a/core/src/parser/read_town.rs
+++ b/core/src/parser/read_town.rs
@@ -58,7 +58,7 @@ fn find_town(input: &String, city: &City) -> Option<(String, String)> {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::api::BlockingApiImpl;
+    use crate::api::BlockingApi;
     use crate::entity::{City, Town};
     use crate::parser::read_town::read_town;
 
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn read_town_丁目が算用数字の場合_京都府京都市東山区n丁目() {
-        let client = BlockingApiImpl::new();
+        let client = BlockingApi::new();
         let city = client.get_city_master("京都府", "京都市東山区").unwrap();
         let test_cases = vec![
             ("本町1丁目45番", "本町一丁目"),
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn read_town_大字の省略_東京都西多摩郡日の出町大字平井() {
-        let blocking_api = BlockingApiImpl::new();
+        let blocking_api = BlockingApi::new();
         let city = blocking_api
             .get_city_master("東京都", "西多摩郡日の出町")
             .unwrap();

--- a/core/src/parser/read_town.rs
+++ b/core/src/parser/read_town.rs
@@ -58,7 +58,7 @@ fn find_town(input: &String, city: &City) -> Option<(String, String)> {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::api::{BlockingApi, BlockingApiImpl};
+    use crate::api::BlockingApiImpl;
     use crate::entity::{City, Town};
     use crate::parser::read_town::read_town;
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,4 +1,4 @@
-use japanese_address_parser::api::BlockingApiImpl;
+use japanese_address_parser::api::BlockingApi;
 use japanese_address_parser::entity::ParseResult;
 use japanese_address_parser::parser::parse_blocking;
 use pyo3::prelude::*;
@@ -30,7 +30,7 @@ impl From<ParseResult> for PyParseResult {
 
 #[pyfunction]
 fn parse(address: &str) -> PyParseResult {
-    let api = BlockingApiImpl::new();
+    let api = BlockingApi::new();
     parse_blocking(api, address).into()
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,4 +1,4 @@
-use japanese_address_parser::api::{BlockingApi, BlockingApiImpl};
+use japanese_address_parser::api::BlockingApiImpl;
 use japanese_address_parser::entity::ParseResult;
 use japanese_address_parser::parser::parse_blocking;
 use pyo3::prelude::*;


### PR DESCRIPTION
### 変更点
- トレイト`BlockingApi`を削除し、`parse()`では`BlockingApiImpl`をそのまま使用するように変更
- 構造体`BlockingApiImpl`を`BlockingApi`にリネーム