### PR TITLE
郡名と町名が一致している場合: 既存のテストコードのリファクタリング

### DIFF
--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -31,8 +31,9 @@ mod tests {
 
     #[test]
     fn 郡名が省略されている場合_吉田郡永平寺町() {
+        let hukui = Prefecture::hukui();
         let (rest, city_name) = VagueExpressionAdapter {}
-            .apply("永平寺町志比５－５", &provide_city_name_list())
+            .apply("永平寺町志比５－５", &hukui.cities)
             .unwrap();
         assert_eq!(rest, "志比５－５");
         assert_eq!(city_name, "吉田郡永平寺町");
@@ -40,8 +41,9 @@ mod tests {
 
     #[test]
     fn 郡名が省略されている場合_今立郡池田町() {
+        let hukui = Prefecture::hukui();
         let (rest, city_name) = VagueExpressionAdapter {}
-            .apply("池田町稲荷２８－７", &provide_city_name_list())
+            .apply("池田町稲荷２８－７", &hukui.cities)
             .unwrap();
         assert_eq!(rest, "稲荷２８－７");
         assert_eq!(city_name, "今立郡池田町");
@@ -49,33 +51,12 @@ mod tests {
 
     #[test]
     fn 郡名が省略されている場合_南条郡南越前町() {
+        let hukui = Prefecture::hukui();
         let (rest, city_name) = VagueExpressionAdapter {}
-            .apply("南越前町今庄７４－７－１", &provide_city_name_list())
+            .apply("南越前町今庄７４－７－１", &hukui.cities)
             .unwrap();
         assert_eq!(rest, "今庄７４－７－１");
         assert_eq!(city_name, "南条郡南越前町");
-    }
-
-    fn provide_city_name_list() -> Vec<String> {
-        vec![
-            "福井市".to_string(),
-            "敦賀市".to_string(),
-            "小浜市".to_string(),
-            "大野市".to_string(),
-            "勝山市".to_string(),
-            "鯖江市".to_string(),
-            "あわら市".to_string(),
-            "越前市".to_string(),
-            "坂井市".to_string(),
-            "吉田郡永平寺町".to_string(),
-            "今立郡池田町".to_string(),
-            "南条郡南越前町".to_string(),
-            "丹生郡越前町".to_string(),
-            "三方郡美浜町".to_string(),
-            "大飯郡高浜町".to_string(),
-            "大飯郡おおい町".to_string(),
-            "三方上中郡若狭町".to_string(),
-        ]
     }
 
     impl Prefecture {

--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -26,6 +26,7 @@ impl VagueExpressionAdapter {
 
 #[cfg(test)]
 mod tests {
+    use crate::entity::Prefecture;
     use crate::parser::adapter::vague_expression_adapter::VagueExpressionAdapter;
 
     #[test]
@@ -75,5 +76,32 @@ mod tests {
             "大飯郡おおい町".to_string(),
             "三方上中郡若狭町".to_string(),
         ]
+    }
+
+    impl Prefecture {
+        fn hukui() -> Self {
+            Prefecture {
+                name: "福井県".to_string(),
+                cities: vec![
+                    "福井市".to_string(),
+                    "敦賀市".to_string(),
+                    "小浜市".to_string(),
+                    "大野市".to_string(),
+                    "勝山市".to_string(),
+                    "鯖江市".to_string(),
+                    "あわら市".to_string(),
+                    "越前市".to_string(),
+                    "坂井市".to_string(),
+                    "吉田郡永平寺町".to_string(),
+                    "今立郡池田町".to_string(),
+                    "南条郡南越前町".to_string(),
+                    "丹生郡越前町".to_string(),
+                    "三方郡美浜町".to_string(),
+                    "大飯郡高浜町".to_string(),
+                    "大飯郡おおい町".to_string(),
+                    "三方上中郡若狭町".to_string(),
+                ],
+            }
+        }
     }
 }


### PR DESCRIPTION
### 変更点
- `provide_city_name_list()`という名前のヘルパー関数で市町村名のリストを生成してテストコードに渡していたが、他の都道府県のケースを追加したい時にこのままだと不便なため、リファクタリング。

### 確認すべき項目
- [x] `cargo fmt`
- [x] `cargo test`

### 備考
- #268 
