### PR TITLE
chimei-ruiju.orgへの移行: `repository`クレートを作成

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ keywords = ["parser", "geo", "wasm"]
 categories = ["parser-implementations", "wasm"]
 
 [workspace.dependencies]
+serde = { version = "1.0.192", features = ["derive"] }
 wasm-bindgen = "0.2.92"
 wasm-bindgen-futures = "0.4.42"
 wasm-bindgen-test = "0.3.42"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "wasm",
     "python",
     "tests",
+    "repository",
 ]
 resolver = "2"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ nom = "7.1.3"
 rapidfuzz = "0.5.0"
 regex = "1.10.2"
 reqwest = { version = "0.12.3", default-features = false, features = ["json", "rustls-tls", "blocking"] }
-serde = { version = "1.0.192", features = ["derive"] }
+serde = { workspace = true }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -13,3 +13,4 @@ categories.workspace = true
 jisx0401 = "0.1.0-beta.2"
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { workspace = true }
+thiserror = "1.0.61"

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -10,3 +10,4 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+serde = { workspace = true }

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -10,5 +10,6 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+jisx0401 = "0.1.0-beta.2"
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { workspace = true }

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -14,3 +14,6 @@ jisx0401 = "0.1.0-beta.2"
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { workspace = true }
 thiserror = "1.0.61"
+
+[dev-dependencies]
+tokio = { version = "1.38.0", features = ["rt", "macros"] }

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "repository"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+authors.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -16,4 +16,5 @@ serde = { workspace = true }
 thiserror = "1.0.61"
 
 [dev-dependencies]
+mockito = "1.4.0"
 tokio = { version = "1.38.0", features = ["rt", "macros"] }

--- a/repository/Cargo.toml
+++ b/repository/Cargo.toml
@@ -10,4 +10,5 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls", "blocking"] }
 serde = { workspace = true }

--- a/repository/src/city.rs
+++ b/repository/src/city.rs
@@ -23,6 +23,38 @@ impl CityMasterRepository {
     }
 }
 
+#[cfg(test)]
+mod async_tests {
+    use jisx0401::Prefecture;
+
+    use crate::city::CityMasterRepository;
+    use crate::service::ChimeiRuijuApiService;
+
+    #[tokio::test]
+    async fn 神奈川県愛甲郡清川村() {
+        let repository = CityMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
+        let result = repository.get(&Prefecture::KANAGAWA, "愛甲郡清川村").await;
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "愛甲郡清川村");
+        assert_eq!(entity.towns, vec!["煤ヶ谷", "宮ヶ瀬"]);
+    }
+
+    #[tokio::test]
+    async fn 京都府乙訓郡大山崎町() {
+        let repository = CityMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
+        let result = repository.get(&Prefecture::KYOTO, "乙訓郡大山崎町").await;
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "乙訓郡大山崎町");
+        assert_eq!(entity.towns, vec!["字円明寺", "字大山崎", "字下植野"]);
+    }
+}
+
 impl CityMasterRepository {
     pub fn get_blocking(
         &self,
@@ -35,5 +67,74 @@ impl CityMasterRepository {
             city_name
         );
         self.api_service.get_blocking::<CityMaster>(&url)
+    }
+}
+
+#[cfg(test)]
+mod blocking_tests {
+    use jisx0401::Prefecture;
+
+    use crate::city::CityMasterRepository;
+    use crate::service::ChimeiRuijuApiService;
+
+    #[test]
+    fn 埼玉県比企郡嵐山町() {
+        let repository = CityMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
+        let result = repository.get_blocking(&Prefecture::SAITAMA, "比企郡嵐山町");
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "比企郡嵐山町");
+        assert_eq!(
+            entity.towns,
+            vec![
+                "むさし台一丁目",
+                "むさし台二丁目",
+                "むさし台三丁目",
+                "大字根岸",
+                "大字勝田",
+                "大字太郎丸",
+                "大字川島",
+                "花見台",
+                "大字遠山",
+                "大字大蔵",
+                "大字菅谷",
+                "大字千手堂",
+                "大字廣野",
+                "大字杉山",
+                "大字平澤",
+                "大字将軍澤",
+                "大字志賀",
+                "大字吉田",
+                "大字古里",
+                "大字越畑",
+                "大字鎌形"
+            ]
+        );
+    }
+
+    #[test]
+    fn 岐阜県不破郡関ケ原町() {
+        let repository = CityMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
+        let result = repository.get_blocking(&Prefecture::GIFU, "不破郡関ケ原町");
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "不破郡関ケ原町");
+        assert_eq!(
+            entity.towns,
+            vec![
+                "大字今須",
+                "大字大高",
+                "大字関ケ原",
+                "大字玉",
+                "大字藤下",
+                "大字野上",
+                "大字松尾",
+                "大字山中"
+            ]
+        );
     }
 }

