### PR TITLE
Defaultトレイトの実装: wasmモジュールの`Parser`に`cargo clippy`の警告を抑制するアトリュートを追加

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -35,6 +35,7 @@ pub struct Parser {
     async_api: Arc<AsyncApi>,
 }
 
+#[warn(clippy::new_without_default)]
 #[wasm_bindgen]
 impl Parser {
     #[wasm_bindgen(constructor)]


### PR DESCRIPTION
### 変更点
- wasmモジュールの`Parser`に`cargo clippy`の警告を抑制するアトリュートを追加
  - 警告を解消する手段がないため、警告を抑制する設定を追加した

