### PR TITLE
blocking parserのリファクタリング: `Parser`に`parse_blocking()`を追加

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,10 @@ rust-version = "1.64.0"
 [lib]
 crate-type = ["rlib", "cdylib"]
 
+[features]
+default = []
+blocking = []
+
 [dependencies]
 itertools = "0.12.0"
 js-sys = "0.3.67"

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -36,6 +36,15 @@ pub struct Parser {
 
 impl Parser {
     /// Constructs a new `Parser`.
+    #[cfg(feature = "blocking")]
+    pub fn new() -> Self {
+        Parser {
+            async_api: Arc::new(AsyncApi::new()),
+            blocking_api: Arc::new(BlockingApi::new()),
+        }
+    }
+
+    /// Constructs a new `Parser`.
     #[cfg(not(feature = "blocking"))]
     pub fn new() -> Self {
         Parser {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -51,9 +51,16 @@ impl Parser {
             async_api: Arc::new(AsyncApi::new()),
         }
     }
-    /// Parses the given `address`.
+
+    /// Parses the given `address` asynchronously.
     pub async fn parse(&self, address: &str) -> ParseResult {
         parse(self.async_api.clone(), address).await
+    }
+
+    /// Parses the given `address` synchronously.
+    #[cfg(feature = "blocking")]
+    pub fn parse_blocking(&self, address: &str) -> ParseResult {
+        parse_blocking(self.blocking_api.clone(), address)
     }
 }
 

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -30,10 +30,13 @@ mod read_town;
 /// ```
 pub struct Parser {
     async_api: Arc<AsyncApi>,
+    #[cfg(feature = "blocking")]
+    blocking_api: Arc<BlockingApi>,
 }
 
 impl Parser {
     /// Constructs a new `Parser`.
+    #[cfg(not(feature = "blocking"))]
     pub fn new() -> Self {
         Parser {
             async_api: Arc::new(AsyncApi::new()),

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -202,7 +202,7 @@ mod non_blocking_tests {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn parse_blocking(api: BlockingApi, input: &str) -> ParseResult {
+pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     let (rest, prefecture_name) = match read_prefecture(input) {
         None => {
             return ParseResult {
@@ -264,7 +264,7 @@ mod blocking_tests {
     #[test]
     fn parse_blocking_success_埼玉県秩父市熊木町8番15号() {
         let client = BlockingApi::new();
-        let result = parse_blocking(client, "埼玉県秩父市熊木町8番15号");
+        let result = parse_blocking(client.into(), "埼玉県秩父市熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "秩父市");
         assert_eq!(result.address.town, "熊木町");
@@ -275,7 +275,7 @@ mod blocking_tests {
     #[test]
     fn parse_blocking_fail_市町村名が間違っている場合() {
         let client = BlockingApi::new();
-        let result = parse_blocking(client, "埼玉県秩父柿熊木町8番15号");
+        let result = parse_blocking(client.into(), "埼玉県秩父柿熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "");
         assert_eq!(result.address.town, "");

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -31,7 +31,7 @@ impl From<ParseResult> for PyParseResult {
 #[pyfunction]
 fn parse(address: &str) -> PyParseResult {
     let api = BlockingApi::new();
-    parse_blocking(api, address).into()
+    parse_blocking(api.into(), address).into()
 }
 
 #[pymodule]


### PR DESCRIPTION
### 変更点
- `core`モジュールにフィーチャフラグ`blocking`を追加
- フィーチャフラグ`blocking`を指定している場合は、`Parser::parse_blocking()`が使用できるようにした。
