### PR TITLE
coreモジュールのリファクタ: `NonKanjiBlockNumberFilter`を`format_chome_with_arabic_numerals`に差し替え

### DIFF
--- a/core/src/formatter.rs
+++ b/core/src/formatter.rs
@@ -1,3 +1,4 @@
+pub(crate) mod chome_with_arabic_numerals;
 pub(crate) mod fullwidth_character;
 pub(crate) mod house_number;
 pub(crate) mod informal_town_name_notation;

--- a/core/src/formatter/chome_with_arabic_numerals.rs
+++ b/core/src/formatter/chome_with_arabic_numerals.rs
@@ -1,24 +1,24 @@
 use crate::util::converter::JapaneseNumber;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn format_chome_with_arabic_numerals(target: &str) -> Option<String> {
-    let expression = regex::Regex::new(r"\D+(?<block_number>\d+)丁目").unwrap();
-    let capture_block_number = expression.captures(target)?.name("block_number")?.as_str();
-    let block_number = capture_block_number.parse::<i8>().ok()?;
-    Some(target.replacen(
-        capture_block_number,
-        block_number.to_japanese_form()?.as_str(),
-        1,
-    ))
+pub(crate) fn format_chome_with_arabic_numerals(input: &str) -> Option<String> {
+    let chome = regex::Regex::new(r"\D+(?<chome>\d+)丁目")
+        .unwrap()
+        .captures(input)?
+        .name("chome")?
+        .as_str();
+    let chome_int = chome.parse::<i8>().ok()?;
+    Some(input.replacen(chome, chome_int.to_japanese_form()?.as_str(), 1))
 }
 
 #[cfg(target_arch = "wasm32")]
 pub(crate) fn format_chome_with_arabic_numerals(target: &str) -> Option<String> {
-    let expression = js_sys::RegExp::new(r"\D+(\d+)丁目", "");
-    let capture_block_number = expression.exec(target)?.get(1).as_string()?;
-    let block_number = capture_block_number.parse::<i8>().ok()?;
-    let block_number_in_japanese_form = block_number.to_japanese_form()?;
-    Some(target.replacen(&capture_block_number, &block_number_in_japanese_form, 1))
+    let chome = js_sys::RegExp::new(r"\D+(\d+)丁目", "")
+        .exec(target)?
+        .get(1)
+        .as_string()?;
+    let chome_int = chome.parse::<i8>().ok()?;
+    Some(target.replacen(&chome, &chome_int.to_japanese_form()?, 1))
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/core/src/formatter/chome_with_arabic_numerals.rs
+++ b/core/src/formatter/chome_with_arabic_numerals.rs
@@ -45,7 +45,7 @@ pub(crate) fn format_chome_with_arabic_numerals(input: String) -> String {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::parser::filter::non_kanji_block_number::format_chome_with_arabic_numerals;
+    use crate::formatter::chome_with_arabic_numerals::format_chome_with_arabic_numerals;
 
     #[test]
     fn filter_with_regex_成功() {
@@ -62,7 +62,7 @@ mod tests {
 
 #[cfg(all(test, target_arch = "wasm32"))]
 mod wasm_tests {
-    use crate::parser::filter::non_kanji_block_number::format_chome_with_arabic_numerals;
+    use crate::formatter::chome_with_arabic_numerals::format_chome_with_arabic_numerals;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     wasm_bindgen_test_configure!(run_in_browser);

--- a/core/src/formatter/chome_with_arabic_numerals.rs
+++ b/core/src/formatter/chome_with_arabic_numerals.rs
@@ -26,15 +26,25 @@ mod tests {
     use crate::formatter::chome_with_arabic_numerals::format_chome_with_arabic_numerals;
 
     #[test]
-    fn filter_with_regex_成功() {
-        let result = format_chome_with_arabic_numerals("銀座1丁目");
-        assert_eq!(result, Some("銀座一丁目".to_string()));
+    fn 丁目を検出できない場合() {
+        assert_eq!(format_chome_with_arabic_numerals("a丁目"), None);
     }
 
     #[test]
-    fn filter_with_regex_失敗() {
-        let result = format_chome_with_arabic_numerals("銀座１丁目");
-        assert_eq!(result, None);
+    fn 丁目をi8に変換できない場合() {
+        assert_eq!(
+            format_chome_with_arabic_numerals("銀座127丁目"),
+            Some("銀座百二十七丁目".to_string())
+        );
+        assert_eq!(format_chome_with_arabic_numerals("銀座128丁目"), None);
+    }
+
+    #[test]
+    fn 成功() {
+        assert_eq!(
+            format_chome_with_arabic_numerals("銀座1丁目"),
+            Some("銀座一丁目".to_string())
+        );
     }
 }
 
@@ -46,20 +56,24 @@ mod wasm_tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[wasm_bindgen_test]
-    fn filter_with_js_sys_regexp_input_value_will_be_filtered() {
-        let result = format_chome_with_arabic_numerals("銀座1丁目");
-        assert_eq!(result, Some("銀座一丁目".to_string()));
-
-        let result = format_chome_with_arabic_numerals("銀座1丁目1-1");
-        assert_eq!(result, Some("銀座一丁目1-1".to_string()));
+    fn chome_not_detected() {
+        assert_eq!(format_chome_with_arabic_numerals("a丁目"), None);
     }
 
     #[wasm_bindgen_test]
-    fn filter_with_js_sys_regexp_return_original_value() {
-        let result = format_chome_with_arabic_numerals("銀座A丁目");
-        assert_eq!(result, Some("銀座A丁目".to_string()));
+    fn failed_to_convert_chome_into_i8() {
+        assert_eq!(
+            format_chome_with_arabic_numerals("銀座127丁目"),
+            Some("銀座百二十七丁目".to_string())
+        );
+        assert_eq!(format_chome_with_arabic_numerals("銀座128丁目"), None);
+    }
 
-        let result = format_chome_with_arabic_numerals("銀座2147483648丁目");
-        assert_eq!(result, Some("銀座2147483648丁目".to_string()));
+    #[wasm_bindgen_test]
+    fn success() {
+        assert_eq!(
+            format_chome_with_arabic_numerals("銀座1丁目"),
+            Some("銀座一丁目".to_string())
+        );
     }
 }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -9,7 +9,6 @@ use crate::tokenizer::Tokenizer;
 use serde::Serialize;
 
 pub(crate) mod adapter;
-pub(crate) mod filter;
 
 impl<T> From<Tokenizer<T>> for Address {
     fn from(value: Tokenizer<T>) -> Self {

--- a/core/src/parser/filter.rs
+++ b/core/src/parser/filter.rs
@@ -1,3 +1,0 @@
-pub trait Filter {
-    fn apply(self, input: String) -> String;
-}

--- a/core/src/parser/filter.rs
+++ b/core/src/parser/filter.rs
@@ -1,5 +1,3 @@
-pub mod non_kanji_block_number;
-
 pub trait Filter {
     fn apply(self, input: String) -> String;
 }

--- a/core/src/parser/filter/non_kanji_block_number.rs
+++ b/core/src/parser/filter/non_kanji_block_number.rs
@@ -6,7 +6,7 @@ pub struct NonKanjiBlockNumberFilter {}
 impl Filter for NonKanjiBlockNumberFilter {
     #[cfg(not(target_arch = "wasm32"))]
     fn apply(self, input: String) -> String {
-        filter_with_regex(input)
+        format_chome_with_arabic_numerals(input)
     }
     #[cfg(target_arch = "wasm32")]
     fn apply(self, input: String) -> String {
@@ -15,7 +15,7 @@ impl Filter for NonKanjiBlockNumberFilter {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn filter_with_regex(input: String) -> String {
+fn format_chome_with_arabic_numerals(input: String) -> String {
     let expression = regex::Regex::new(r"\D+(?<block_number>\d+)丁目").unwrap();
     match expression.captures(&input) {
         Some(captures) => {
@@ -59,17 +59,17 @@ fn filter_with_js_sys_regexp(input: String) -> String {
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
-    use crate::parser::filter::non_kanji_block_number::filter_with_regex;
+    use crate::parser::filter::non_kanji_block_number::format_chome_with_arabic_numerals;
 
     #[test]
     fn filter_with_regex_成功() {
-        let result = filter_with_regex("銀座1丁目".to_string());
+        let result = format_chome_with_arabic_numerals("銀座1丁目".to_string());
         assert_eq!(result, "銀座一丁目");
     }
 
     #[test]
     fn filter_with_regex_失敗() {
-        let result = filter_with_regex("銀座１丁目".to_string());
+        let result = format_chome_with_arabic_numerals("銀座１丁目".to_string());
         assert_ne!(result, "銀座一丁目");
     }
 }

--- a/core/src/parser/filter/non_kanji_block_number.rs
+++ b/core/src/parser/filter/non_kanji_block_number.rs
@@ -1,21 +1,7 @@
-use crate::parser::filter::Filter;
 use crate::util::converter::JapaneseNumber;
 
-pub struct NonKanjiBlockNumberFilter {}
-
-impl Filter for NonKanjiBlockNumberFilter {
-    #[cfg(not(target_arch = "wasm32"))]
-    fn apply(self, input: String) -> String {
-        format_chome_with_arabic_numerals(input)
-    }
-    #[cfg(target_arch = "wasm32")]
-    fn apply(self, input: String) -> String {
-        format_chome_with_arabic_numerals(input)
-    }
-}
-
 #[cfg(not(target_arch = "wasm32"))]
-fn format_chome_with_arabic_numerals(input: String) -> String {
+pub(crate) fn format_chome_with_arabic_numerals(input: String) -> String {
     let expression = regex::Regex::new(r"\D+(?<block_number>\d+)丁目").unwrap();
     match expression.captures(&input) {
         Some(captures) => {
@@ -35,7 +21,7 @@ fn format_chome_with_arabic_numerals(input: String) -> String {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn format_chome_with_arabic_numerals(input: String) -> String {
+pub(crate) fn format_chome_with_arabic_numerals(input: String) -> String {
     let expression = js_sys::RegExp::new(r"\D+(\d+)丁目", "");
     match expression.exec(&input) {
         Some(result) => {

--- a/core/src/parser/filter/non_kanji_block_number.rs
+++ b/core/src/parser/filter/non_kanji_block_number.rs
@@ -10,7 +10,7 @@ impl Filter for NonKanjiBlockNumberFilter {
     }
     #[cfg(target_arch = "wasm32")]
     fn apply(self, input: String) -> String {
-        filter_with_js_sys_regexp(input)
+        format_chome_with_arabic_numerals(input)
     }
 }
 
@@ -35,7 +35,7 @@ fn format_chome_with_arabic_numerals(input: String) -> String {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn filter_with_js_sys_regexp(input: String) -> String {
+fn format_chome_with_arabic_numerals(input: String) -> String {
     let expression = js_sys::RegExp::new(r"\D+(\d+)丁目", "");
     match expression.exec(&input) {
         Some(result) => {
@@ -76,26 +76,26 @@ mod tests {
 
 #[cfg(all(test, target_arch = "wasm32"))]
 mod wasm_tests {
-    use crate::parser::filter::non_kanji_block_number::filter_with_js_sys_regexp;
+    use crate::parser::filter::non_kanji_block_number::format_chome_with_arabic_numerals;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[wasm_bindgen_test]
     fn filter_with_js_sys_regexp_input_value_will_be_filtered() {
-        let result = filter_with_js_sys_regexp("銀座1丁目".to_string());
+        let result = format_chome_with_arabic_numerals("銀座1丁目".to_string());
         assert_eq!(result, "銀座一丁目");
 
-        let result = filter_with_js_sys_regexp("銀座1丁目1-1".to_string());
+        let result = format_chome_with_arabic_numerals("銀座1丁目1-1".to_string());
         assert_eq!(result, "銀座一丁目1-1");
     }
 
     #[wasm_bindgen_test]
     fn filter_with_js_sys_regexp_return_original_value() {
-        let result = filter_with_js_sys_regexp("銀座A丁目".to_string());
+        let result = format_chome_with_arabic_numerals("銀座A丁目".to_string());
         assert_eq!(result, "銀座A丁目");
 
-        let result = filter_with_js_sys_regexp("銀座2147483648丁目".to_string());
+        let result = format_chome_with_arabic_numerals("銀座2147483648丁目".to_string());
         assert_eq!(result, "銀座2147483648丁目");
     }
 }

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -1,10 +1,10 @@
+use crate::formatter::chome_with_arabic_numerals::format_chome_with_arabic_numerals;
 use crate::formatter::fullwidth_character::format_fullwidth_number;
 use crate::formatter::house_number::format_house_number;
 use crate::formatter::informal_town_name_notation::format_informal_town_name_notation;
 use crate::parser::adapter::orthographical_variant_adapter::{
     OrthographicalVariantAdapter, OrthographicalVariants, Variant,
 };
-use crate::parser::filter::non_kanji_block_number::format_chome_with_arabic_numerals;
 use crate::tokenizer::{CityNameFound, End, Tokenizer, TownNameFound};
 use std::marker::PhantomData;
 

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -15,7 +15,7 @@ impl Tokenizer<CityNameFound> {
     ) -> Result<Tokenizer<TownNameFound>, Tokenizer<End>> {
         let mut rest = format_fullwidth_number(&self.rest);
         if rest.contains("丁目") {
-            rest = format_chome_with_arabic_numerals(rest)
+            rest = format_chome_with_arabic_numerals(&rest).unwrap_or(rest);
         }
         if let Some((town_name, rest)) = find_town(&rest, &candidates) {
             return Ok(Tokenizer {

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -4,8 +4,7 @@ use crate::formatter::informal_town_name_notation::format_informal_town_name_not
 use crate::parser::adapter::orthographical_variant_adapter::{
     OrthographicalVariantAdapter, OrthographicalVariants, Variant,
 };
-use crate::parser::filter::non_kanji_block_number::NonKanjiBlockNumberFilter;
-use crate::parser::filter::Filter;
+use crate::parser::filter::non_kanji_block_number::format_chome_with_arabic_numerals;
 use crate::tokenizer::{CityNameFound, End, Tokenizer, TownNameFound};
 use std::marker::PhantomData;
 
@@ -16,7 +15,7 @@ impl Tokenizer<CityNameFound> {
     ) -> Result<Tokenizer<TownNameFound>, Tokenizer<End>> {
         let mut rest = format_fullwidth_number(&self.rest);
         if rest.contains("丁目") {
-            rest = NonKanjiBlockNumberFilter {}.apply(rest);
+            rest = format_chome_with_arabic_numerals(rest)
         }
         if let Some((town_name, rest)) = find_town(&rest, &candidates) {
             return Ok(Tokenizer {


### PR DESCRIPTION
### 変更点
- 新たに`format_chome_with_arabic_numerals()`を定義し、`NonKanjiBlockNumberFilter {}.apply()`を使用していた箇所を置き換えた。
- `NonKanjiBlockNumberFilter`は不要になるので削除。

### 備考
- #384 
