### PR TITLE
blocking parserのリファクタリング: targetによる条件コンパイルを設定していた箇所をfeature flagによる条件コンパイルに変更

### DIFF
--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -26,4 +26,6 @@ jobs:
       - name: Build check
         run: cargo build --verbose
       - name: Unit Testing
-        run: cargo test --verbose
+        run: | 
+          cargo test
+          cargo test --features blocking 

--- a/.github/workflows/upload-cratesio.yaml
+++ b/.github/workflows/upload-cratesio.yaml
@@ -18,7 +18,9 @@ jobs:
       - name: Build check
         run: cargo build --verbose
       - name: Unit Testing
-        run: cargo test --verbose
+        run: |
+          cargo test
+          cargo test --features blocking 
 
       - name: Try packaging
         run: cargo publish --dry-run

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -37,13 +37,13 @@ impl AsyncApi {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "blocking")]
 pub struct BlockingApi {
     prefecture_master_api: PrefectureMasterApi,
     city_master_api: CityMasterApi,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "blocking")]
 impl BlockingApi {
     pub fn new() -> Self {
         BlockingApi {

--- a/core/src/api/city_master_api.rs
+++ b/core/src/api/city_master_api.rs
@@ -24,7 +24,7 @@ impl CityMasterApi {
             Err(Error::new_api_error(ApiErrorKind::Fetch(endpoint)))
         }
     }
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "blocking")]
     pub fn get_blocking(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
         let endpoint = format!("{}/{}/{}.json", self.server_url, prefecture_name, city_name);
         let response = match reqwest::blocking::get(&endpoint) {

--- a/core/src/api/city_master_api.rs
+++ b/core/src/api/city_master_api.rs
@@ -45,7 +45,7 @@ impl CityMasterApi {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "blocking")))]
 mod tests {
     use crate::api::city_master_api::CityMasterApi;
     use crate::entity::Town;
@@ -56,24 +56,6 @@ mod tests {
             server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
         };
         let result = city_master_api.get("石川県", "羽咋郡志賀町").await;
-        let city = result.unwrap();
-        assert_eq!(city.name, "羽咋郡志賀町");
-        let town = Town {
-            name: "末吉".to_string(),
-            koaza: "千古".to_string(),
-            lat: Some(37.006235),
-            lng: Some(136.779155),
-        };
-        assert!(city.towns.contains(&town));
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn 同期_石川県羽咋郡志賀町_成功() {
-        let city_master_api = CityMasterApi {
-            server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
-        };
-        let result = city_master_api.get_blocking("石川県", "羽咋郡志賀町");
         let city = result.unwrap();
         assert_eq!(city.name, "羽咋郡志賀町");
         let town = Town {
@@ -100,8 +82,30 @@ mod tests {
             )
         );
     }
+}
 
-    #[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(test, feature = "blocking"))]
+mod blocking_tests {
+    use crate::api::city_master_api::CityMasterApi;
+    use crate::entity::Town;
+
+    #[test]
+    fn 同期_石川県羽咋郡志賀町_成功() {
+        let city_master_api = CityMasterApi {
+            server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
+        };
+        let result = city_master_api.get_blocking("石川県", "羽咋郡志賀町");
+        let city = result.unwrap();
+        assert_eq!(city.name, "羽咋郡志賀町");
+        let town = Town {
+            name: "末吉".to_string(),
+            koaza: "千古".to_string(),
+            lat: Some(37.006235),
+            lng: Some(136.779155),
+        };
+        assert!(city.towns.contains(&town));
+    }
+
     #[test]
     fn 同期_誤った市区町村名_失敗() {
         let city_master_api = CityMasterApi {

--- a/core/src/api/prefecture_master_api.rs
+++ b/core/src/api/prefecture_master_api.rs
@@ -21,7 +21,7 @@ impl PrefectureMasterApi {
             Err(Error::new_api_error(ApiErrorKind::Fetch(endpoint)))
         }
     }
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "blocking")]
     pub fn get_blocking(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         let endpoint = format!("{}/{}/master.json", self.server_url, prefecture_name);
         let response = match reqwest::blocking::get(&endpoint) {

--- a/core/src/api/prefecture_master_api.rs
+++ b/core/src/api/prefecture_master_api.rs
@@ -39,7 +39,7 @@ impl PrefectureMasterApi {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "blocking")))]
 mod tests {
     use crate::api::prefecture_master_api::PrefectureMasterApi;
 
@@ -49,37 +49,6 @@ mod tests {
             server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
         };
         let result = prefecture_master_api.get("富山県").await;
-        let prefecture = result.unwrap();
-        assert_eq!(prefecture.name, "富山県");
-        let cities = vec![
-            "富山市",
-            "高岡市",
-            "魚津市",
-            "氷見市",
-            "滑川市",
-            "黒部市",
-            "砺波市",
-            "小矢部市",
-            "南砺市",
-            "射水市",
-            "中新川郡舟橋村",
-            "中新川郡上市町",
-            "中新川郡立山町",
-            "下新川郡入善町",
-            "下新川郡朝日町",
-        ];
-        for city in cities {
-            assert!(prefecture.cities.contains(&city.to_string()));
-        }
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn 同期_富山県_成功() {
-        let prefecture_master_api = PrefectureMasterApi {
-            server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
-        };
-        let result = prefecture_master_api.get_blocking("富山県");
         let prefecture = result.unwrap();
         assert_eq!(prefecture.name, "富山県");
         let cities = vec![
@@ -119,8 +88,42 @@ mod tests {
             )
         );
     }
+}
 