--- a/repository/src/city.rs
+++ b/repository/src/city.rs
@@ -1,8 +1,12 @@
-use crate::entity::{CityMaster, PrefectureMaster};
-use crate::error::ApiError;
 use jisx0401::Prefecture;
 
-pub struct CityMasterRepository {}
+use crate::entity::CityMaster;
+use crate::error::ApiError;
+use crate::service::ChimeiRuijuApiService;
+
+pub struct CityMasterRepository {
+    api_service: ChimeiRuijuApiService,
+}
 
 impl CityMasterRepository {
     pub async fn get(
@@ -15,14 +19,7 @@ impl CityMasterRepository {
             prefecture.name_en(),
             city_name
         );
-        let response = reqwest::get(&url)
-            .await
-            .map_err(|error| ApiError::Network { url: url.clone() })?;
-        let json = response
-            .json::<CityMaster>()
-            .await
-            .map_err(|_| ApiError::Deserialize { url })?;
-        Ok(json)
+        self.api_service.get::<CityMaster>(&url).await
     }
 }
 
@@ -37,11 +34,6 @@ impl CityMasterRepository {
             prefecture.name_en(),
             city_name
         );
-        let response =
-            reqwest::blocking::get(&url).map_err(|error| ApiError::Network { url: url.clone() })?;
-        let json = response
-            .json::<CityMaster>()
-            .map_err(|_| ApiError::Deserialize { url })?;
-        Ok(json)
+        self.api_service.get_blocking::<CityMaster>(&url)
     }
 }

--- a/repository/src/city.rs
+++ b/repository/src/city.rs
@@ -1,0 +1,52 @@
+use crate::entity::{CityMaster, PrefectureMaster};
+use crate::error::ApiError;
+use jisx0401::Prefecture;
+
+pub struct CityMasterRepository {}
+
+impl CityMasterRepository {
+    pub async fn get(
+        &self,
+        prefecture: &Prefecture,
+        city_name: &str,
+    ) -> Result<CityMaster, ApiError> {
+        let url = format!(
+            "https://{}.chimei-ruiju.org/{}/master.json",
+            prefecture.name_en(),
+            city_name
+        );
+        let response = reqwest::get(&url)
+            .await
+            .map_err(|error| ApiError::Network {
+                url: url.clone(),
+                status_code: error.status().unwrap(),
+            })?;
+        let json = response
+            .json::<CityMaster>()
+            .await
+            .map_err(|_| ApiError::Deserialize { url })?;
+        Ok(json)
+    }
+}
+
+impl CityMasterRepository {
+    pub fn get_blocking(
+        &self,
+        prefecture: &Prefecture,
+        city_name: &str,
+    ) -> Result<CityMaster, ApiError> {
+        let url = format!(
+            "https://{}.chimei-ruiju.org/{}/master.json",
+            prefecture.name_en(),
+            city_name
+        );
+        let response = reqwest::blocking::get(&url).map_err(|error| ApiError::Network {
+            url: url.clone(),
+            status_code: error.status().unwrap(),
+        })?;
+        let json = response
+            .json::<CityMaster>()
+            .map_err(|_| ApiError::Deserialize { url })?;
+        Ok(json)
+    }
+}

--- a/repository/src/city.rs
+++ b/repository/src/city.rs
@@ -17,10 +17,7 @@ impl CityMasterRepository {
         );
         let response = reqwest::get(&url)
             .await
-            .map_err(|error| ApiError::Network {
-                url: url.clone(),
-                status_code: error.status().unwrap(),
-            })?;
+            .map_err(|error| ApiError::Network { url: url.clone() })?;
         let json = response
             .json::<CityMaster>()
             .await
@@ -40,10 +37,8 @@ impl CityMasterRepository {
             prefecture.name_en(),
             city_name
         );
