### PR TITLE
coreモジュールのリファクタ: `test-case`クレートへの依存を削除

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,6 +28,5 @@ reqwest = { version = "0.12.3", default-features = false, features = ["json", "r
 serde = { version = "1.0.192", features = ["derive"] }
 
 [dev-dependencies]
-test-case = "3.3.1"
 tokio = { version = "1.38.0", features = ["rt", "macros"] }
 wasm-bindgen-test = { workspace = true }


### PR DESCRIPTION
### 変更点
- #342 で`test-case`クレートの使用箇所がなくなったが、除却が漏れていた

### 備考
- #343 
