### PR TITLE
blocking parserのリファクタリング: ビルドターゲットが`wasm*`かつフィーチャフラグ`blocking`を指定している場合にエラーメッセージを表示する

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,8 @@
+#[cfg(all(target_family = "wasm", feature = "blocking"))]
+compile_error! {
+    "The `blocking` feature is not supported with wasm target."
+}
+
 pub mod api;
 pub mod entity;
 mod err;


### PR DESCRIPTION
### 変更点
- フィーチャフラグ`blocking`を指定した状態で`wasm`向けにビルドしようとすると以下のようなメッセージが表示されるようにした。

![image](https://github.com/YuukiToriyama/japanese-address-parser/assets/43945424/30a0cd24-53f9-4423-811d-97dfcc5b95a5)
