### PR TITLE
Defaultトレイトの実装: `Parser::new()`を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ use japanese_address_parser::parser::Parser;
 
 #[tokio::main]
 async fn main() {
-    let parser = Parser::new();
+    let parser: Parser = Default::default();
     let parse_result = parser.parse("東京都千代田区丸の内1-1-1").await;
     println!("{:?}", parse_result);
 }
@@ -36,7 +36,7 @@ async fn main() {
 use japanese_address_parser::parser::Parser;
 
 fn main() {
-    let parser = Parser::new();
+    let parser: Parser = Default::default();
     let parse_result = parser.parse_blocking("東京都千代田区丸の内1-1-1"); // `parse_blocking()` is available on `blocking` feature only
     println!("{:?}", parse_result);
 }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -34,6 +34,24 @@ pub struct Parser {
     blocking_api: Arc<BlockingApi>,
 }
 
+impl Default for Parser {
+    /// Constructs a new `Parser`.
+    #[cfg(feature = "blocking")]
+    fn default() -> Self {
+        Self {
+            async_api: Arc::new(Default::default()),
+            blocking_api: Arc::new(Default::default()),
+        }
+    }
+    /// Constructs a new `Parser`.
+    #[cfg(not(feature = "blocking"))]
+    fn default() -> Self {
+        Self {
+            async_api: Arc::new(Default::default()),
+        }
+    }
+}
+
 impl Parser {
     /// Constructs a new `Parser`.
     #[cfg(feature = "blocking")]

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -53,23 +53,6 @@ impl Default for Parser {
 }
 
 impl Parser {
-    /// Constructs a new `Parser`.
-    #[cfg(feature = "blocking")]
-    pub fn new() -> Self {
-        Parser {
-            async_api: Arc::new(Default::default()),
-            blocking_api: Arc::new(Default::default()),
-        }
-    }
-
-    /// Constructs a new `Parser`.
-    #[cfg(not(feature = "blocking"))]
-    pub fn new() -> Self {
-        Parser {
-            async_api: Arc::new(Default::default()),
-        }
-    }
-
     /// Parses the given `address` asynchronously.
     pub async fn parse(&self, address: &str) -> ParseResult {
         parse(self.async_api.clone(), address).await

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -23,7 +23,7 @@ mod read_town;
 /// use japanese_address_parser::parser::Parser;
 ///
 /// async fn example() {
-///     let parser = Parser::new();
+///     let parser : Parser = Default::default();
 ///     let result = parser.parse("東京都新宿区西新宿2-8-1").await;
 ///     println!("{:?}", result);
 /// }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -39,7 +39,7 @@ impl PyParser {
     #[new]
     fn default() -> Self {
         PyParser {
-            parser: Parser::new(),
+            parser: Default::default(),
         }
     }
 
@@ -50,7 +50,7 @@ impl PyParser {
 
 #[pyfunction]
 fn parse(address: &str) -> PyParseResult {
-    let parser = Parser::new();
+    let parser: Parser = Default::default();
     parser.parse_blocking(address).into()
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -27,7 +27,7 @@ fn read_test_data_from_csv(file_path: &str) -> Result<Vec<Record>, &str> {
 pub async fn run_data_driven_tests(file_path: &str) {
     let records = read_test_data_from_csv(file_path).unwrap();
     let mut success_count = 0;
-    let parser = Parser::new();
+    let parser: Parser = Default::default();
     for record in &records {
         let result = parser.parse(&record.address).await;
 


### PR DESCRIPTION
### 変更点
- `Parser`に対して`Default`トレイトを実装
- `Parser::new()`を削除