### PR TITLE
nomの除却をrelease/v0.1.8にマージ

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,6 @@ blocking = ["reqwest/blocking"]
 [dependencies]
 itertools = "0.13.0"
 js-sys = "0.3.67"
-nom = "7.1.3"
 rapidfuzz = "0.5.0"
 regex = "1.10.2"
 serde.workspace = true

--- a/core/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/core/src/parser/adapter/orthographical_variant_adapter.rs
@@ -1,7 +1,4 @@
 use itertools::Itertools;
-use nom::bytes::complete::tag;
-use nom::error::VerboseError;
-use nom::Parser;
 
 pub type Variant = &'static [&'static str];
 
@@ -86,11 +83,15 @@ impl OrthographicalVariantAdapter {
                     // マッチ候補の中でパターンに引っかかるものがあれば文字を置き換えてマッチを試す
                     if candidate.contains(permutation[0]) {
                         let edited_region_name = candidate.replace(permutation[0], permutation[1]);
-                        if let Ok((rest, _)) =
-                            tag::<&str, &str, VerboseError<&str>>(&edited_region_name).parse(input)
-                        {
+                        if input.starts_with(&edited_region_name) {
                             // マッチすれば早期リターン
-                            return Some((rest.to_string(), region_name.to_string()));
+                            return Some((
+                                input
+                                    .chars()
+                                    .skip(edited_region_name.chars().count())
+                                    .collect(),
+                                region_name.to_string(),
+                            ));
                         } else {
                             // マッチしなければsemi_candidatesに置き換え後の文字列をpush
                             semi_candidates.push(edited_region_name.clone());

--- a/core/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/core/src/parser/adapter/orthographical_variant_adapter.rs
@@ -86,11 +86,11 @@ impl OrthographicalVariantAdapter {
                         if input.starts_with(&edited_region_name) {
                             // マッチすれば早期リターン
                             return Some((
+                                region_name.to_string(),
                                 input
                                     .chars()
                                     .skip(edited_region_name.chars().count())
                                     .collect(),
-                                region_name.to_string(),
                             ));
                         } else {
                             // マッチしなければsemi_candidatesに置き換え後の文字列をpush

--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -8,7 +8,7 @@ impl VagueExpressionAdapter {
             SequenceMatcher::get_most_similar_match(input, region_name_list, None)
         {
             if let Some(position) = input.chars().position(|c| c == '町' || c == '村') {
-                return Some((input.chars().skip(position + 1).collect(), highest_match));
+                return Some((highest_match, input.chars().skip(position + 1).collect()));
             }
         }
         None
@@ -23,50 +23,50 @@ mod tests {
     #[test]
     fn 郡名が省略されている場合_吉田郡永平寺町() {
         let fukui = Prefecture::fukui();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("永平寺町志比５－５", &fukui.cities)
             .unwrap();
-        assert_eq!(rest, "志比５－５");
         assert_eq!(city_name, "吉田郡永平寺町");
+        assert_eq!(rest, "志比５－５");
     }
 
     #[test]
     fn 郡名が省略されている場合_今立郡池田町() {
         let fukui = Prefecture::fukui();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("池田町稲荷２８－７", &fukui.cities)
             .unwrap();
-        assert_eq!(rest, "稲荷２８－７");
         assert_eq!(city_name, "今立郡池田町");
+        assert_eq!(rest, "稲荷２８－７");
     }
 
     #[test]
     fn 郡名が省略されている場合_南条郡南越前町() {
         let fukui = Prefecture::fukui();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("南越前町今庄７４－７－１", &fukui.cities)
             .unwrap();
-        assert_eq!(rest, "今庄７４－７－１");
         assert_eq!(city_name, "南条郡南越前町");
+        assert_eq!(rest, "今庄７４－７－１");
     }
 
     #[test]
     fn 郡名が省略されている場合_西村山郡河北町() {
         let yamagata = Prefecture::yamagata();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("河北町大字吉田字馬場261", &yamagata.cities)
             .unwrap();
-        assert_eq!(rest, "大字吉田字馬場261");
         assert_eq!(city_name, "西村山郡河北町");
+        assert_eq!(rest, "大字吉田字馬場261");
     }
 
     #[test]
     fn 郡名と町名が一致している場合_最上郡最上町() {
         let yamagata = Prefecture::yamagata();
-        let (rest, city_name) = VagueExpressionAdapter {}
+        let (city_name, rest) = VagueExpressionAdapter {}
             .apply("最上町法田2672-2", &yamagata.cities)
             .unwrap();
-        assert_eq!(rest, "法田2672-2");
         assert_eq!(city_name, "最上郡最上町");
+        assert_eq!(rest, "法田2672-2");
     }
 }

--- a/core/src/parser/adapter/vague_expression_adapter.rs
+++ b/core/src/parser/adapter/vague_expression_adapter.rs
@@ -1,8 +1,4 @@
 use crate::util::sequence_matcher::SequenceMatcher;
-use nom::bytes::complete::{is_a, is_not};
-use nom::combinator::rest;
-use nom::error::Error;
-use nom::sequence::tuple;
 
 pub struct VagueExpressionAdapter;
 
@@ -11,13 +7,8 @@ impl VagueExpressionAdapter {
         if let Ok(highest_match) =
             SequenceMatcher::get_most_similar_match(input, region_name_list, None)
         {
-            let mut parser = tuple((
-                is_not::<&str, &str, Error<&str>>("町村"),
-                is_a::<&str, &str, Error<&str>>("町村"),
-                rest,
-            ));
-            if let Ok((_, (_, _, rest))) = parser(input) {
-                return Some((rest.to_string(), highest_match));
+            if let Some(position) = input.chars().position(|c| c == '町' || c == '村') {
+                return Some((input.chars().skip(position + 1).collect(), highest_match));
             }
         }
         None

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -75,9 +75,9 @@ impl Tokenizer<PrefectureNameFound> {
             return Ok(Tokenizer {
                 input: self.input.clone(),
                 prefecture_name: self.prefecture_name.clone(),
-                city_name: Some(result.1),
+                city_name: Some(result.0),
                 town_name: None,
-                rest: result.0,
+                rest: result.1,
                 _state: PhantomData::<CityNameFound>,
             });
         }

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -61,9 +61,9 @@ impl Tokenizer<PrefectureNameFound> {
                 return Ok(Tokenizer {
                     input: self.input.clone(),
                     prefecture_name: self.prefecture_name.clone(),
-                    city_name: Some(result.1),
+                    city_name: Some(result.0),
                     town_name: None,
-                    rest: result.0,
+                    rest: result.1,
                     _state: PhantomData::<CityNameFound>,
                 });
             }

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -95,8 +95,8 @@ fn find_town(input: &str, candidates: &Vec<String>) -> Option<(String, String)> 
                 Variant::蛍,
             ],
         };
-        if let Some(result) = adapter.apply(input, candidate) {
-            return Some(result);
+        if let Some((region_name, rest)) = adapter.apply(input, candidate) {
+            return Some((rest, region_name));
         };
     }
     None

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -18,36 +18,36 @@ impl Tokenizer<CityNameFound> {
         if rest.contains("丁目") {
             rest = NonKanjiBlockNumberFilter {}.apply(rest);
         }
-        if let Some(result) = find_town(&rest, &candidates) {
+        if let Some((town_name, rest)) = find_town(&rest, &candidates) {
             return Ok(Tokenizer {
                 input: self.input.clone(),
                 prefecture_name: self.prefecture_name.clone(),
                 city_name: self.city_name.clone(),
-                town_name: Some(result.1),
-                rest: result.0,
+                town_name: Some(town_name),
+                rest,
                 _state: PhantomData::<TownNameFound>,
             });
         }
         // 「〇〇町L丁目M番N」ではなく「〇〇町L-M-N」と表記されているような場合
         rest = InvalidTownNameFormatFilter {}.apply(rest);
-        if let Some(result) = find_town(&rest, &candidates) {
+        if let Some((town_name, rest)) = find_town(&rest, &candidates) {
             return Ok(Tokenizer {
                 input: self.input.clone(),
                 prefecture_name: self.prefecture_name.clone(),
                 city_name: self.city_name.clone(),
-                town_name: Some(result.1),
-                rest: result.0,
+                town_name: Some(town_name),
+                rest,
                 _state: PhantomData::<TownNameFound>,
             });
         }
         // ここまでで町名の検出に成功しない場合は、「大字」の省略の可能性を検討する
-        if let Some(result) = find_town(&format!("大字{}", rest), &candidates) {
+        if let Some((town_name, rest)) = find_town(&format!("大字{}", rest), &candidates) {
             return Ok(Tokenizer {
                 input: self.input.clone(),
                 prefecture_name: self.prefecture_name.clone(),
                 city_name: self.city_name.clone(),
-                town_name: Some(result.1),
-                rest: result.0,
+                town_name: Some(town_name),
+                rest,
                 _state: PhantomData::<TownNameFound>,
             });
         }
@@ -66,11 +66,11 @@ fn find_town(input: &str, candidates: &Vec<String>) -> Option<(String, String)> 
     for candidate in candidates {
         if input.starts_with(candidate) {
             return Some((
+                candidate.to_string(),
                 input
                     .chars()
                     .skip(candidate.chars().count())
                     .collect::<String>(),
-                candidate.to_string(),
             ));
         }
         let adapter = OrthographicalVariantAdapter {
@@ -95,8 +95,8 @@ fn find_town(input: &str, candidates: &Vec<String>) -> Option<(String, String)> 
                 Variant::蛍,
             ],
         };
-        if let Some((region_name, rest)) = adapter.apply(input, candidate) {
-            return Some((rest, region_name));
+        if let Some(result) = adapter.apply(input, candidate) {
+            return Some(result);
         };
     }
     None


### PR DESCRIPTION
### 変更点
- WasmやPython向けのビルドサイズを小さくしたいため、nomを使用している箇所を自前の実装に置き換えた
  - #358 
  - #359 
  - #360 

### 備考
- #308 
