### PR TITLE
住居番号の正規化オプション: `core`クレートに`format-house-number`を追加

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["rlib", "cdylib"]
 default = ["city-name-correction"]
 blocking = ["reqwest/blocking"]
 city-name-correction = []
+format-house-number = []
 
 [dependencies]
 itertools = "0.13.0"

--- a/core/src/formatter.rs
+++ b/core/src/formatter.rs
@@ -1,1 +1,1 @@
-mod house_number;
+pub(crate) mod house_number;

--- a/core/src/formatter/house_number.rs
+++ b/core/src/formatter/house_number.rs
@@ -1,6 +1,5 @@
-#[allow(dead_code)]
 #[cfg(not(target_arch = "wasm32"))]
-fn format_house_number(input: &str) -> Result<String, &'static str> {
+pub(crate) fn format_house_number(input: &str) -> Result<String, &'static str> {
     let captures = regex::Regex::new(r"(?<block_number>\d+)\D+(?<house_number>\d+)(?<rest>.*)$")
         .unwrap()
         .captures(input)
@@ -23,9 +22,8 @@ fn format_house_number(input: &str) -> Result<String, &'static str> {
     ))
 }
 
-#[allow(dead_code)]
 #[cfg(target_arch = "wasm32")]
-fn format_house_number(input: &str) -> Result<String, &'static str> {
+pub(crate) fn format_house_number(input: &str) -> Result<String, &'static str> {
     let captures = js_sys::RegExp::new(
         r"(?<block_number>\d+)\D+(?<house_number>\d+)(?<rest>.*)$",
         "",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,6 +3,7 @@
 //! ## Feature flags
 //! - `blocking`: Provide method that works synchronously
 //! - `city-name-correction`*(enabled by default)*: Enable autocorrection if ambiguous city name was typed
+//! - `format-house-number`: Enable normalization of addresses after town name
 
 #[cfg(all(target_family = "wasm", feature = "blocking"))]
 compile_error! {

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use crate::formatter::house_number::format_house_number;
 use crate::parser::adapter::orthographical_variant_adapter::{
     OrthographicalVariantAdapter, OrthographicalVariants, Variant,
 };
@@ -24,7 +25,12 @@ impl Tokenizer<CityNameFound> {
                 prefecture_name: self.prefecture_name.clone(),
                 city_name: self.city_name.clone(),
                 town_name: Some(town_name),
-                rest,
+                rest: if cfg!(feature = "format-house-number") && format_house_number(&rest).is_ok()
+                {
+                    format_house_number(&rest).unwrap()
+                } else {
+                    rest
+                },
                 _state: PhantomData::<TownNameFound>,
             });
         }
@@ -36,7 +42,12 @@ impl Tokenizer<CityNameFound> {
                 prefecture_name: self.prefecture_name.clone(),
                 city_name: self.city_name.clone(),
                 town_name: Some(town_name),
-                rest,
+                rest: if cfg!(feature = "format-house-number") && format_house_number(&rest).is_ok()
+                {
+                    format_house_number(&rest).unwrap()
+                } else {
+                    rest
+                },
                 _state: PhantomData::<TownNameFound>,
             });
         }
@@ -47,7 +58,12 @@ impl Tokenizer<CityNameFound> {
                 prefecture_name: self.prefecture_name.clone(),
                 city_name: self.city_name.clone(),
                 town_name: Some(town_name),
-                rest,
+                rest: if cfg!(feature = "format-house-number") && format_house_number(&rest).is_ok()
+                {
+                    format_house_number(&rest).unwrap()
+                } else {
+                    rest
+                },
                 _state: PhantomData::<TownNameFound>,
             });
         }


### PR DESCRIPTION
### 変更点
- フィーチャフラグ`format-house-number`が有効なとき、町名以降の住居番号、番地の表記を正規化します

### 備考
- #92 
