### PR TITLE
rust-cacheの導入: PR作成時とmainへのpush時に動くワークフローに`Swatinem/rust-cache`を導入

### DIFF
--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: true
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Set up clippy
         run: rustup component add clippy

--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -18,7 +18,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          shared-key: 'test-on-pr'
+          save-if: 'true'
+          #save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Set up clippy
         run: rustup component add clippy

--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -15,6 +15,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          save-if: true
+          cache-provider: 'github'
       - name: Set up clippy
         run: rustup component add clippy
       - name: Code review with clippy

--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -19,8 +19,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'test-on-pr'
-          save-if: 'true'
-          #save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Set up clippy
         run: rustup component add clippy

--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: true
+          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -35,7 +35,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: true
+          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -56,7 +56,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: true
+          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -76,7 +76,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: true
+          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - name: Build sdist
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -25,7 +25,6 @@ jobs:
           target: x86_64
           args: --release --out dist --zig
           working-directory: python
-          sccache: 'true'
           manylinux: auto
 
   windows:
@@ -47,7 +46,6 @@ jobs:
           target: x64
           args: --release --out dist
           working-directory: python
-          sccache: 'true'
 
   macos:
     runs-on: macos-14
@@ -67,7 +65,6 @@ jobs:
           target: aarch64
           args: --release --out dist
           working-directory: python
-          sccache: 'true'
 
   sdist:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -15,8 +15,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-linux'
-          save-if: 'true'
-          #save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -37,8 +36,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-windows'
-          save-if: 'true'
-          #save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -59,8 +57,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-macos'
-          save-if: 'true'
-          #save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -80,8 +77,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-sdist'
-          save-if: 'true'
-          #save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - name: Build sdist
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          save-if: true
+          cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -27,6 +32,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          save-if: true
+          cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -43,6 +53,11 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          save-if: true
+          cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -58,6 +73,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          save-if: true
+          cache-provider: 'github'
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -2,6 +2,8 @@ name: Python module build check
 
 on:
   pull_request:
+  push:
+    branches: [ 'main' ]
 
 permissions:
   contents: read
@@ -15,7 +17,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-linux'
-          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -36,7 +38,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-windows'
-          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -57,7 +59,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-macos'
-          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -77,7 +79,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-sdist'
-          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Build sdist
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -14,7 +14,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          shared-key: 'maturin-linux'
+          save-if: 'true'
+          #save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -34,7 +36,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          shared-key: 'maturin-windows'
+          save-if: 'true'
+          #save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -54,7 +58,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          shared-key: 'maturin-macos'
+          save-if: 'true'
+          #save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
@@ -73,7 +79,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
+          shared-key: 'maturin-sdist'
+          save-if: 'true'
+          #save-if: false # mainブランチで保存したキャッシュを利用するので、PR作成時にはキャッシュを保存しない
           cache-provider: 'github'
       - name: Build sdist
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          save-if: true
+          cache-provider: 'github'
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Unit test for core module

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: true
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -13,7 +13,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           cache-all-crates: true
-          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          shared-key: 'wasm-pack'
+          save-if: 'true'
+          #save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -14,8 +14,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'wasm-pack'
-          save-if: 'true'
-          #save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
### 変更点
- `Swatinem/rust-cache`を使ってcargoのキャッシュを保存するように修正

### 備考
- #331 