-        let response = reqwest::blocking::get(&url).map_err(|error| ApiError::Network {
-            url: url.clone(),
-            status_code: error.status().unwrap(),
-        })?;
+        let response =
+            reqwest::blocking::get(&url).map_err(|error| ApiError::Network { url: url.clone() })?;
         let json = response
             .json::<CityMaster>()
             .map_err(|_| ApiError::Deserialize { url })?;

--- a/repository/src/entity.rs
+++ b/repository/src/entity.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct PrefectureMaster {
     /// 都道府県名
     pub name: String,
@@ -10,7 +10,7 @@ pub struct PrefectureMaster {
     pub coordinate: Coordinate,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct CityMaster {
     /// 市区町村名
     pub name: String,
@@ -20,7 +20,7 @@ pub struct CityMaster {
     pub coordinate: Coordinate,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct Coordinate {
     /// 緯度
     pub latitude: f64,

--- a/repository/src/entity.rs
+++ b/repository/src/entity.rs
@@ -21,6 +21,28 @@ pub struct CityMaster {
 }
 
 #[derive(Deserialize, Debug)]
+pub struct TownMaster {
+    /// 町名
+    pub name: String,
+    /// 街区リスト
+    pub blocks: Vec<Block>,
+    /// 緯度経度
+    pub coordinate: Coordinate,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Block {
+    /// 小字・通称名
+    pub koaza: String,
+    /// 街区符号・地番
+    pub block_number: String,
+    /// 住居表示の有無
+    pub residential_address_indication: bool,
+    /// 緯度経度
+    pub coordinate: Coordinate,
+}
+
+#[derive(Deserialize, Debug)]
 pub struct Coordinate {
     /// 緯度
     pub latitude: f64,

--- a/repository/src/entity.rs
+++ b/repository/src/entity.rs
@@ -11,6 +11,16 @@ pub struct PrefectureMaster {
 }
 
 #[derive(Deserialize)]
+pub struct CityMaster {
+    /// 市区町村名
+    pub name: String,
+    /// 町名リスト
+    pub towns: Vec<String>,
+    /// 緯度経度
+    pub coordinate: Coordinate,
+}
+
+#[derive(Deserialize)]
 pub struct Coordinate {
     /// 緯度
     pub latitude: f64,

--- a/repository/src/entity.rs
+++ b/repository/src/entity.rs
@@ -1,0 +1,19 @@
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct PrefectureMaster {
+    /// 都道府県名
+    pub name: String,
+    /// 市区町村名リスト
+    pub cities: Vec<String>,
+    /// 代表点の緯度経度
+    pub coordinate: Coordinate,
+}
+
+#[derive(Deserialize)]
+pub struct Coordinate {
+    /// 緯度
+    pub latitude: f64,
+    /// 経度
+    pub longitude: f64,
+}

--- a/repository/src/error.rs
+++ b/repository/src/error.rs
@@ -1,12 +1,11 @@
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, PartialEq, Debug)]
 pub enum ApiError {
-    #[error("cannot fetch resource of {url}. status_code: {status_code}")]
-    Network {
-        url: String,
-        status_code: StatusCode,
-    },
+    #[error("network error occurs: {url}")]
+    Network { url: String },
+    #[error("cannot fetch resource of {url}")]
+    NotFound { url: String },
     #[error("cannot deserialize response from {url}")]
     Deserialize { url: String },
 }

--- a/repository/src/error.rs
+++ b/repository/src/error.rs
@@ -1,0 +1,12 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ApiError {
+    #[error("cannot fetch resource of {url}. status_code: {status_code}")]
+    Network {
+        url: String,
+        status_code: StatusCode,
+    },
+    #[error("cannot deserialize response from {url}")]
+    Deserialize { url: String },
+}

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -3,3 +3,4 @@ mod entity;
 mod error;
 pub mod prefecture;
 mod service;
+pub mod town;

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -1,2 +1,3 @@
 mod entity;
+mod error;
 pub mod prefecture;

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -2,3 +2,4 @@ pub mod city;
 mod entity;
 mod error;
 pub mod prefecture;
+mod service;

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -1,0 +1,2 @@
+mod entity;
+pub mod prefecture;

--- a/repository/src/lib.rs
+++ b/repository/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod city;
 mod entity;
 mod error;
 pub mod prefecture;

--- a/repository/src/prefecture.rs
+++ b/repository/src/prefecture.rs
@@ -24,7 +24,7 @@ mod async_tests {
     use jisx0401::Prefecture;
 
     #[tokio::test]
-    async fn tokyo() {
+    async fn 東京都() {
         let repository = PrefectureMasterRepository {
             api_service: ChimeiRuijuApiService {},
         };
@@ -102,7 +102,7 @@ mod async_tests {
     }
 
     #[tokio::test]
-    async fn toyama() {
+    async fn 富山県() {
         let repository = PrefectureMasterRepository {
             api_service: ChimeiRuijuApiService {},
         };
@@ -150,7 +150,7 @@ mod blocking_tests {
     use jisx0401::Prefecture;
 
     #[tokio::test]
-    async fn kochi() {
+    async fn 高知県() {
         let repository = PrefectureMasterRepository {
             api_service: ChimeiRuijuApiService {},
         };
@@ -200,7 +200,7 @@ mod blocking_tests {
     }
 
     #[tokio::test]
-    async fn saga() {
+    async fn 佐賀県() {
         let repository = PrefectureMasterRepository {
             api_service: ChimeiRuijuApiService {},
         };

--- a/repository/src/prefecture.rs
+++ b/repository/src/prefecture.rs
@@ -1,28 +1,42 @@
 use crate::entity::PrefectureMaster;
+use crate::error::ApiError;
 use jisx0401::Prefecture;
 
 pub struct PrefectureMasterRepository {}
 
 impl PrefectureMasterRepository {
-    pub async fn get(&self, prefecture: Prefecture) -> PrefectureMaster {
+    pub async fn get(&self, prefecture: &Prefecture) -> Result<PrefectureMaster, ApiError> {
         let url = format!(
             "https://{}.chimei-ruiju.org/master.json",
             prefecture.name_en()
         );
-        let response = reqwest::get(&url).await?;
-        let json = response.json::<PrefectureMaster>().await?;
-        json
+        let response = reqwest::get(&url)
+            .await
+            .map_err(|error| ApiError::Network {
+                url: url.clone(),
+                status_code: error.status().unwrap(),
+            })?;
+        let json = response
+            .json::<PrefectureMaster>()
+            .await
+            .map_err(|_| ApiError::Deserialize { url })?;
+        Ok(json)
     }
 }
 
 impl PrefectureMasterRepository {
-    pub fn get_blocking(&self, prefecture: Prefecture) -> PrefectureMaster {
+    pub fn get_blocking(&self, prefecture: Prefecture) -> Result<PrefectureMaster, ApiError> {
         let url = format!(
             "https://{}.chimei-ruiju.org/master.json",
             prefecture.name_en()
         );
-        let response = reqwest::blocking::get(&url)?;
-        let json = response.json::<PrefectureMaster>()?;
-        json
+        let response = reqwest::blocking::get(&url).map_err(|error| ApiError::Network {
+            url: url.clone(),
+            status_code: error.status().unwrap(),
+        })?;
+        let json = response
+            .json::<PrefectureMaster>()
+            .map_err(|_| ApiError::Deserialize { url })?;
+        Ok(json)
     }
 }

--- a/repository/src/prefecture.rs
+++ b/repository/src/prefecture.rs
@@ -1,0 +1,28 @@
+use crate::entity::PrefectureMaster;
+use jisx0401::Prefecture;
+
+pub struct PrefectureMasterRepository {}
+
+impl PrefectureMasterRepository {
+    pub async fn get(&self, prefecture: Prefecture) -> PrefectureMaster {
+        let url = format!(
+            "https://{}.chimei-ruiju.org/master.json",
+            prefecture.name_en()
+        );
+        let response = reqwest::get(&url).await?;
+        let json = response.json::<PrefectureMaster>().await?;
+        json
+    }
+}
+
+impl PrefectureMasterRepository {
+    pub fn get_blocking(&self, prefecture: Prefecture) -> PrefectureMaster {
+        let url = format!(
+            "https://{}.chimei-ruiju.org/master.json",
+            prefecture.name_en()
+        );
+        let response = reqwest::blocking::get(&url)?;
+        let json = response.json::<PrefectureMaster>()?;
+        json
+    }
+}

--- a/repository/src/prefecture.rs
+++ b/repository/src/prefecture.rs
@@ -24,6 +24,117 @@ impl PrefectureMasterRepository {
     }
 }
 
+#[cfg(test)]
+mod async_tests {
+    use crate::prefecture::PrefectureMasterRepository;
+    use jisx0401::Prefecture;
+
+    #[tokio::test]
+    async fn tokyo() {
+        let repository = PrefectureMasterRepository {};
+        let result = repository.get(&Prefecture::TOKYO).await;
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "東京都");
+        assert_eq!(
+            entity.cities,
+            vec![
+                "千代田区",
+                "中央区",
+                "港区",
+                "新宿区",
+                "文京区",
+                "台東区",
+                "墨田区",
+                "江東区",
+                "品川区",
+                "目黒区",
+                "大田区",
+                "世田谷区",
+                "渋谷区",
+                "中野区",
+                "杉並区",
+                "豊島区",
+                "北区",
+                "荒川区",
+                "板橋区",
+                "練馬区",
+                "足立区",
+                "葛飾区",
+                "江戸川区",
+                "八王子市",
+                "立川市",
+                "武蔵野市",
+                "三鷹市",
+                "青梅市",
+                "府中市",
+                "昭島市",
+                "調布市",
+                "町田市",
+                "小金井市",
+                "小平市",
+                "日野市",
+                "東村山市",
+                "国分寺市",
+                "国立市",
+                "福生市",
+                "狛江市",
+                "東大和市",
+                "清瀬市",
+                "東久留米市",
+                "武蔵村山市",
+                "多摩市",
+                "稲城市",
+                "羽村市",
+                "あきる野市",
+                "西東京市",
+                "西多摩郡瑞穂町",
+                "西多摩郡日の出町",
+                "西多摩郡檜原村",
+                "西多摩郡奥多摩町",
+                "大島町",
+                "利島村",
+                "新島村",
+                "神津島村",
+                "三宅村",
+                "御蔵島村",
+                "八丈町",
+                "青ヶ島村",
+                "小笠原村",
+            ]
+        )
+    }
+
+    #[tokio::test]
+    async fn toyama() {
+        let repository = PrefectureMasterRepository {};
+        let result = repository.get(&Prefecture::TOYAMA).await;
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "富山県");
+        assert_eq!(
+            entity.cities,
+            vec![
+                "富山市",
+                "高岡市",
+                "魚津市",
+                "氷見市",
+                "滑川市",
+                "黒部市",
+                "砺波市",
+                "小矢部市",
+                "南砺市",
+                "射水市",
+                "中新川郡舟橋村",
+                "中新川郡上市町",
+                "中新川郡立山町",
+                "下新川郡入善町",
+                "下新川郡朝日町",
+            ]
+        );
+    }
+}
+
 impl PrefectureMasterRepository {
     pub fn get_blocking(&self, prefecture: Prefecture) -> Result<PrefectureMaster, ApiError> {
         let url = format!(

--- a/repository/src/prefecture.rs
+++ b/repository/src/prefecture.rs
@@ -1,8 +1,11 @@
 use crate::entity::PrefectureMaster;
 use crate::error::ApiError;
+use crate::service::ChimeiRuijuApiService;
 use jisx0401::Prefecture;
 
-pub struct PrefectureMasterRepository {}
+pub struct PrefectureMasterRepository {
+    api_service: ChimeiRuijuApiService,
+}
 
 impl PrefectureMasterRepository {
     pub async fn get(&self, prefecture: &Prefecture) -> Result<PrefectureMaster, ApiError> {
@@ -10,28 +13,21 @@ impl PrefectureMasterRepository {
             "https://{}.chimei-ruiju.org/master.json",
             prefecture.name_en()
         );
-        let response = reqwest::get(&url)
-            .await
-            .map_err(|error| ApiError::Network {
-                url: url.clone(),
-                status_code: error.status().unwrap(),
-            })?;
-        let json = response
-            .json::<PrefectureMaster>()
-            .await
-            .map_err(|_| ApiError::Deserialize { url })?;
-        Ok(json)
+        self.api_service.get::<PrefectureMaster>(&url).await
     }
 }
 
 #[cfg(test)]
 mod async_tests {
     use crate::prefecture::PrefectureMasterRepository;
+    use crate::service::ChimeiRuijuApiService;
     use jisx0401::Prefecture;
 
     #[tokio::test]
     async fn tokyo() {
-        let repository = PrefectureMasterRepository {};
+        let repository = PrefectureMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
         let result = repository.get(&Prefecture::TOKYO).await;
         assert!(result.is_ok());
         let entity = result.unwrap();
@@ -107,7 +103,9 @@ mod async_tests {
 
     #[tokio::test]
     async fn toyama() {
-        let repository = PrefectureMasterRepository {};
+        let repository = PrefectureMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
         let result = repository.get(&Prefecture::TOYAMA).await;
         assert!(result.is_ok());
         let entity = result.unwrap();
@@ -141,25 +139,21 @@ impl PrefectureMasterRepository {
             "https://{}.chimei-ruiju.org/master.json",
             prefecture.name_en()
         );
-        let response = reqwest::blocking::get(&url).map_err(|error| ApiError::Network {
-            url: url.clone(),
-            status_code: error.status().unwrap(),
-        })?;
-        let json = response
-            .json::<PrefectureMaster>()
-            .map_err(|_| ApiError::Deserialize { url })?;
-        Ok(json)
+        self.api_service.get_blocking::<PrefectureMaster>(&url)
     }
 }
 
 #[cfg(test)]
 mod blocking_tests {
     use crate::prefecture::PrefectureMasterRepository;
+    use crate::service::ChimeiRuijuApiService;
     use jisx0401::Prefecture;
 
     #[tokio::test]
     async fn kochi() {
-        let repository = PrefectureMasterRepository {};
+        let repository = PrefectureMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
         let result = repository.get(&Prefecture::KOCHI).await;
         assert!(result.is_ok());
         let entity = result.unwrap();
@@ -207,7 +201,9 @@ mod blocking_tests {
 
     #[tokio::test]
     async fn saga() {
-        let repository = PrefectureMasterRepository {};
+        let repository = PrefectureMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
         let result = repository.get(&Prefecture::SAGA).await;
         assert!(result.is_ok());
         let entity = result.unwrap();

--- a/repository/src/prefecture.rs
+++ b/repository/src/prefecture.rs
@@ -151,3 +151,91 @@ impl PrefectureMasterRepository {
         Ok(json)
     }
 }
+
+#[cfg(test)]
+mod blocking_tests {
+    use crate::prefecture::PrefectureMasterRepository;
+    use jisx0401::Prefecture;
+
+    #[tokio::test]
+    async fn kochi() {
+        let repository = PrefectureMasterRepository {};
+        let result = repository.get(&Prefecture::KOCHI).await;
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "高知県");
+        assert_eq!(
+            entity.cities,
+            vec![
+                "高知市",
+                "室戸市",
+                "安芸市",
+                "南国市",
+                "土佐市",
+                "須崎市",
+                "宿毛市",
+                "土佐清水市",
+                "四万十市",
+                "香南市",
+                "香美市",
+                "安芸郡東洋町",
+                "安芸郡奈半利町",
+                "安芸郡田野町",
+                "安芸郡安田町",
+                "安芸郡北川村",
+                "安芸郡馬路村",
+                "安芸郡芸西村",
+                "長岡郡本山町",
+                "長岡郡大豊町",
+                "土佐郡土佐町",
+                "土佐郡大川村",
+                "吾川郡いの町",
+                "吾川郡仁淀川町",
+                "高岡郡中土佐町",
+                "高岡郡佐川町",
+                "高岡郡越知町",
+                "高岡郡檮原町",
+                "高岡郡日高村",
+                "高岡郡津野町",
+                "高岡郡四万十町",
+                "幡多郡大月町",
+                "幡多郡三原村",
+                "幡多郡黒潮町"
+            ]
+        )
+    }
+
+    #[tokio::test]
+    async fn saga() {
+        let repository = PrefectureMasterRepository {};
+        let result = repository.get(&Prefecture::SAGA).await;
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "佐賀県");
+        assert_eq!(
+            entity.cities,
+            vec![
+                "佐賀市",
+                "唐津市",
+                "鳥栖市",
+                "多久市",
+                "伊万里市",
+                "武雄市",
+                "鹿島市",
+                "小城市",
+                "嬉野市",
+                "神埼市",
+                "神埼郡吉野ヶ里町",
+                "三養基郡基山町",
+                "三養基郡上峰町",
+                "三養基郡みやき町",
+                "東松浦郡玄海町",
+                "西松浦郡有田町",
+                "杵島郡大町町",
+                "杵島郡江北町",
+                "杵島郡白石町",
+                "藤津郡太良町"
+            ]
+        );
+    }
+}

--- a/repository/src/service.rs
+++ b/repository/src/service.rs
@@ -25,7 +25,99 @@ impl ChimeiRuijuApiService {
                 url: url.to_string(),
             })
     }
+}
 
+#[cfg(test)]
+mod async_tests {
+    use crate::entity::PrefectureMaster;
+    use crate::error::ApiError;
+    use crate::service::ChimeiRuijuApiService;
+
+    #[tokio::test]
+    async fn 失敗_ネットワークエラー() {
+        let invalid_url = "htttp://chimei-ruiju.org";
+        let api_service = ChimeiRuijuApiService {};
+
+        let result = api_service.get::<PrefectureMaster>(invalid_url).await;
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(
+            error,
+            ApiError::Network {
+                url: invalid_url.to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn 失敗_404エラー() {
+        let mut server = mockito::Server::new_async().await;
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let api_service = ChimeiRuijuApiService {};
+
+        let result = api_service.get::<PrefectureMaster>(&url).await;
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error, ApiError::NotFound { url: url.clone() });
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn 失敗_デシリアライズエラー() {
+        let mut server = mockito::Server::new_async().await;
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"hoge": true, "piyo": 100}"#)
+            .create_async()
+            .await;
+
+        let api_service = ChimeiRuijuApiService {};
+
+        let result = api_service.get::<PrefectureMaster>(&url).await;
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error, ApiError::Deserialize { url: url.clone() });
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn 成功() {
+        let mut server = mockito::Server::new_async().await;
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"name": "新浜県", "cities": ["新浜市"], "coordinate": {"latitude": 34.6570413, "longitude": 135.2741341}}"#)
+            .create_async()
+            .await;
+
+        let api_service = ChimeiRuijuApiService {};
+
+        let result = api_service.get::<PrefectureMaster>(&url).await;
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "新浜県");
+        assert_eq!(entity.cities, vec!["新浜市"]);
+        assert_eq!(entity.coordinate.latitude, 34.6570413);
+        assert_eq!(entity.coordinate.longitude, 135.2741341);
+
+        mock.assert_async().await;
+    }
+}
+
+impl ChimeiRuijuApiService {
     pub fn get_blocking<T>(&self, url: &str) -> Result<T, ApiError>
     where
         T: DeserializeOwned,
@@ -41,5 +133,89 @@ impl ChimeiRuijuApiService {
         response.json::<T>().map_err(|_| ApiError::Deserialize {
             url: url.to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod blocking_tests {
+    use crate::entity::PrefectureMaster;
+    use crate::error::ApiError;
+    use crate::service::ChimeiRuijuApiService;
+
+    #[test]
+    fn 失敗_ネットワークエラー() {
+        let invalid_url = "htttp://chimei-ruiju.org";
+        let api_service = ChimeiRuijuApiService {};
+
+        let result = api_service.get_blocking::<PrefectureMaster>(invalid_url);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(
+            error,
+            ApiError::Network {
+                url: invalid_url.to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn 失敗_404エラー() {
+        let mut server = mockito::Server::new();
+        let url = format!("{}/master.json", &server.url());
+        let mock = server.mock("GET", "/master.json").with_status(404).create();
+
+        let api_service = ChimeiRuijuApiService {};
+
+        let result = api_service.get_blocking::<PrefectureMaster>(&url);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error, ApiError::NotFound { url: url.clone() });
+
+        mock.assert();
+    }
+
+    #[test]
+    fn 失敗_デシリアライズエラー() {
+        let mut server = mockito::Server::new();
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"hoge": true, "piyo": 100}"#)
+            .create();
+
+        let api_service = ChimeiRuijuApiService {};
+
+        let result = api_service.get_blocking::<PrefectureMaster>(&url);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error, ApiError::Deserialize { url: url.clone() });
+
+        mock.assert();
+    }
+
+    #[test]
+    fn 成功() {
+        let mut server = mockito::Server::new();
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"name": "新浜県", "cities": ["新浜市"], "coordinate": {"latitude": 34.6570413, "longitude": 135.2741341}}"#)
+            .create();
+
+        let api_service = ChimeiRuijuApiService {};
+
+        let result = api_service.get_blocking::<PrefectureMaster>(&url);
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "新浜県");
+        assert_eq!(entity.cities, vec!["新浜市"]);
+        assert_eq!(entity.coordinate.latitude, 34.6570413);
+        assert_eq!(entity.coordinate.longitude, 135.2741341);
+
+        mock.assert();
     }
 }

--- a/repository/src/service.rs
+++ b/repository/src/service.rs
@@ -1,0 +1,35 @@
+use crate::error::ApiError;
+use serde::de::DeserializeOwned;
+
+pub struct ChimeiRuijuApiService {}
+
+impl ChimeiRuijuApiService {
+    pub async fn get<T>(&self, url: &str) -> Result<T, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let response = reqwest::get(url).await.map_err(|error| ApiError::Network {
+            url: url.to_string(),
+            status_code: error.status().unwrap(),
+        })?;
+        response
+            .json::<T>()
+            .await
+            .map_err(|_| ApiError::Deserialize {
+                url: url.to_string(),
+            })
+    }
+
+    pub fn get_blocking<T>(&self, url: &str) -> Result<T, ApiError>
+    where
+        T: DeserializeOwned,
+    {
+        let response = reqwest::blocking::get(url).map_err(|error| ApiError::Network {
+            url: url.to_string(),
+            status_code: error.status().unwrap(),
+        })?;
+        response.json::<T>().map_err(|_| ApiError::Deserialize {
+            url: url.to_string(),
+        })
+    }
+}

--- a/repository/src/town.rs
+++ b/repository/src/town.rs
@@ -1,0 +1,42 @@
+use crate::entity::TownMaster;
+use crate::error::ApiError;
+use crate::service::ChimeiRuijuApiService;
+use jisx0401::Prefecture;
+
+pub struct TownMasterRepository {
+    api_service: ChimeiRuijuApiService,
+}
+
+impl TownMasterRepository {
+    pub async fn get(
+        &self,
+        prefecture: &Prefecture,
+        city_name: &str,
+        town_name: &str,
+    ) -> Result<TownMaster, ApiError> {
+        let url = format!(
+            "https://{}.chimei-ruiju.org/{}/{}/master.json",
+            prefecture.name_en(),
+            city_name,
+            town_name
+        );
+        self.api_service.get::<TownMaster>(&url).await
+    }
+}
+
+impl TownMasterRepository {
+    pub fn get_blocking(
+        &self,
+        prefecture: &Prefecture,
+        city_name: &str,
+        town_name: &str,
+    ) -> Result<TownMaster, ApiError> {
+        let url = format!(
+            "https://{}.chimei-ruiju.org/{}/{}/master.json",
+            prefecture.name_en(),
+            city_name,
+            town_name
+        );
+        self.api_service.get_blocking::<TownMaster>(&url)
+    }
+}

--- a/repository/src/town.rs
+++ b/repository/src/town.rs
@@ -24,6 +24,26 @@ impl TownMasterRepository {
     }
 }
 
+#[cfg(test)]
+mod async_tests {
+    use crate::service::ChimeiRuijuApiService;
+    use crate::town::TownMasterRepository;
+    use jisx0401::Prefecture;
+
+    #[tokio::test]
+    async fn 東京都千代田区千代田() {
+        let repository = TownMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
+        let result = repository
+            .get(&Prefecture::TOKYO, "千代田区", "千代田")
+            .await;
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "千代田");
+    }
+}
+
 impl TownMasterRepository {
     pub fn get_blocking(
         &self,
@@ -38,5 +58,23 @@ impl TownMasterRepository {
             town_name
         );
         self.api_service.get_blocking::<TownMaster>(&url)
+    }
+}
+
+#[cfg(test)]
+mod blocking_tests {
+    use crate::service::ChimeiRuijuApiService;
+    use crate::town::TownMasterRepository;
+    use jisx0401::Prefecture;
+
+    #[test]
+    fn 京都府京都市伏見区魚屋町() {
+        let repository = TownMasterRepository {
+            api_service: ChimeiRuijuApiService {},
+        };
+        let result = repository.get_blocking(&Prefecture::KYOTO, "京都市伏見区", "魚屋町");
+        assert!(result.is_ok());
+        let entity = result.unwrap();
+        assert_eq!(entity.name, "魚屋町");
     }
 }


### PR DESCRIPTION
### 変更点
- `chimei-ruiju.org`に対応するために、`repository`クレートを作成。
- `repository`クレートだが、色々混在しているので後のPRで整理する。

### 確認すべき項目
- [x] `cargo fmt`
- [x] `cargo test`

### 備考
- #324 
