### PR TITLE
blocking parserのリファクタリング: CIを修正

### DIFF
--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -31,5 +31,5 @@ jobs:
           cargo test
           cargo test --features blocking
       - name: Integration Testing
-        working-directory: test
+        working-directory: tests
         run: cargo test

--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -26,6 +26,10 @@ jobs:
       - name: Build check
         run: cargo build --verbose
       - name: Unit Testing
+        working-directory: core
         run: | 
           cargo test
-          cargo test --features blocking 
+          cargo test --features blocking
+      - name: Integration Testing
+        working-directory: test
+        run: cargo test

--- a/.github/workflows/upload-cratesio.yaml
+++ b/.github/workflows/upload-cratesio.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Unit Testing
         run: |
           cargo test
-          cargo test --features blocking 
+          cargo test --features blocking
 
       - name: Try packaging
         run: cargo publish --dry-run


### PR DESCRIPTION
### 変更点
- ルートディレクトリで`cargo test --features blocking`を実行しても、`cargo test`と同じ実行結果になってしまうため、`core`ディレクトリの中で実行するように修正
