### PR TITLE
郡名補完機能のオプトアウト: フィーチャフラグ`city-name-correction`を追加

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,8 +15,9 @@ rust-version = "1.73.0"
 crate-type = ["rlib", "cdylib"]
 
 [features]
-default = []
+default = ["enable-city-name-correction"]
 blocking = ["reqwest/blocking"]
+enable-city-name-correction = []
 
 [dependencies]
 itertools = "0.13.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,9 +15,9 @@ rust-version = "1.73.0"
 crate-type = ["rlib", "cdylib"]
 
 [features]
-default = ["enable-city-name-correction"]
+default = ["city-name-correction"]
 blocking = ["reqwest/blocking"]
-enable-city-name-correction = []
+city-name-correction = []
 
 [dependencies]
 itertools = "0.13.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,9 @@
+//! A Rust library to parse japanese addresses.
+//!
+//! ## Feature flags
+//! - `blocking`: Provide method that works synchronously
+//! - `city-name-correction`*(enabled by default)*: Enable autocorrection if ambiguous city name was typed
+
 #[cfg(all(target_family = "wasm", feature = "blocking"))]
 compile_error! {
     "The `blocking` feature is not supported with wasm target."

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -101,16 +101,17 @@ pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
     let tokenizer = match tokenizer.read_city(&prefecture.cities) {
         Ok(found) => found,
         Err(not_found) => {
-            // 見つからない場合は郡名が抜けている可能性を検討
-            let Ok(found) = not_found.read_city_with_county_name_completion(&prefecture.cities)
-            else {
+            // 市区町村が特定できない場合かつフィーチャフラグが有効な場合、郡名が抜けている可能性を検討
+            let result = not_found.read_city_with_county_name_completion(&prefecture.cities);
+            if cfg!(feature = "enable-city-name-correction") && result.is_ok() {
+                result.unwrap()
+            } else {
                 // それでも見つからない場合は終了
                 return ParseResult {
                     address: Address::from(tokenizer),
                     error: Some(Error::new_parse_error(ParseErrorKind::City)),
                 };
-            };
-            found
+            }
         }
     };
     // その市町村の町名リストを取得
@@ -266,14 +267,15 @@ pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     let tokenizer = match tokenizer.read_city(&prefecture.cities) {
         Ok(found) => found,
         Err(not_found) => {
-            let Ok(found) = not_found.read_city_with_county_name_completion(&prefecture.cities)
-            else {
+            let result = not_found.read_city_with_county_name_completion(&prefecture.cities);
+            if cfg!(feature = "enable-city-name-correction") && result.is_ok() {
+                result.unwrap()
+            } else {
                 return ParseResult {
                     address: Address::from(tokenizer),
                     error: Some(Error::new_parse_error(ParseErrorKind::City)),
                 };
-            };
-            found
+            }
         }
     };
     let city = match api.get_city_master(

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -102,15 +102,15 @@ pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
         Ok(found) => found,
         Err(not_found) => {
             // 市区町村が特定できない場合かつフィーチャフラグが有効な場合、郡名が抜けている可能性を検討
-            let result = not_found.read_city_with_county_name_completion(&prefecture.cities);
-            if cfg!(feature = "enable-city-name-correction") && result.is_ok() {
-                result.unwrap()
-            } else {
-                // それでも見つからない場合は終了
-                return ParseResult {
-                    address: Address::from(tokenizer),
-                    error: Some(Error::new_parse_error(ParseErrorKind::City)),
-                };
+            match not_found.read_city_with_county_name_completion(&prefecture.cities) {
+                Ok(found) if cfg!(feature = "enable-city-name-correction") => found,
+                _ => {
+                    // それでも見つからない場合は終了
+                    return ParseResult {
+                        address: Address::from(tokenizer),
+                        error: Some(Error::new_parse_error(ParseErrorKind::City)),
+                    };
+                }
             }
         }
     };
@@ -267,14 +267,14 @@ pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     let tokenizer = match tokenizer.read_city(&prefecture.cities) {
         Ok(found) => found,
         Err(not_found) => {
-            let result = not_found.read_city_with_county_name_completion(&prefecture.cities);
-            if cfg!(feature = "enable-city-name-correction") && result.is_ok() {
-                result.unwrap()
-            } else {
-                return ParseResult {
-                    address: Address::from(tokenizer),
-                    error: Some(Error::new_parse_error(ParseErrorKind::City)),
-                };
+            match not_found.read_city_with_county_name_completion(&prefecture.cities) {
+                Ok(found) if cfg!(feature = "enable-city-name-correction") => found,
+                _ => {
+                    return ParseResult {
+                        address: Address::from(tokenizer),
+                        error: Some(Error::new_parse_error(ParseErrorKind::City)),
+                    };
+                }
             }
         }
     };

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -103,7 +103,7 @@ pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
         Err(not_found) => {
             // 市区町村が特定できない場合かつフィーチャフラグが有効な場合、郡名が抜けている可能性を検討
             match not_found.read_city_with_county_name_completion(&prefecture.cities) {
-                Ok(found) if cfg!(feature = "enable-city-name-correction") => found,
+                Ok(found) if cfg!(feature = "city-name-correction") => found,
                 _ => {
                     // それでも見つからない場合は終了
                     return ParseResult {
@@ -268,7 +268,7 @@ pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
         Ok(found) => found,
         Err(not_found) => {
             match not_found.read_city_with_county_name_completion(&prefecture.cities) {
-                Ok(found) if cfg!(feature = "enable-city-name-correction") => found,
+                Ok(found) if cfg!(feature = "city-name-correction") => found,
                 _ => {
                     return ParseResult {
                         address: Address::from(tokenizer),


### PR DESCRIPTION
### 変更点
-  フィーチャフラグ`city-name-correction`を指定した場合のみ、郡名補完機能を有効にするようにした。
- ただし、`city-name-correction`フィーチャはデフォルトで有効になるよう設定しているため、既存と挙動が変わらないようにしている。

### 備考
- #372 
