### PR TITLE
ライブラリの更新をrelease/0.1.4にマージ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ keywords = ["parser", "geo", "wasm"]
 categories = ["parser-implementations", "wasm"]
 
 [workspace.dependencies]
-wasm-bindgen = "0.2.89"
-wasm-bindgen-futures = "0.4.39"
-wasm-bindgen-test = "0.3.38"
+wasm-bindgen = "0.2.92"
+wasm-bindgen-futures = "0.4.42"
+wasm-bindgen-test = "0.3.42"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,7 +19,7 @@ default = []
 blocking = []
 
 [dependencies]
-itertools = "0.12.0"
+itertools = "0.13.0"
 js-sys = "0.3.67"
 nom = "7.1.3"
 rapidfuzz = "0.5.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -29,5 +29,5 @@ serde = { version = "1.0.192", features = ["derive"] }
 
 [dev-dependencies]
 test-case = "3.3.1"
-tokio = { version = "1.37.0", features = ["rt", "macros"] }
+tokio = { version = "1.38.0", features = ["rt", "macros"] }
 wasm-bindgen-test = { workspace = true }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -17,4 +17,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 japanese-address-parser = { path = "../core", features = ["blocking"] }
-pyo3 = { version = "0.21.0", features = ["abi3-py37"] }
+pyo3 = { version = "0.22.0", features = ["abi3-py37"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,4 +13,4 @@ path = "integration_tests.rs"
 csv = "1.3.0"
 japanese-address-parser = { path = "../core" }
 serde = { version = "1.0.197", features = ["derive"] }
-tokio = { version = "1.37.0", features = ["rt", "macros"] }
+tokio = { version = "1.38.0", features = ["rt", "macros"] }


### PR DESCRIPTION
### 変更点
- `itertools`, `tokio`, `pyo3`, `wasm-bindgen*`のバージョンを最新に更新
