### PR TITLE
blocking parserのリファクタリング: pythonモジュールに`Parser`のラッパーを追加

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,5 +16,5 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-japanese-address-parser = { path = "../core" }
+japanese-address-parser = { path = "../core", features = ["blocking"] }
 pyo3 = { version = "0.21.0", features = ["abi3-py37"] }

--- a/python/README.md
+++ b/python/README.md
@@ -17,7 +17,7 @@ pip install japanese-address-parser-py
 ## Usage
 
 ```python
-import japanese_address_parser_py
+from japanese_address_parser_py import Parser
 
 address_list = [
     "埼玉県さいたま市浦和区高砂3-15-1",
@@ -25,8 +25,9 @@ address_list = [
     "東京都新宿区西新宿2-8-1",
     "神奈川県横浜市中区日本大通1"
 ]
+parser = Parser()
 for address in address_list:
-    parse_result = japanese_address_parser_py.parse(address)
+    parse_result = parser.parse(address)
     print(parse_result.address)
 ```
 
@@ -39,10 +40,11 @@ for address in address_list:
 
 
 ```python
-import japanese_address_parser_py
+from japanese_address_parser_py import Parser
 
+parser = Parser()
 address = "神奈川県横浜市中区本町6丁目50-10"
-parse_result = japanese_address_parser_py.parse(address)
+parse_result = parser.parse(address)
 print(parse_result.address["prefecture"])
 print(parse_result.address["city"])
 print(parse_result.address["town"])

--- a/python/japanese_address_parser_py.pyi
+++ b/python/japanese_address_parser_py.pyi
@@ -29,3 +29,24 @@ def parse(address: str) -> ParseResult:
     :param address: 住所
     :return: ParseResult
     """
+
+
+class Parser:
+    def __new__(cls) -> Parser:
+        """
+        Construct a parser.
+    
+        パーサーを生成します。
+
+        :return: JapaneseAddressParser
+        """
+
+    def parse(cls, address: str) -> ParseResult:
+        """
+        Format informal address into formal style
+
+        入力された住所を正式な表記に整形します。
+
+        :param address: 住所
+        :return: ParseResult
+        """

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -29,6 +29,25 @@ impl From<ParseResult> for PyParseResult {
     }
 }
 
+#[pyclass(name = "Parser")]
+struct PyParser {
+    parser: Parser,
+}
+
+#[pymethods]
+impl PyParser {
+    #[new]
+    fn default() -> Self {
+        PyParser {
+            parser: Parser::new(),
+        }
+    }
+
+    fn parse(&self, address: &str) -> PyParseResult {
+        self.parser.parse_blocking(address).into()
+    }
+}
+
 #[pyfunction]
 fn parse(address: &str) -> PyParseResult {
     let parser = Parser::new();
@@ -39,6 +58,7 @@ fn parse(address: &str) -> PyParseResult {
 #[pyo3(name = "japanese_address_parser_py")]
 fn python_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyParseResult>()?;
+    m.add_class::<PyParser>()?;
     m.add_function(wrap_pyfunction!(parse, m)?)?;
     Ok(())
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,8 +1,9 @@
-use japanese_address_parser::api::BlockingApi;
-use japanese_address_parser::entity::ParseResult;
-use japanese_address_parser::parser::parse_blocking;
-use pyo3::prelude::*;
 use std::collections::HashMap;
+
+use pyo3::prelude::*;
+
+use japanese_address_parser::entity::ParseResult;
+use japanese_address_parser::parser::Parser;
 
 #[pyclass(name = "ParseResult")]
 struct PyParseResult {
@@ -30,8 +31,8 @@ impl From<ParseResult> for PyParseResult {
 
 #[pyfunction]
 fn parse(address: &str) -> PyParseResult {
-    let api = BlockingApi::new();
-    parse_blocking(api.into(), address).into()
+    let parser = Parser::new();
+    parser.parse_blocking(address).into()
 }
 
 #[pymodule]


### PR DESCRIPTION
### 変更点
- pythonモジュールはblocking parserを使用しているため、blocking parserの仕様変更に伴い改善を行なった。
- coreモジュールの`Parser`のラッパーとして`PyParser`を定義し、Python側から使用できるようにした。
