### PR TITLE
nomの除却: VagueExpressionAdapter

### DIFF
--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -8,7 +8,7 @@ impl VagueExpressionAdapter {
             SequenceMatcher::get_most_similar_match(input, region_name_list, None)
         {
             if let Some(position) = input.chars().position(|c| c == '町' || c == '村') {
-                return Some((input.chars().skip(position + 1).collect(), highest_match));
+                return Some((highest_match, input.chars().skip(position + 1).collect()));
             }
         }
         None
@@ -23,50 +23,50 @@ mod tests {
     #[test]
     fn 郡名が省略されている場合_吉田郡永平寺町() {
         let fukui = Prefecture::fukui();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("永平寺町志比５－５", &fukui.cities)
             .unwrap();
-        assert_eq!(rest, "志比５－５");
         assert_eq!(city_name, "吉田郡永平寺町");
+        assert_eq!(rest, "志比５－５");
     }
 
     #[test]
     fn 郡名が省略されている場合_今立郡池田町() {
         let fukui = Prefecture::fukui();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("池田町稲荷２８－７", &fukui.cities)
             .unwrap();
-        assert_eq!(rest, "稲荷２８－７");
         assert_eq!(city_name, "今立郡池田町");
+        assert_eq!(rest, "稲荷２８－７");
     }
 
     #[test]
     fn 郡名が省略されている場合_南条郡南越前町() {
         let fukui = Prefecture::fukui();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("南越前町今庄７４－７－１", &fukui.cities)
             .unwrap();
-        assert_eq!(rest, "今庄７４－７－１");
         assert_eq!(city_name, "南条郡南越前町");
+        assert_eq!(rest, "今庄７４－７－１");
     }
 
     #[test]
     fn 郡名が省略されている場合_西村山郡河北町() {
         let yamagata = Prefecture::yamagata();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("河北町大字吉田字馬場261", &yamagata.cities)
             .unwrap();
-        assert_eq!(rest, "大字吉田字馬場261");
         assert_eq!(city_name, "西村山郡河北町");
+        assert_eq!(rest, "大字吉田字馬場261");
     }
 
     #[test]
     fn 郡名と町名が一致している場合_最上郡最上町() {
         let yamagata = Prefecture::yamagata();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("最上町法田2672-2", &yamagata.cities)
             .unwrap();
-        assert_eq!(rest, "法田2672-2");
         assert_eq!(city_name, "最上郡最上町");
+        assert_eq!(rest, "法田2672-2");
     }
 }

--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -1,8 +1,4 @@
 use crate::util::sequence_matcher::SequenceMatcher;
-use nom::bytes::complete::{is_a, is_not};
-use nom::combinator::rest;
-use nom::error::Error;
-use nom::sequence::tuple;
 
 pub struct VagueExpressionAdapter;
 
@@ -11,13 +7,8 @@ impl VagueExpressionAdapter {
         if let Ok(highest_match) =
             SequenceMatcher::get_most_similar_match(input, region_name_list, None)
         {
-            let mut parser = tuple((
-                is_not::<&str, &str, Error<&str>>("町村"),
-                is_a::<&str, &str, Error<&str>>("町村"),
-                rest,
-            ));
-            if let Ok((_, (_, _, rest))) = parser(input) {
-                return Some((rest.to_string(), highest_match));
+            if let Some(position) = input.chars().position(|c| c == '町' || c == '村') {
+                return Some((input.chars().skip(position + 1).collect(), highest_match));
             }
         }
         None

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -75,9 +75,9 @@ impl Tokenizer<PrefectureNameFound> {
             return Ok(Tokenizer {
                 input: self.input.clone(),
                 prefecture_name: self.prefecture_name.clone(),
-                city_name: Some(result.1),
+                city_name: Some(result.0),
                 town_name: None,
-                rest: result.0,
+                rest: result.1,
                 _state: PhantomData::<CityNameFound>,
             });
         }


### PR DESCRIPTION
### 変更点
- `VagueExpressionAdapter`の実装から`nom`を除却

### 備考
- #308 
