### PR TITLE
coreモジュールのリファクタ: wasm32向けの関数とそれ以外のアーキテクチャ向けの関数の定義をまとめた

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -26,8 +26,6 @@ rapidfuzz = "0.5.0"
 regex = "1.10.2"
 serde.workspace = true
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls"] }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3.67"
 
 [dev-dependencies]

--- a/core/src/formatter/chome_with_arabic_numerals.rs
+++ b/core/src/formatter/chome_with_arabic_numerals.rs
@@ -1,24 +1,21 @@
 use crate::util::converter::JapaneseNumber;
 
-#[cfg(not(target_arch = "wasm32"))]
-pub(crate) fn format_chome_with_arabic_numerals(input: &str) -> Option<String> {
-    let chome = regex::Regex::new(r"\D+(?<chome>\d+)丁目")
-        .unwrap()
-        .captures(input)?
-        .name("chome")?
-        .as_str();
-    let chome_int = chome.parse::<i8>().ok()?;
-    Some(input.replacen(chome, chome_int.to_japanese_form()?.as_str(), 1))
-}
-
-#[cfg(target_arch = "wasm32")]
 pub(crate) fn format_chome_with_arabic_numerals(target: &str) -> Option<String> {
-    let chome = js_sys::RegExp::new(r"\D+(\d+)丁目", "")
-        .exec(target)?
-        .get(1)
-        .as_string()?;
+    let chome = if cfg!(target_arch = "wasm32") {
+        js_sys::RegExp::new(r"\D+(\d+)丁目", "")
+            .exec(target)?
+            .get(1)
+            .as_string()?
+    } else {
+        regex::Regex::new(r"\D+(?<chome>\d+)丁目")
+            .unwrap()
+            .captures(target)?
+            .name("chome")?
+            .as_str()
+            .to_string()
+    };
     let chome_int = chome.parse::<i8>().ok()?;
-    Some(target.replacen(&chome, &chome_int.to_japanese_form()?, 1))
+    Some(target.replacen(&chome, chome_int.to_japanese_form()?.as_str(), 1))
 }
 
 #[cfg(all(test, not(target_arch = "wasm32")))]

--- a/core/src/formatter/informal_town_name_notation.rs
+++ b/core/src/formatter/informal_town_name_notation.rs
@@ -99,7 +99,7 @@ mod wasm_tests {
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[wasm_bindgen_test]
-    fn own_name_not_detected() {
+    fn town_name_not_detected() {
         assert_eq!(format_informal_town_name_notation("1-1-1"), None);
     }
 

--- a/core/src/formatter/informal_town_name_notation.rs
+++ b/core/src/formatter/informal_town_name_notation.rs
@@ -6,8 +6,7 @@ pub(crate) fn format_informal_town_name_notation(target: &str) -> Option<String>
         let captures = js_sys::RegExp::new(
             r"^(\D+)(\d+)[\u002D\u2010\u2011\u2012\u2013\u2014\u2015\u2212\u30FC\uFF0D\uFF70]*(.*)$",
             "",
-        )
-            .exec(target)?;
+        ).exec(target)?;
         (
             captures.get(1).as_string()?,
             captures.get(2).as_string()?.parse::<i8>().ok()?,
@@ -16,9 +15,7 @@ pub(crate) fn format_informal_town_name_notation(target: &str) -> Option<String>
     } else {
         let captures = regex::Regex::new(
             r"^(?<town_name>\D+)(?<chome>\d+)[\u002D\u2010\u2011\u2012\u2013\u2014\u2015\u2212\u30FC\uFF0D\uFF70]*(?<rest>.*)$",
-        )
-            .unwrap()
-            .captures(target)?;
+        ).unwrap().captures(target)?;
         (
             captures.name("town_name")?.as_str().to_string(),
             captures.name("chome")?.as_str().parse::<i8>().ok()?,


### PR DESCRIPTION
### 変更点
- 関数の出し分けを`#[cfg(target_arch = "wasm32")]`および`#[cfg(not(target_arch = "wasm32"))]`というアトリビューションを用いて実現していたが、重複コードが増えてしまうので、`if cfg!(target_arch = "wasm32") {} else {}`で書き直した。
  - `format_chome_with_arabic_numerals()`
  - `format_informal_town_name_notation()`
- `format_house_number()`も同様にリファクタ可能だが、実装の多様性を残すためにそのままにした。

### 備考
- #384 
