### PR TITLE
chimei-ruiju.orgへの移行: v0.1.4以前のバージョンとの後方互換性の維持

### DIFF
--- a/core/src/entity.rs
+++ b/core/src/entity.rs
@@ -1,0 +1,5 @@
+pub use crate::parser::ParseResult;
+pub use domain::geolonia::entity::Address;
+pub use domain::geolonia::entity::City;
+pub use domain::geolonia::entity::Prefecture;
+pub use domain::geolonia::entity::Town;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,5 +4,7 @@ compile_error! {
 }
 
 pub mod api;
+#[deprecated(since = "0.1.5", note = "This module will be deleted in v0.2")]
+pub mod entity;
 pub mod parser;
 mod util;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@ compile_error! {
     "The `blocking` feature is not supported with wasm target."
 }
 
+#[deprecated(since = "0.1.5", note = "This module will be deleted in v0.2")]
 pub mod api;
 #[deprecated(since = "0.1.5", note = "This module will be deleted in v0.2")]
 pub mod entity;


### PR DESCRIPTION
### 変更点
- v0.1.4以前のバージョンを使用しているプログラムで不整合が起きないよう、`core/src/entity.rs`を再作成し、移動させた構造体を再公開した。
- しかし、v0.2系では削除したいため、`core/src/api.rs`とともにDeprecatedに指定した。

### 備考
- #324 
