### PR TITLE
blocking parserのリファクタリングをrelease/v0.1.0-beta.17にマージ

### DIFF
--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -26,4 +26,6 @@ jobs:
       - name: Build check
         run: cargo build --verbose
       - name: Unit Testing
-        run: cargo test --verbose
+        run: | 
+          cargo test
+          cargo test --features blocking 

--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -26,6 +26,10 @@ jobs:
       - name: Build check
         run: cargo build --verbose
       - name: Unit Testing
+        working-directory: core
         run: | 
           cargo test
-          cargo test --features blocking 
+          cargo test --features blocking
+      - name: Integration Testing
+        working-directory: tests
+        run: cargo test

--- a/.github/workflows/upload-cratesio.yaml
+++ b/.github/workflows/upload-cratesio.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Unit Testing
         run: |
           cargo test
-          cargo test --features blocking 
+          cargo test --features blocking
 
       - name: Try packaging
         run: cargo publish --dry-run

--- a/.github/workflows/upload-cratesio.yaml
+++ b/.github/workflows/upload-cratesio.yaml
@@ -18,7 +18,9 @@ jobs:
       - name: Build check
         run: cargo build --verbose
       - name: Unit Testing
-        run: cargo test --verbose
+        run: |
+          cargo test
+          cargo test --features blocking 
 
       - name: Try packaging
         run: cargo publish --dry-run

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Add this to your `Cargo.toml`
 
 ```bash
 cargo add japanese-address-parser
+# or
+cargo add japanese-address-parser -F blocking
 ```
 
 ### Async Version
