### PR TITLE
Defaultトレイトの実装をrelease/v0.1.0-beta.18にマージ

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ use japanese_address_parser::parser::Parser;
 
 #[tokio::main]
 async fn main() {
-    let parser = Parser::new();
+    let parser: Parser = Default::default();
     let parse_result = parser.parse("東京都千代田区丸の内1-1-1").await;
     println!("{:?}", parse_result);
 }
@@ -36,7 +36,7 @@ async fn main() {
 use japanese_address_parser::parser::Parser;
 
 fn main() {
-    let parser = Parser::new();
+    let parser: Parser = Default::default();
     let parse_result = parser.parse_blocking("東京都千代田区丸の内1-1-1"); // `parse_blocking()` is available on `blocking` feature only
     println!("{:?}", parse_result);
 }

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -14,13 +14,8 @@ pub struct AsyncApi {
 impl AsyncApi {
     pub fn new() -> Self {
         AsyncApi {
-            prefecture_master_api: PrefectureMasterApi {
-                server_url:
-                    "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
-            },
-            city_master_api: CityMasterApi {
-                server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
-            },
+            prefecture_master_api: Default::default(),
+            city_master_api: Default::default(),
         }
     }
 
@@ -47,13 +42,8 @@ pub struct BlockingApi {
 impl BlockingApi {
     pub fn new() -> Self {
         BlockingApi {
-            prefecture_master_api: PrefectureMasterApi {
-                server_url:
-                    "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
-            },
-            city_master_api: CityMasterApi {
-                server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
-            },
+            prefecture_master_api: Default::default(),
+            city_master_api: Default::default(),
         }
     }
 

--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -6,19 +6,13 @@ use crate::api::prefecture_master_api::PrefectureMasterApi;
 use crate::entity::{City, Prefecture};
 use crate::err::Error;
 
+#[derive(Default)]
 pub struct AsyncApi {
     pub prefecture_master_api: PrefectureMasterApi,
     pub city_master_api: CityMasterApi,
 }
 
 impl AsyncApi {
-    pub fn new() -> Self {
-        AsyncApi {
-            prefecture_master_api: Default::default(),
-            city_master_api: Default::default(),
-        }
-    }
-
     pub async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         self.prefecture_master_api.get(prefecture_name).await
     }
@@ -33,6 +27,7 @@ impl AsyncApi {
 }
 
 #[cfg(feature = "blocking")]
+#[derive(Default)]
 pub struct BlockingApi {
     prefecture_master_api: PrefectureMasterApi,
     city_master_api: CityMasterApi,
@@ -40,13 +35,6 @@ pub struct BlockingApi {
 
 #[cfg(feature = "blocking")]
 impl BlockingApi {
-    pub fn new() -> Self {
-        BlockingApi {
-            prefecture_master_api: Default::default(),
-            city_master_api: Default::default(),
-        }
-    }
-
     pub fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         self.prefecture_master_api.get_blocking(prefecture_name)
     }

--- a/core/src/api/city_master_api.rs
+++ b/core/src/api/city_master_api.rs
@@ -5,6 +5,14 @@ pub struct CityMasterApi {
     pub server_url: &'static str,
 }
 
+impl Default for CityMasterApi {
+    fn default() -> Self {
+        Self {
+            server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
+        }
+    }
+}
+
 impl CityMasterApi {
     pub async fn get(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
         let endpoint = format!("{}/{}/{}.json", self.server_url, prefecture_name, city_name);
@@ -52,9 +60,7 @@ mod tests {
 
     #[tokio::test]
     async fn 非同期_石川県羽咋郡志賀町_成功() {
-        let city_master_api = CityMasterApi {
-            server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
-        };
+        let city_master_api: CityMasterApi = Default::default();
         let result = city_master_api.get("石川県", "羽咋郡志賀町").await;
         let city = result.unwrap();
         assert_eq!(city.name, "羽咋郡志賀町");
@@ -69,9 +75,7 @@ mod tests {
 
     #[tokio::test]
     async fn 非同期_誤った市区町村名_失敗() {
-        let city_master_api = CityMasterApi {
-            server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
-        };
+        let city_master_api: CityMasterApi = Default::default();
         let result = city_master_api.get("石川県", "敦賀市").await;
         assert!(result.is_err());
         assert_eq!(
@@ -91,9 +95,7 @@ mod blocking_tests {
 
     #[test]
     fn 同期_石川県羽咋郡志賀町_成功() {
-        let city_master_api = CityMasterApi {
-            server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
-        };
+        let city_master_api: CityMasterApi = Default::default();
         let result = city_master_api.get_blocking("石川県", "羽咋郡志賀町");
         let city = result.unwrap();
         assert_eq!(city.name, "羽咋郡志賀町");
@@ -108,9 +110,7 @@ mod blocking_tests {
 
     #[test]
     fn 同期_誤った市区町村名_失敗() {
-        let city_master_api = CityMasterApi {
-            server_url: "https://geolonia.github.io/japanese-addresses/api/ja",
-        };
+        let city_master_api: CityMasterApi = Default::default();
         let result = city_master_api.get_blocking("石川県", "敦賀市");
         assert!(result.is_err());
         assert_eq!(

--- a/core/src/api/prefecture_master_api.rs
+++ b/core/src/api/prefecture_master_api.rs
@@ -5,6 +5,14 @@ pub struct PrefectureMasterApi {
     pub server_url: &'static str,
 }
 
+impl Default for PrefectureMasterApi {
+    fn default() -> Self {
+        Self {
+            server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
+        }
+    }
+}
+
 impl PrefectureMasterApi {
     pub async fn get(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         let endpoint = format!("{}/{}/master.json", self.server_url, prefecture_name);
@@ -45,9 +53,7 @@ mod tests {
 
     #[tokio::test]
     async fn 非同期_富山県_成功() {
-        let prefecture_master_api = PrefectureMasterApi {
-            server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
-        };
+        let prefecture_master_api: PrefectureMasterApi = Default::default();
         let result = prefecture_master_api.get("富山県").await;
         let prefecture = result.unwrap();
         assert_eq!(prefecture.name, "富山県");
@@ -75,9 +81,7 @@ mod tests {
 
     #[tokio::test]
     async fn 非同期_誤った都道府県名_失敗() {
-        let prefecture_master_api = PrefectureMasterApi {
-            server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
-        };
+        let prefecture_master_api: PrefectureMasterApi = Default::default();
         let result = prefecture_master_api.get("大阪都").await;
         assert!(result.is_err());
         assert_eq!(
@@ -96,9 +100,7 @@ mod blocking_tests {
 
     #[test]
     fn 同期_富山県_成功() {
-        let prefecture_master_api = PrefectureMasterApi {
-            server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
-        };
+        let prefecture_master_api: PrefectureMasterApi = Default::default();
         let result = prefecture_master_api.get_blocking("富山県");
         let prefecture = result.unwrap();
         assert_eq!(prefecture.name, "富山県");
@@ -126,9 +128,7 @@ mod blocking_tests {
 
     #[test]
     fn 同期_誤った都道府県名_失敗() {
-        let prefecture_master_api = PrefectureMasterApi {
-            server_url: "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist",
-        };
+        let prefecture_master_api: PrefectureMasterApi = Default::default();
         let result = prefecture_master_api.get_blocking("大阪都");
         assert!(result.is_err());
         assert_eq!(

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -23,7 +23,7 @@ mod read_town;
 /// use japanese_address_parser::parser::Parser;
 ///
 /// async fn example() {
-///     let parser = Parser::new();
+///     let parser : Parser = Default::default();
 ///     let result = parser.parse("東京都新宿区西新宿2-8-1").await;
 ///     println!("{:?}", result);
 /// }
@@ -34,24 +34,25 @@ pub struct Parser {
     blocking_api: Arc<BlockingApi>,
 }
 
-impl Parser {
+impl Default for Parser {
     /// Constructs a new `Parser`.
     #[cfg(feature = "blocking")]
-    pub fn new() -> Self {
-        Parser {
+    fn default() -> Self {
+        Self {
             async_api: Arc::new(Default::default()),
             blocking_api: Arc::new(Default::default()),
         }
     }
-
     /// Constructs a new `Parser`.
     #[cfg(not(feature = "blocking"))]
-    pub fn new() -> Self {
-        Parser {
+    fn default() -> Self {
+        Self {
             async_api: Arc::new(Default::default()),
         }
     }
+}
 
+impl Parser {
     /// Parses the given `address` asynchronously.
     pub async fn parse(&self, address: &str) -> ParseResult {
         parse(self.async_api.clone(), address).await

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -39,8 +39,8 @@ impl Parser {
     #[cfg(feature = "blocking")]
     pub fn new() -> Self {
         Parser {
-            async_api: Arc::new(AsyncApi::new()),
-            blocking_api: Arc::new(BlockingApi::new()),
+            async_api: Arc::new(Default::default()),
+            blocking_api: Arc::new(Default::default()),
         }
     }
 
@@ -48,7 +48,7 @@ impl Parser {
     #[cfg(not(feature = "blocking"))]
     pub fn new() -> Self {
         Parser {
-            async_api: Arc::new(AsyncApi::new()),
+            async_api: Arc::new(Default::default()),
         }
     }
 
@@ -133,7 +133,7 @@ mod tests {
 
     #[tokio::test]
     async fn 都道府県名が誤っている場合() {
-        let api = AsyncApi::new();
+        let api: AsyncApi = Default::default();
         let result = parse(api.into(), "青盛県青森市長島１丁目１−１").await;
         assert_eq!(result.address.prefecture, "");
         assert_eq!(result.address.city, "");
@@ -148,7 +148,7 @@ mod tests {
 
     #[tokio::test]
     async fn 都道府県マスタが取得できない場合() {
-        let mut api = AsyncApi::new();
+        let mut api: AsyncApi = Default::default();
         api.prefecture_master_api = PrefectureMasterApi {
             server_url: "https://example.com/invalid_url/api/",
         };
@@ -163,7 +163,7 @@ mod tests {
 
     #[tokio::test]
     async fn 市区町村名が誤っている場合() {
-        let api = AsyncApi::new();
+        let api: AsyncApi = Default::default();
         let result = parse(api.into(), "青森県青盛市長島１丁目１−１").await;
         assert_eq!(result.address.prefecture, "青森県");
         assert_eq!(result.address.city, "");
@@ -178,7 +178,7 @@ mod tests {
 
     #[tokio::test]
     async fn 市区町村マスタが取得できない場合() {
-        let mut api = AsyncApi::new();
+        let mut api: AsyncApi = Default::default();
         api.city_master_api = CityMasterApi {
             server_url: "https://example.com/invalid_url/api/",
         };
@@ -193,7 +193,7 @@ mod tests {
 
     #[tokio::test]
     async fn 町名が誤っている場合() {
-        let api = AsyncApi::new();
+        let api: AsyncApi = Default::default();
         let result = parse(api.into(), "青森県青森市永嶋１丁目１−１").await;
         assert_eq!(result.address.prefecture, "青森県");
         assert_eq!(result.address.city, "青森市");
@@ -210,7 +210,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn parse_wasm_success() {
-        let api = AsyncApi::new();
+        let api: AsyncApi = Default::default();
         let result = parse(api.into(), "兵庫県淡路市生穂新島8番地").await;
         assert_eq!(result.address.prefecture, "兵庫県".to_string());
         assert_eq!(result.address.city, "淡路市".to_string());
@@ -285,7 +285,7 @@ mod blocking_tests {
 
     #[test]
     fn parse_blocking_success_埼玉県秩父市熊木町8番15号() {
-        let client = BlockingApi::new();
+        let client: BlockingApi = Default::default();
         let result = parse_blocking(client.into(), "埼玉県秩父市熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "秩父市");
@@ -296,7 +296,7 @@ mod blocking_tests {
 
     #[test]
     fn parse_blocking_fail_市町村名が間違っている場合() {
-        let client = BlockingApi::new();
+        let client: BlockingApi = Default::default();
         let result = parse_blocking(client.into(), "埼玉県秩父柿熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "");

--- a/core/src/parser/read_city.rs
+++ b/core/src/parser/read_city.rs
@@ -62,7 +62,7 @@ mod tests {
     #[test_case("群馬県", "みなかみ町後閑318", "利根郡みなかみ町"; "success_利根郡みなかみ町_郡名が省略されている")]
     #[test_case("埼玉県", "東秩父村大字御堂634番地", "秩父郡東秩父村"; "success_秩父郡東秩父村_郡名が省略されている")]
     fn test_read_city(prefecture_name: &str, input: &str, expected: &str) {
-        let api = BlockingApi::new();
+        let api: BlockingApi = Default::default();
         let prefecture = api.get_prefecture_master(prefecture_name).unwrap();
         let (_, city_name) = read_city(input, prefecture).unwrap();
         assert_eq!(city_name, expected);

--- a/core/src/parser/read_town.rs
+++ b/core/src/parser/read_town.rs
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn read_town_丁目が算用数字の場合_京都府京都市東山区n丁目() {
-        let client = BlockingApi::new();
+        let client: BlockingApi = Default::default();
         let city = client.get_city_master("京都府", "京都市東山区").unwrap();
         let test_cases = vec![
             ("本町1丁目45番", "本町一丁目"),
@@ -171,7 +171,7 @@ mod tests {
 
     #[test]
     fn read_town_大字の省略_東京都西多摩郡日の出町大字平井() {
-        let blocking_api = BlockingApi::new();
+        let blocking_api: BlockingApi = Default::default();
         let city = blocking_api
             .get_city_master("東京都", "西多摩郡日の出町")
             .unwrap();

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -39,7 +39,7 @@ impl PyParser {
     #[new]
     fn default() -> Self {
         PyParser {
-            parser: Parser::new(),
+            parser: Default::default(),
         }
     }
 
@@ -50,7 +50,7 @@ impl PyParser {
 
 #[pyfunction]
 fn parse(address: &str) -> PyParseResult {
-    let parser = Parser::new();
+    let parser: Parser = Default::default();
     parser.parse_blocking(address).into()
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -27,7 +27,7 @@ fn read_test_data_from_csv(file_path: &str) -> Result<Vec<Record>, &str> {
 pub async fn run_data_driven_tests(file_path: &str) {
     let records = read_test_data_from_csv(file_path).unwrap();
     let mut success_count = 0;
-    let parser = Parser::new();
+    let parser: Parser = Default::default();
     for record in &records {
         let result = parser.parse(&record.address).await;
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -35,6 +35,7 @@ pub struct Parser {
     async_api: Arc<AsyncApi>,
 }
 
+#[warn(clippy::new_without_default)]
 #[wasm_bindgen]
 impl Parser {
     #[wasm_bindgen(constructor)]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -42,7 +42,7 @@ impl Parser {
         #[cfg(feature = "debug")]
         console_error_panic_hook::set_once();
         Parser {
-            async_api: Arc::new(AsyncApi::new()),
+            async_api: Arc::new(Default::default()),
         }
     }
 


### PR DESCRIPTION
### 変更点
- 構造体の初期化のために`new()`メソッドを定義し用いてきたが、代わりに`Default`トレイトを実装し`default()`メソッドを使用するように修正した。