-    #[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(test, feature = "blocking"))]
+mod blocking_tests {
+    use crate::api::prefecture_master_api::PrefectureMasterApi;
+
+    #[test]
+    fn 同期_富山県_成功() {
+        let prefecture_master_api = PrefectureMasterApi {
+            server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
+        };
+        let result = prefecture_master_api.get_blocking("富山県");
+        let prefecture = result.unwrap();
+        assert_eq!(prefecture.name, "富山県");
+        let cities = vec![
+            "富山市",
+            "高岡市",
+            "魚津市",
+            "氷見市",
+            "滑川市",
+            "黒部市",
+            "砺波市",
+            "小矢部市",
+            "南砺市",
+            "射水市",
+            "中新川郡舟橋村",
+            "中新川郡上市町",
+            "中新川郡立山町",
+            "下新川郡入善町",
+            "下新川郡朝日町",
+        ];
+        for city in cities {
+            assert!(prefecture.cities.contains(&city.to_string()));
+        }
+    }
+
     #[test]
     fn 同期_誤った都道府県名_失敗() {
         let prefecture_master_api = PrefectureMasterApi {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -122,8 +122,8 @@ pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
     }
 }
 
-#[cfg(test)]
-mod non_blocking_tests {
+#[cfg(all(test, not(feature = "blocking")))]
+mod tests {
     use crate::api::city_master_api::CityMasterApi;
     use crate::api::prefecture_master_api::PrefectureMasterApi;
     use crate::api::AsyncApi;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::api::AsyncApi;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "blocking")]
 use crate::api::BlockingApi;
 use crate::entity::{Address, ParseResult};
 use crate::err::{Error, ParseErrorKind};
@@ -223,7 +223,7 @@ mod non_blocking_tests {
 /// A function to parse the given address synchronously.
 ///
 /// publicにしていますが、直接の使用は推奨されません。[Parser]の利用を検討してください。
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "blocking")]
 pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     let (rest, prefecture_name) = match read_prefecture(input) {
         None => {
@@ -277,7 +277,7 @@ pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, feature = "blocking"))]
 mod blocking_tests {
     use crate::api::BlockingApi;
     use crate::err::ParseErrorKind;

--- a/core/src/parser/read_city.rs
+++ b/core/src/parser/read_city.rs
@@ -42,7 +42,7 @@ pub fn read_city(input: &str, prefecture: Prefecture) -> Option<(String, String)
     None
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, feature = "blocking"))]
 mod tests {
     use crate::api::BlockingApi;
     use crate::parser::read_city::read_city;

--- a/core/src/parser/read_town.rs
+++ b/core/src/parser/read_town.rs
@@ -56,7 +56,7 @@ fn find_town(input: &String, city: &City) -> Option<(String, String)> {
     None
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, feature = "blocking"))]
 mod tests {
     use crate::api::BlockingApi;
     use crate::entity::{City, Town};


### PR DESCRIPTION
### 変更点
- `reqwest::blocking`が`wasm`向けにビルドできないことから、`#[cfg(not(target_arch = "wasm32"))]`のような条件コンパイルを各所に設定していたが、
- 先の修正でフィーチャフラグ`blocking`を定義したため、`#[cfg(feature = "blocking")]`に寄せる。