@@ -31,12 +33,11 @@ async fn main() {
 ### Blocking Version
 
 ```rust
-use japanese_address_parser::api::{BlockingApi, BlockingApiImpl};
-use japanese_address_parser::parser::parse_blocking;
+use japanese_address_parser::parser::Parser;
 
 fn main() {
-    let blocking_api = BlockingApiImpl::new();
-    let parse_result = parse_blocking(blocking_api, "東京都千代田区丸の内1-1-1");
+    let parser = Parser::new();
+    let parse_result = parser.parse_blocking("東京都千代田区丸の内1-1-1"); // `parse_blocking()` is available on `blocking` feature only
     println!("{:?}", parse_result);
 }
 ```

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,6 +14,10 @@ rust-version = "1.64.0"
 [lib]
 crate-type = ["rlib", "cdylib"]
 
+[features]
+default = []
+blocking = []
+
 [dependencies]
 itertools = "0.12.0"
 js-sys = "0.3.67"

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -37,13 +37,13 @@ impl AsyncApi {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "blocking")]
 pub struct BlockingApi {
     prefecture_master_api: PrefectureMasterApi,
     city_master_api: CityMasterApi,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "blocking")]
 impl BlockingApi {
     pub fn new() -> Self {
         BlockingApi {

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -38,22 +38,15 @@ impl AsyncApi {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub trait BlockingApi {
-    fn new() -> Self;
-    fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error>;
-    fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error>;
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-pub struct BlockingApiImpl {
+pub struct BlockingApi {
     prefecture_master_api: PrefectureMasterApi,
     city_master_api: CityMasterApi,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-impl BlockingApi for BlockingApiImpl {
-    fn new() -> Self {
-        BlockingApiImpl {
+impl BlockingApi {
+    pub fn new() -> Self {
+        BlockingApi {
             prefecture_master_api: PrefectureMasterApi {
                 server_url:
                     "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
@@ -64,11 +57,11 @@ impl BlockingApi for BlockingApiImpl {
         }
     }
 
-    fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
+    pub fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         self.prefecture_master_api.get_blocking(prefecture_name)
     }
 
-    fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
+    pub fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
         self.city_master_api
             .get_blocking(prefecture_name, city_name)
     }

--- a/core/src/api/city_master_api.rs
+++ b/core/src/api/city_master_api.rs
@@ -24,7 +24,7 @@ impl CityMasterApi {
             Err(Error::new_api_error(ApiErrorKind::Fetch(endpoint)))
         }
     }
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "blocking")]
     pub fn get_blocking(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
         let endpoint = format!("{}/{}/{}.json", self.server_url, prefecture_name, city_name);
         let response = match reqwest::blocking::get(&endpoint) {
@@ -45,7 +45,7 @@ impl CityMasterApi {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "blocking")))]
 mod tests {
     use crate::api::city_master_api::CityMasterApi;
     use crate::entity::Town;
@@ -56,24 +56,6 @@ mod tests {
             server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
         };
         let result = city_master_api.get("石川県", "羽咋郡志賀町").await;
-        let city = result.unwrap();
-        assert_eq!(city.name, "羽咋郡志賀町");
-        let town = Town {
-            name: "末吉".to_string(),
-            koaza: "千古".to_string(),
-            lat: Some(37.006235),
-            lng: Some(136.779155),
-        };
-        assert!(city.towns.contains(&town));
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn 同期_石川県羽咋郡志賀町_成功() {
-        let city_master_api = CityMasterApi {
-            server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
-        };
-        let result = city_master_api.get_blocking("石川県", "羽咋郡志賀町");
         let city = result.unwrap();
         assert_eq!(city.name, "羽咋郡志賀町");
         let town = Town {
@@ -100,8 +82,30 @@ mod tests {
             )
         );
     }
+}
 
-    #[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(test, feature = "blocking"))]
+mod blocking_tests {
+    use crate::api::city_master_api::CityMasterApi;
+    use crate::entity::Town;
+
+    #[test]
+    fn 同期_石川県羽咋郡志賀町_成功() {
+        let city_master_api = CityMasterApi {
+            server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
+        };
+        let result = city_master_api.get_blocking("石川県", "羽咋郡志賀町");
+        let city = result.unwrap();
+        assert_eq!(city.name, "羽咋郡志賀町");
+        let town = Town {
+            name: "末吉".to_string(),
+            koaza: "千古".to_string(),
+            lat: Some(37.006235),
+            lng: Some(136.779155),
+        };
+        assert!(city.towns.contains(&town));
+    }
+
     #[test]
     fn 同期_誤った市区町村名_失敗() {
         let city_master_api = CityMasterApi {

--- a/core/src/api/prefecture_master_api.rs
+++ b/core/src/api/prefecture_master_api.rs
@@ -21,7 +21,7 @@ impl PrefectureMasterApi {
             Err(Error::new_api_error(ApiErrorKind::Fetch(endpoint)))
         }
     }
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(feature = "blocking")]
     pub fn get_blocking(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         let endpoint = format!("{}/{}/master.json", self.server_url, prefecture_name);
         let response = match reqwest::blocking::get(&endpoint) {
@@ -39,7 +39,7 @@ impl PrefectureMasterApi {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "blocking")))]
 mod tests {
     use crate::api::prefecture_master_api::PrefectureMasterApi;
 
@@ -49,37 +49,6 @@ mod tests {
             server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
         };
         let result = prefecture_master_api.get("富山県").await;
-        let prefecture = result.unwrap();
-        assert_eq!(prefecture.name, "富山県");
-        let cities = vec![
-            "富山市",
-            "高岡市",
-            "魚津市",
-            "氷見市",
-            "滑川市",
-            "黒部市",
-            "砺波市",
-            "小矢部市",
-            "南砺市",
-            "射水市",
-            "中新川郡舟橋村",
-            "中新川郡上市町",
-            "中新川郡立山町",
-            "下新川郡入善町",
-            "下新川郡朝日町",
-        ];
-        for city in cities {
-            assert!(prefecture.cities.contains(&city.to_string()));
-        }
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    #[test]
-    fn 同期_富山県_成功() {
-        let prefecture_master_api = PrefectureMasterApi {
-            server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
-        };
-        let result = prefecture_master_api.get_blocking("富山県");
         let prefecture = result.unwrap();
         assert_eq!(prefecture.name, "富山県");
         let cities = vec![
@@ -119,8 +88,42 @@ mod tests {
             )
         );
     }
+}
 
-    #[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(test, feature = "blocking"))]
+mod blocking_tests {
+    use crate::api::prefecture_master_api::PrefectureMasterApi;
+
+    #[test]
+    fn 同期_富山県_成功() {
+        let prefecture_master_api = PrefectureMasterApi {
+            server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
+        };
+        let result = prefecture_master_api.get_blocking("富山県");
+        let prefecture = result.unwrap();
+        assert_eq!(prefecture.name, "富山県");
+        let cities = vec![
+            "富山市",
+            "高岡市",
+            "魚津市",
+            "氷見市",
+            "滑川市",
+            "黒部市",
+            "砺波市",
+            "小矢部市",
+            "南砺市",
+            "射水市",
+            "中新川郡舟橋村",
+            "中新川郡上市町",
+            "中新川郡立山町",
+            "下新川郡入善町",
+            "下新川郡朝日町",
+        ];
+        for city in cities {
+            assert!(prefecture.cities.contains(&city.to_string()));
+        }
+    }
+
     #[test]
     fn 同期_誤った都道府県名_失敗() {
         let prefecture_master_api = PrefectureMasterApi {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,8 @@
+#[cfg(all(target_family = "wasm", feature = "blocking"))]
+compile_error! {
+    "The `blocking` feature is not supported with wasm target."
+}
+
 pub mod api;
 pub mod entity;
 mod err;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::api::AsyncApi;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "blocking")]
 use crate::api::BlockingApi;
 use crate::entity::{Address, ParseResult};
 use crate::err::{Error, ParseErrorKind};
@@ -122,8 +122,8 @@ pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
     }
 }
 
-#[cfg(test)]
-mod non_blocking_tests {
+#[cfg(all(test, not(feature = "blocking")))]
+mod tests {
     use crate::api::city_master_api::CityMasterApi;
     use crate::api::prefecture_master_api::PrefectureMasterApi;
     use crate::api::AsyncApi;
@@ -223,7 +223,7 @@ mod non_blocking_tests {
 /// A function to parse the given address synchronously.
 ///
 /// publicにしていますが、直接の使用は推奨されません。[Parser]の利用を検討してください。
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "blocking")]
 pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     let (rest, prefecture_name) = match read_prefecture(input) {
         None => {
@@ -277,7 +277,7 @@ pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, feature = "blocking"))]
 mod blocking_tests {
     use crate::api::BlockingApi;
     use crate::err::ParseErrorKind;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -64,7 +64,7 @@ impl Parser {
     }
 }
 
-/// A function to parse the given address.
+/// A function to parse the given address asynchronously.
 ///
 /// publicにしていますが、直接の使用は推奨されません。[Parser]の利用を検討してください。
 pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
@@ -220,6 +220,9 @@ mod non_blocking_tests {
     }
 }
 
+/// A function to parse the given address synchronously.
+///
+/// publicにしていますが、直接の使用は推奨されません。[Parser]の利用を検討してください。
 #[cfg(not(target_arch = "wasm32"))]
 pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     let (rest, prefecture_name) = match read_prefecture(input) {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -202,7 +202,7 @@ mod non_blocking_tests {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn parse_blocking<T: BlockingApi>(api: T, input: &str) -> ParseResult {
+pub fn parse_blocking(api: BlockingApi, input: &str) -> ParseResult {
     let (rest, prefecture_name) = match read_prefecture(input) {
         None => {
             return ParseResult {
@@ -257,13 +257,13 @@ pub fn parse_blocking<T: BlockingApi>(api: T, input: &str) -> ParseResult {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod blocking_tests {
-    use crate::api::{BlockingApi, BlockingApiImpl};
+    use crate::api::BlockingApi;
     use crate::err::ParseErrorKind;
     use crate::parser::parse_blocking;
 
     #[test]
     fn parse_blocking_success_埼玉県秩父市熊木町8番15号() {
-        let client = BlockingApiImpl::new();
+        let client = BlockingApi::new();
         let result = parse_blocking(client, "埼玉県秩父市熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "秩父市");
@@ -274,7 +274,7 @@ mod blocking_tests {
 
     #[test]
     fn parse_blocking_fail_市町村名が間違っている場合() {
-        let client = BlockingApiImpl::new();
+        let client = BlockingApi::new();
         let result = parse_blocking(client, "埼玉県秩父柿熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "");

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -30,18 +30,37 @@ mod read_town;
 /// ```
 pub struct Parser {
     async_api: Arc<AsyncApi>,
+    #[cfg(feature = "blocking")]
+    blocking_api: Arc<BlockingApi>,
 }
 
 impl Parser {
     /// Constructs a new `Parser`.
+    #[cfg(feature = "blocking")]
+    pub fn new() -> Self {
+        Parser {
+            async_api: Arc::new(AsyncApi::new()),
+            blocking_api: Arc::new(BlockingApi::new()),
+        }
+    }
+
+    /// Constructs a new `Parser`.
+    #[cfg(not(feature = "blocking"))]
     pub fn new() -> Self {
         Parser {
             async_api: Arc::new(AsyncApi::new()),
         }
     }
-    /// Parses the given `address`.
+
+    /// Parses the given `address` asynchronously.
     pub async fn parse(&self, address: &str) -> ParseResult {
         parse(self.async_api.clone(), address).await
+    }
+
+    /// Parses the given `address` synchronously.
+    #[cfg(feature = "blocking")]
+    pub fn parse_blocking(&self, address: &str) -> ParseResult {
+        parse_blocking(self.blocking_api.clone(), address)
     }
 }
 
@@ -202,7 +221,7 @@ mod non_blocking_tests {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub fn parse_blocking(api: BlockingApi, input: &str) -> ParseResult {
+pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     let (rest, prefecture_name) = match read_prefecture(input) {
         None => {
             return ParseResult {
@@ -264,7 +283,7 @@ mod blocking_tests {
     #[test]
     fn parse_blocking_success_埼玉県秩父市熊木町8番15号() {
         let client = BlockingApi::new();
-        let result = parse_blocking(client, "埼玉県秩父市熊木町8番15号");
+        let result = parse_blocking(client.into(), "埼玉県秩父市熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "秩父市");
         assert_eq!(result.address.town, "熊木町");
@@ -275,7 +294,7 @@ mod blocking_tests {
     #[test]
     fn parse_blocking_fail_市町村名が間違っている場合() {
         let client = BlockingApi::new();
-        let result = parse_blocking(client, "埼玉県秩父柿熊木町8番15号");
+        let result = parse_blocking(client.into(), "埼玉県秩父柿熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "");
         assert_eq!(result.address.town, "");

--- a/core/src/parser/read_city.rs
+++ b/core/src/parser/read_city.rs
@@ -44,7 +44,7 @@ pub fn read_city(input: &str, prefecture: Prefecture) -> Option<(String, String)
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::api::{BlockingApi, BlockingApiImpl};
+    use crate::api::BlockingApi;
     use crate::parser::read_city::read_city;
     use test_case::test_case;
 
@@ -62,7 +62,7 @@ mod tests {
     #[test_case("群馬県", "みなかみ町後閑318", "利根郡みなかみ町"; "success_利根郡みなかみ町_郡名が省略されている")]
     #[test_case("埼玉県", "東秩父村大字御堂634番地", "秩父郡東秩父村"; "success_秩父郡東秩父村_郡名が省略されている")]
     fn test_read_city(prefecture_name: &str, input: &str, expected: &str) {
-        let api = BlockingApiImpl::new();
+        let api = BlockingApi::new();
         let prefecture = api.get_prefecture_master(prefecture_name).unwrap();
         let (_, city_name) = read_city(input, prefecture).unwrap();
         assert_eq!(city_name, expected);

--- a/core/src/parser/read_city.rs
+++ b/core/src/parser/read_city.rs
@@ -42,7 +42,7 @@ pub fn read_city(input: &str, prefecture: Prefecture) -> Option<(String, String)
     None
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, feature = "blocking"))]
 mod tests {
     use crate::api::BlockingApi;
     use crate::parser::read_city::read_city;

--- a/core/src/parser/read_town.rs
+++ b/core/src/parser/read_town.rs
@@ -56,7 +56,7 @@ fn find_town(input: &String, city: &City) -> Option<(String, String)> {
     None
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, feature = "blocking"))]
 mod tests {
     use crate::api::BlockingApi;
     use crate::entity::{City, Town};

--- a/core/src/parser/read_town.rs
+++ b/core/src/parser/read_town.rs
@@ -58,7 +58,7 @@ fn find_town(input: &String, city: &City) -> Option<(String, String)> {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::api::{BlockingApi, BlockingApiImpl};
+    use crate::api::BlockingApi;
     use crate::entity::{City, Town};
     use crate::parser::read_town::read_town;
 
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn read_town_丁目が算用数字の場合_京都府京都市東山区n丁目() {
-        let client = BlockingApiImpl::new();
+        let client = BlockingApi::new();
         let city = client.get_city_master("京都府", "京都市東山区").unwrap();
         let test_cases = vec![
             ("本町1丁目45番", "本町一丁目"),
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn read_town_大字の省略_東京都西多摩郡日の出町大字平井() {
-        let blocking_api = BlockingApiImpl::new();
+        let blocking_api = BlockingApi::new();
         let city = blocking_api
             .get_city_master("東京都", "西多摩郡日の出町")
             .unwrap();

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,5 +16,5 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-japanese-address-parser = { path = "../core" }
+japanese-address-parser = { path = "../core", features = ["blocking"] }
 pyo3 = { version = "0.21.0", features = ["abi3-py37"] }

--- a/python/README.md
+++ b/python/README.md
@@ -17,7 +17,7 @@ pip install japanese-address-parser-py
 ## Usage
 
 ```python
-import japanese_address_parser_py
+from japanese_address_parser_py import Parser
 
 address_list = [
     "埼玉県さいたま市浦和区高砂3-15-1",
@@ -25,8 +25,9 @@ address_list = [
     "東京都新宿区西新宿2-8-1",
     "神奈川県横浜市中区日本大通1"
 ]
+parser = Parser()
 for address in address_list:
-    parse_result = japanese_address_parser_py.parse(address)
+    parse_result = parser.parse(address)
     print(parse_result.address)
 ```
 
@@ -39,10 +40,11 @@ for address in address_list:
 
 
 ```python
-import japanese_address_parser_py
+from japanese_address_parser_py import Parser
 
+parser = Parser()
 address = "神奈川県横浜市中区本町6丁目50-10"
-parse_result = japanese_address_parser_py.parse(address)
+parse_result = parser.parse(address)
 print(parse_result.address["prefecture"])
 print(parse_result.address["city"])
 print(parse_result.address["town"])

--- a/python/japanese_address_parser_py.pyi
+++ b/python/japanese_address_parser_py.pyi
@@ -29,3 +29,24 @@ def parse(address: str) -> ParseResult:
     :param address: 住所
     :return: ParseResult
     """
+
+
+class Parser:
+    def __new__(cls) -> Parser:
+        """
+        Construct a parser.
+    
+        パーサーを生成します。
+
+        :return: JapaneseAddressParser
+        """
+
+    def parse(cls, address: str) -> ParseResult:
+        """
+        Format informal address into formal style
+
+        入力された住所を正式な表記に整形します。
+
+        :param address: 住所
+        :return: ParseResult
+        """

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,8 +1,9 @@
-use japanese_address_parser::api::BlockingApi;
-use japanese_address_parser::entity::ParseResult;
-use japanese_address_parser::parser::parse_blocking;
-use pyo3::prelude::*;
 use std::collections::HashMap;
+
+use pyo3::prelude::*;
+
+use japanese_address_parser::entity::ParseResult;
+use japanese_address_parser::parser::Parser;
 
 #[pyclass(name = "ParseResult")]
 struct PyParseResult {
@@ -28,16 +29,36 @@ impl From<ParseResult> for PyParseResult {
     }
 }
 
+#[pyclass(name = "Parser")]
+struct PyParser {
+    parser: Parser,
+}
+
+#[pymethods]
+impl PyParser {
+    #[new]
+    fn default() -> Self {
+        PyParser {
+            parser: Parser::new(),
+        }
+    }
+
+    fn parse(&self, address: &str) -> PyParseResult {
+        self.parser.parse_blocking(address).into()
+    }
+}
+
 #[pyfunction]
 fn parse(address: &str) -> PyParseResult {
-    let api = BlockingApi::new();
-    parse_blocking(api.into(), address).into()
+    let parser = Parser::new();
+    parser.parse_blocking(address).into()
 }
 
 #[pymodule]
 #[pyo3(name = "japanese_address_parser_py")]
 fn python_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyParseResult>()?;
+    m.add_class::<PyParser>()?;
     m.add_function(wrap_pyfunction!(parse, m)?)?;
     Ok(())
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,4 +1,4 @@
-use japanese_address_parser::api::{BlockingApi, BlockingApiImpl};
+use japanese_address_parser::api::BlockingApi;
 use japanese_address_parser::entity::ParseResult;
 use japanese_address_parser::parser::parse_blocking;
 use pyo3::prelude::*;
@@ -30,7 +30,7 @@ impl From<ParseResult> for PyParseResult {
 
 #[pyfunction]
 fn parse(address: &str) -> PyParseResult {
-    let api = BlockingApiImpl::new();
+    let api = BlockingApi::new();
     parse_blocking(api, address).into()
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -31,7 +31,7 @@ impl From<ParseResult> for PyParseResult {
 #[pyfunction]
 fn parse(address: &str) -> PyParseResult {
     let api = BlockingApi::new();
-    parse_blocking(api, address).into()
+    parse_blocking(api.into(), address).into()
 }
 
 #[pymodule]


### PR DESCRIPTION
### 変更点
- `BlockingApi`と`BlockingApiImpl`を整理し、`BlockingApi`に統合
- coreモジュールの`Parser`に`parse_blocking()`を追加
- pythonモジュールのコードをcoreモジュールの`Parser`を用いたコードに修正
- coreモジュールにフィーチャフラグ`blocking`を追加
