### PR TITLE
PR作成時にデモページをCloudflareにデプロイ: デモページをビルドするシェルスクリプトを作成

### DIFF
--- a/.github/scripts/build_demo_page.sh
+++ b/.github/scripts/build_demo_page.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+npm install -g wasm-pack
+cd wasm
+wasm-pack build --target web --scope toriyama --out-name japanese_address_parser --features debug
+cd ../
+mkdir dist
+rm wasm/pkg/.gitignore
+mv wasm/pkg dist
+mv public dist


### PR DESCRIPTION
### 変更点
- CloudflarePagesと連携し、PR作成時にデモページをデプロイするようにした

### 確認すべき項目
- [ ] `cargo fmt`
- [ ] `cargo test`

### 備考
- 
