### PR TITLE
rust-cacheの導入をmainブランチにマージ

### DIFF
--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -19,6 +19,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'test-on-pr'
+          key: 'main'
           save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Set up clippy

--- a/.github/workflows/code-check.yaml
+++ b/.github/workflows/code-check.yaml
@@ -15,6 +15,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          shared-key: 'test-on-pr'
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          cache-provider: 'github'
       - name: Set up clippy
         run: rustup component add clippy
       - name: Code review with clippy

--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -2,6 +2,8 @@ name: Python module build check
 
 on:
   pull_request:
+  push:
+    branches: [ 'main' ]
 
 permissions:
   contents: read
@@ -11,6 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          shared-key: 'maturin-linux'
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -20,13 +28,18 @@ jobs:
           target: x86_64
           args: --release --out dist --zig
           working-directory: python
-          sccache: 'true'
           manylinux: auto
 
   windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          shared-key: 'maturin-windows'
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -37,12 +50,17 @@ jobs:
           target: x64
           args: --release --out dist
           working-directory: python
-          sccache: 'true'
 
   macos:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          shared-key: 'maturin-macos'
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          cache-provider: 'github'
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -52,12 +70,17 @@ jobs:
           target: aarch64
           args: --release --out dist
           working-directory: python
-          sccache: 'true'
 
   sdist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          shared-key: 'maturin-sdist'
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          cache-provider: 'github'
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:

--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -17,6 +17,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-linux'
+          key: 'main'
           save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - uses: actions/setup-python@v5
@@ -38,6 +39,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-windows'
+          key: 'main'
           save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - uses: actions/setup-python@v5
@@ -59,6 +61,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-macos'
+          key: 'main'
           save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - uses: actions/setup-python@v5
@@ -79,6 +82,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'maturin-sdist'
+          key: 'main'
           save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Build sdist

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -10,6 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-all-crates: true
+          shared-key: 'wasm-pack'
+          save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
+          cache-provider: 'github'
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Unit test for core module

--- a/.github/workflows/wasm-pack-test.yaml
+++ b/.github/workflows/wasm-pack-test.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           cache-all-crates: true
           shared-key: 'wasm-pack'
+          key: 'main'
           save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Install wasm-pack


### PR DESCRIPTION
### 変更点
- PR作成時に回るCIでcargoのキャッシュを有効化しました。
- キャッシュの作成はmainブランチにコミットが追加された場合のみに行ない、各フィーチャブランチではキャッシュを保存しません。

### 備考
- #331 
