### PR TITLE
clippyの警告対応をrelease/v0.1.0-beta.18にマージ

### DIFF
--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -7,7 +7,7 @@ use nom::sequence::tuple;
 pub struct VagueExpressionAdapter;
 
 impl VagueExpressionAdapter {
-    pub fn apply(self, input: &str, region_name_list: &Vec<String>) -> Option<(String, String)> {
+    pub fn apply(self, input: &str, region_name_list: &[String]) -> Option<(String, String)> {
         if let Ok(highest_match) =
             SequenceMatcher::get_most_similar_match(input, region_name_list, None)
         {


### PR DESCRIPTION
### 変更点
- `VagueExpressionAdapter`に`cargo clippy`の警告が出ていたので修正