### PR TITLE
住居番号の正規化オプション: `format_house_number()`を定義

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,11 +21,13 @@ city-name-correction = []
 
 [dependencies]
 itertools = "0.13.0"
-js-sys = "0.3.67"
 rapidfuzz = "0.5.0"
 regex = "1.10.2"
 serde.workspace = true
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = "0.3.67"
 
 [dev-dependencies]
 tokio.workspace = true

--- a/core/src/formatter.rs
+++ b/core/src/formatter.rs
@@ -1,0 +1,1 @@
+mod house_number;

--- a/core/src/formatter/house_number.rs
+++ b/core/src/formatter/house_number.rs
@@ -31,7 +31,7 @@ fn read_house_number_with_js_sys_regexp(input: &str) -> Option<(String, String)>
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::parser::read_house_number::read_house_number_with_regex;
+    use crate::formatter::house_number::read_house_number_with_regex;
 
     #[test]
     fn read_house_number_1番() {
@@ -50,7 +50,7 @@ mod tests {
 
 #[cfg(all(test, target_arch = "wasm32"))]
 mod wasm_tests {
-    use crate::parser::read_house_number::read_house_number_with_js_sys_regexp;
+    use crate::formatter::house_number::read_house_number_with_js_sys_regexp;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     wasm_bindgen_test_configure!(run_in_browser);

--- a/core/src/formatter/house_number.rs
+++ b/core/src/formatter/house_number.rs
@@ -4,13 +4,13 @@ fn format_house_number(input: &str) -> Result<String, &'static str> {
     let captures = regex::Regex::new(r"(?<block_number>\d+)\D+(?<house_number>\d+)(?<rest>.*)$")
         .unwrap()
         .captures(input)
-        .ok_or_else(|| "マッチするものがありませんでした")?;
+        .ok_or("マッチするものがありませんでした")?;
     let block_number = captures
         .name("block_number")
-        .ok_or_else(|| "街区符号を検出できませんでした")?;
+        .ok_or("街区符号を検出できませんでした")?;
     let house_number = captures
         .name("house_number")
-        .ok_or_else(|| "住居番号を検出できませんでした")?;
+        .ok_or("住居番号を検出できませんでした")?;
     let rest = match captures.name("rest") {
         Some(matched) => matched.as_str(),
         None => "",
@@ -31,15 +31,15 @@ fn format_house_number(input: &str) -> Result<String, &'static str> {
         "",
     )
     .exec(input)
-    .ok_or_else(|| "マッチするものがありませんでした")?;
+    .ok_or("マッチするものがありませんでした")?;
     let block_number = captures
         .get(1)
         .as_string()
-        .ok_or_else(|| "街区符号を検出できませんでした")?;
+        .ok_or("街区符号を検出できませんでした")?;
     let house_number = captures
         .get(2)
         .as_string()
-        .ok_or_else(|| "住居番号を検出できませんでした")?;
+        .ok_or("住居番号を検出できませんでした")?;
     let rest = captures
         .get(3)
         .as_string()

--- a/core/src/formatter/house_number.rs
+++ b/core/src/formatter/house_number.rs
@@ -1,6 +1,6 @@
 #[allow(dead_code)]
 #[cfg(not(target_arch = "wasm32"))]
-fn read_house_number_with_regex(input: &str) -> Option<(String, String)> {
+fn format_house_number(input: &str) -> Option<(String, String)> {
     let expression = regex::Regex::new(r"(?<house_number>\d+)\D*(?<rest>.*)$").unwrap();
     let captures = expression.captures(input)?;
     let house_number = if let Some(matched) = captures.name("house_number") {
@@ -31,18 +31,18 @@ fn read_house_number_with_js_sys_regexp(input: &str) -> Option<(String, String)>
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::formatter::house_number::read_house_number_with_regex;
+    use crate::formatter::house_number::format_house_number;
 
     #[test]
-    fn read_house_number_1番() {
-        let (rest, house_number) = read_house_number_with_regex("1").unwrap();
+    fn format_house_number_1番() {
+        let (rest, house_number) = format_house_number("1").unwrap();
         assert_eq!(house_number, "1番");
         assert_eq!(rest, "");
     }
 
     #[test]
-    fn read_house_number_3番2() {
-        let (rest, house_number) = read_house_number_with_regex("3-2").unwrap();
+    fn format_house_number_3番2() {
+        let (rest, house_number) = format_house_number("3-2").unwrap();
         assert_eq!(house_number, "3番");
         assert_eq!(rest, "2");
     }

--- a/core/src/formatter/house_number.rs
+++ b/core/src/formatter/house_number.rs
@@ -18,7 +18,7 @@ fn format_house_number(input: &str) -> Option<(String, String)> {
 
 #[allow(dead_code)]
 #[cfg(target_arch = "wasm32")]
-fn read_house_number_with_js_sys_regexp(input: &str) -> Option<(String, String)> {
+fn format_house_number(input: &str) -> Option<(String, String)> {
     let expression = js_sys::RegExp::new(r"(?<house_number>\d+)\D*(?<rest>.*)$", "");
     let captures = expression.exec(input)?;
     let house_number = captures.get(1).as_string()?;
@@ -50,18 +50,18 @@ mod tests {
 
 #[cfg(all(test, target_arch = "wasm32"))]
 mod wasm_tests {
-    use crate::formatter::house_number::read_house_number_with_js_sys_regexp;
+    use crate::formatter::house_number::format_house_number;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[wasm_bindgen_test]
-    fn read_house_number_with_js_sys_regexp_success() {
-        let (rest, house_number) = read_house_number_with_js_sys_regexp("1").unwrap();
+    fn format_house_number_success() {
+        let (rest, house_number) = format_house_number("1").unwrap();
         assert_eq!(house_number, "1番");
         assert_eq!(rest, "");
 
-        let (rest, house_number) = read_house_number_with_js_sys_regexp("3-2").unwrap();
+        let (rest, house_number) = format_house_number("3-2").unwrap();
         assert_eq!(house_number, "3番");
         assert_eq!(rest, "2");
     }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod api;
 mod domain;
 #[deprecated(since = "0.1.6", note = "This module will be deleted in v0.2")]
 pub mod entity;
+mod formatter;
 pub mod parser;
 mod repository;
 mod service;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -10,7 +10,6 @@ use serde::Serialize;
 
 pub(crate) mod adapter;
 pub(crate) mod filter;
-mod read_house_number;
 
 impl<T> From<Tokenizer<T>> for Address {
     fn from(value: Tokenizer<T>) -> Self {


### PR DESCRIPTION
### 変更点
- 「3-2レジデンシャルマンション101号室」のような文字列を「3番2号レジデンシャルマンション101号室」と整形する関数を定義
- `src/parser/read_house_number.rs`は不要になるので削除

### 参考リンク
- https://nlftp.mlit.go.jp/isj/dls/form/22.0a.html
- https://ja.wikipedia.org/wiki/%E4%BD%8F%E5%B1%85%E7%95%AA%E5%8F%B7#%E8%A1%97%E5%8C%BA%E6%96%B9%E5%BC%8F
- https://www.city.funabashi.lg.jp/faq/machi/juutaku/004/p010881.html

### 備考
- #92 
