### PR TITLE
Defaultトレイトの実装: `AsyncApi::new()`・`BlockingApi::new()`を削除

### DIFF
--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -35,13 +35,6 @@ pub struct BlockingApi {
 
 #[cfg(feature = "blocking")]
 impl BlockingApi {
-    pub fn new() -> Self {
-        BlockingApi {
-            prefecture_master_api: Default::default(),
-            city_master_api: Default::default(),
-        }
-    }
-
     pub fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         self.prefecture_master_api.get_blocking(prefecture_name)
     }

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -27,6 +27,7 @@ impl AsyncApi {
 }
 
 #[cfg(feature = "blocking")]
+#[derive(Default)]
 pub struct BlockingApi {
     prefecture_master_api: PrefectureMasterApi,
     city_master_api: CityMasterApi,

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -6,6 +6,7 @@ use crate::api::prefecture_master_api::PrefectureMasterApi;
 use crate::entity::{City, Prefecture};
 use crate::err::Error;
 
+#[derive(Default)]
 pub struct AsyncApi {
     pub prefecture_master_api: PrefectureMasterApi,
     pub city_master_api: CityMasterApi,

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -13,13 +13,6 @@ pub struct AsyncApi {
 }
 
 impl AsyncApi {
-    pub fn new() -> Self {
-        AsyncApi {
-            prefecture_master_api: Default::default(),
-            city_master_api: Default::default(),
-        }
-    }
-
     pub async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         self.prefecture_master_api.get(prefecture_name).await
     }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -39,7 +39,7 @@ impl Parser {
     #[cfg(feature = "blocking")]
     pub fn new() -> Self {
         Parser {
-            async_api: Arc::new(AsyncApi::new()),
+            async_api: Arc::new(Default::default()),
             blocking_api: Arc::new(BlockingApi::new()),
         }
     }
@@ -48,7 +48,7 @@ impl Parser {
     #[cfg(not(feature = "blocking"))]
     pub fn new() -> Self {
         Parser {
-            async_api: Arc::new(AsyncApi::new()),
+            async_api: Arc::new(Default::default()),
         }
     }
 
@@ -133,7 +133,7 @@ mod tests {
 
     #[tokio::test]
     async fn 都道府県名が誤っている場合() {
-        let api = AsyncApi::new();
+        let api: AsyncApi = Default::default();
         let result = parse(api.into(), "青盛県青森市長島１丁目１−１").await;
         assert_eq!(result.address.prefecture, "");
         assert_eq!(result.address.city, "");
@@ -148,7 +148,7 @@ mod tests {
 
     #[tokio::test]
     async fn 都道府県マスタが取得できない場合() {
-        let mut api = AsyncApi::new();
+        let mut api: AsyncApi = Default::default();
         api.prefecture_master_api = PrefectureMasterApi {
             server_url: "https://example.com/invalid_url/api/",
         };
@@ -163,7 +163,7 @@ mod tests {
 
     #[tokio::test]
     async fn 市区町村名が誤っている場合() {
-        let api = AsyncApi::new();
+        let api: AsyncApi = Default::default();
         let result = parse(api.into(), "青森県青盛市長島１丁目１−１").await;
         assert_eq!(result.address.prefecture, "青森県");
         assert_eq!(result.address.city, "");
@@ -178,7 +178,7 @@ mod tests {
 
     #[tokio::test]
     async fn 市区町村マスタが取得できない場合() {
-        let mut api = AsyncApi::new();
+        let mut api: AsyncApi = Default::default();
         api.city_master_api = CityMasterApi {
             server_url: "https://example.com/invalid_url/api/",
         };
@@ -193,7 +193,7 @@ mod tests {
 
     #[tokio::test]
     async fn 町名が誤っている場合() {
-        let api = AsyncApi::new();
+        let api: AsyncApi = Default::default();
         let result = parse(api.into(), "青森県青森市永嶋１丁目１−１").await;
         assert_eq!(result.address.prefecture, "青森県");
         assert_eq!(result.address.city, "青森市");
@@ -210,7 +210,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn parse_wasm_success() {
-        let api = AsyncApi::new();
+        let api: AsyncApi = Default::default();
         let result = parse(api.into(), "兵庫県淡路市生穂新島8番地").await;
         assert_eq!(result.address.prefecture, "兵庫県".to_string());
         assert_eq!(result.address.city, "淡路市".to_string());

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -40,7 +40,7 @@ impl Parser {
     pub fn new() -> Self {
         Parser {
             async_api: Arc::new(Default::default()),
-            blocking_api: Arc::new(BlockingApi::new()),
+            blocking_api: Arc::new(Default::default()),
         }
     }
 
@@ -285,7 +285,7 @@ mod blocking_tests {
 
     #[test]
     fn parse_blocking_success_埼玉県秩父市熊木町8番15号() {
-        let client = BlockingApi::new();
+        let client: BlockingApi = Default::default();
         let result = parse_blocking(client.into(), "埼玉県秩父市熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "秩父市");
@@ -296,7 +296,7 @@ mod blocking_tests {
 
     #[test]
     fn parse_blocking_fail_市町村名が間違っている場合() {
-        let client = BlockingApi::new();
+        let client: BlockingApi = Default::default();
         let result = parse_blocking(client.into(), "埼玉県秩父柿熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "");

--- a/core/src/parser/read_city.rs
+++ b/core/src/parser/read_city.rs
@@ -62,7 +62,7 @@ mod tests {
     #[test_case("群馬県", "みなかみ町後閑318", "利根郡みなかみ町"; "success_利根郡みなかみ町_郡名が省略されている")]
     #[test_case("埼玉県", "東秩父村大字御堂634番地", "秩父郡東秩父村"; "success_秩父郡東秩父村_郡名が省略されている")]
     fn test_read_city(prefecture_name: &str, input: &str, expected: &str) {
-        let api = BlockingApi::new();
+        let api: BlockingApi = Default::default();
         let prefecture = api.get_prefecture_master(prefecture_name).unwrap();
         let (_, city_name) = read_city(input, prefecture).unwrap();
         assert_eq!(city_name, expected);

--- a/core/src/parser/read_town.rs
+++ b/core/src/parser/read_town.rs
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn read_town_丁目が算用数字の場合_京都府京都市東山区n丁目() {
-        let client = BlockingApi::new();
+        let client: BlockingApi = Default::default();
         let city = client.get_city_master("京都府", "京都市東山区").unwrap();
         let test_cases = vec![
             ("本町1丁目45番", "本町一丁目"),
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn read_town_大字の省略_東京都西多摩郡日の出町大字平井() {
-        let blocking_api = BlockingApi::new();
+        let blocking_api: BlockingApi = Default::default();
         let city = blocking_api
             .get_city_master("東京都", "西多摩郡日の出町")
             .unwrap();

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -42,7 +42,7 @@ impl Parser {
         #[cfg(feature = "debug")]
         console_error_panic_hook::set_once();
         Parser {
-            async_api: Arc::new(AsyncApi::new()),
+            async_api: Arc::new(Default::default()),
         }
     }
 


### PR DESCRIPTION
### 変更点
-  `AsyncApi::new()`・`BlockingApi::new()`の使用箇所を`Default::default()`に置き換え
-  `AsyncApi::new()`・`BlockingApi::new()`を削除