### PR TITLE
住居番号の正規化オプション: `wasm`クレートに`nightly`フィーチャを追加&デモページの改善

### DIFF
--- a/.github/workflows/ghpages.yaml
+++ b/.github/workflows/ghpages.yaml
@@ -19,7 +19,10 @@ jobs:
         run: wasm-pack test --firefox --headless
       - name: Build wasm module
         working-directory: wasm
-        run: wasm-pack build --target web --scope toriyama --out-name japanese_address_parser --features debug
+        run: |
+          wasm-pack build --target web --scope toriyama --out-name japanese_address_parser_debug --features debug
+          wasm-pack build --target web --scope toriyama --out-name japanese_address_parser_nightly --features nightly
+          wasm-pack build --target web --scope toriyama --out-name japanese_address_parser
       - name: Move files
         run: |
           mkdir ./publish

--- a/public/debug.html
+++ b/public/debug.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>Demo | japanese-address-parser</title>
+    <link rel="stylesheet" href="./style.css" type="text/css">
+</head>
+<body>
+<div class="ribbon">
+    <span class="ribbon-label">Debug</span>
+</div>
+<h2>YuukiToriyama/japanese-address-parser</h2>
+<p>Rust製の住所パーサーです</p>
+
+<h3>住所を入力してください</h3>
+<div class="input">
+    <input class="address" id="input" type="text" placeholder="例) 東京都中央区日本橋一丁目1-1"/>
+    <button class="button" id="exec">パースを実行</button>
+</div>
+
+<h3>処理結果</h3>
+<table class="output">
+    <thead>
+    <tr>
+        <th>入力値</th>
+        <th>ステータス</th>
+        <th>address.prefecture</th>
+        <th>address.city</th>
+        <th>address.town</th>
+        <th>address.rest</th>
+        <th>JSON</th>
+    </tr>
+    </thead>
+    <tbody id="result">
+    <tr>
+        <td><p>東京都中央区日本橋一丁目1-1</p></td>
+        <td><p>成功</p></td>
+        <td><p>東京都</p></td>
+        <td><p>中央区</p></td>
+        <td><p>日本橋一丁目</p></td>
+        <td><p>1-1</p></td>
+        <td><code>{"address":{"prefecture":"東京都","city":"中央区","town":"日本橋一丁目","rest":"1-1"}}</code>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<script src="table_util.js"></script>
+<script type="module">
+    import init, {Parser} from "../pkg/japanese_address_parser_debug.js"
+
+    const inputTextArea = document.getElementById("input")
+
+    init().then(() => {
+        document.getElementById("exec").addEventListener("click", () => {
+            const input = inputTextArea.value
+            alert("input: " + input)
+            const parser = new Parser()
+            parser.parse(input).then(result => {
+                document.getElementById("result").appendChild(
+                    createRow(input, result)
+                )
+            })
+        })
+    })
+</script>
+
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -41,7 +41,25 @@
     </tr>
     </tbody>
 </table>
-<script type="module" src="./main.js"></script>
+<script src="table_util.js"></script>
+<script type="module">
+    import init, {Parser} from "../pkg/japanese_address_parser.js"
+
+    const inputTextArea = document.getElementById("input")
+
+    init().then(() => {
+        document.getElementById("exec").addEventListener("click", () => {
+            const input = inputTextArea.value
+            alert("input: " + input)
+            const parser = new Parser()
+            parser.parse(input).then(result => {
+                document.getElementById("result").appendChild(
+                    createRow(input, result)
+                )
+            })
+        })
+    })
+</script>
 
 </body>
 </html>

--- a/public/nightly.html
+++ b/public/nightly.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>Demo | japanese-address-parser</title>
+    <link rel="stylesheet" href="./style.css" type="text/css">
+</head>
+<body>
+<div class="ribbon">
+    <span class="ribbon-label">Nightly</span>
+</div>
+<h2>YuukiToriyama/japanese-address-parser</h2>
+<p>Rust製の住所パーサーです</p>
+
+<h3>住所を入力してください</h3>
+<div class="input">
+    <input class="address" id="input" type="text" placeholder="例) 東京都中央区日本橋一丁目1-1"/>
+    <button class="button" id="exec">パースを実行</button>
+</div>
+
+<h3>処理結果</h3>
+<table class="output">
+    <thead>
+    <tr>
+        <th>入力値</th>
+        <th>ステータス</th>
+        <th>address.prefecture</th>
+        <th>address.city</th>
+        <th>address.town</th>
+        <th>address.rest</th>
+        <th>JSON</th>
+    </tr>
+    </thead>
+    <tbody id="result">
+    <tr>
+        <td><p>東京都中央区日本橋一丁目1-1</p></td>
+        <td><p>成功</p></td>
+        <td><p>東京都</p></td>
+        <td><p>中央区</p></td>
+        <td><p>日本橋一丁目</p></td>
+        <td><p>1-1</p></td>
+        <td><code>{"address":{"prefecture":"東京都","city":"中央区","town":"日本橋一丁目","rest":"1-1"}}</code>
+        </td>
+    </tr>
+    </tbody>
+</table>
+<script src="table_util.js"></script>
+<script type="module">
+    import init, {Parser} from "../pkg/japanese_address_parser_nightly.js"
+
+    const inputTextArea = document.getElementById("input")
+
+    init().then(() => {
+        document.getElementById("exec").addEventListener("click", () => {
+            const input = inputTextArea.value
+            alert("input: " + input)
+            const parser = new Parser()
+            parser.parse(input).then(result => {
+                document.getElementById("result").appendChild(
+                    createRow(input, result)
+                )
+            })
+        })
+    })
+</script>
+
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -49,3 +49,30 @@
 .output tbody tr td:hover {
     background: #8eeacd;
 }
+
+.ribbon {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 100px;
+    height: 100px;
+    overflow: hidden;
+}
+
+.ribbon-label {
+    display: inline-block;
+    position: absolute;
+    padding: 5px 0;
+    left: -18px;
+    top: 18px;
+    width: 160px;
+    text-align: center;
+    font-size: 20px;
+    line-height: 20px;
+    background: #5bc8ac;
+    color: #fff;
+    transform: rotate(45deg);
+    box-shadow: 0 0 0 2px #8eeacd;
+    border-top: dashed 2px rgba(255, 255, 255, 0.6);
+    border-bottom: dashed 2px rgba(255, 255, 255, 0.6);
+}

--- a/public/table_util.js
+++ b/public/table_util.js
@@ -1,20 +1,3 @@
-import init, {Parser} from "../pkg/japanese_address_parser.js"
-
-const inputTextArea = document.getElementById("input")
-
-init().then(() => {
-    document.getElementById("exec").addEventListener("click", () => {
-        const input = inputTextArea.value
-        alert("input: " + input)
-        const parser = new Parser()
-        parser.parse(input).then(result => {
-            document.getElementById("result").appendChild(
-                createRow(input, result)
-            )
-        })
-    })
-})
-
 const createRow = (input, parseResult) => {
     const tr = document.createElement("tr")
     tr.appendChild(createCell(`<p>${input}</p>`))

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 
 [features]
 debug = []
+nightly = ["japanese-address-parser/format-house-number"]
 
 [dependencies]
 console_error_panic_hook = "0.1.7"


### PR DESCRIPTION
### 変更点
- `wasm`クレートにフィーチャフラグ`nightly`を定義し、`nightly`を指定した場合に住居番号の正規化オプションを有効にする
- `debug`ビルド、`nightly`ビルド用のデモページを追加

### 備考
- #92 
