### PR TITLE
表記ゆれアダプタのリファクタ: `OrthographicVariantAdapter`に対するベンチマークテストを作成

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,10 @@ blocking = ["reqwest/blocking"]
 city-name-correction = []
 format-house-number = []
 
+[[bench]]
+name = "core_benchmark"
+harness = false
+
 [dependencies]
 itertools = "0.13.0"
 rapidfuzz = "0.5.0"
@@ -29,6 +33,7 @@ reqwest = { version = "0.12.5", default-features = false, features = ["json", "r
 js-sys = "0.3.67"
 
 [dev-dependencies]
+criterion = { version = "0.5.1", features = ["html_reports"] }
 tokio.workspace = true
 wasm-bindgen-test = { workspace = true }
 

--- a/core/benches/core_benchmark.rs
+++ b/core/benches/core_benchmark.rs
@@ -1,1 +1,7 @@
-extern crate criterion;
+mod orthographical_variant_adapter;
+
+use crate::orthographical_variant_adapter::bench_orthographical_variant_adapter;
+use criterion::{criterion_group, criterion_main};
+
+criterion_group!(benches, bench_orthographical_variant_adapter);
+criterion_main!(benches);

--- a/core/benches/core_benchmark.rs
+++ b/core/benches/core_benchmark.rs
@@ -1,0 +1,1 @@
+extern crate criterion;

--- a/core/benches/orthographical_variant_adapter.rs
+++ b/core/benches/orthographical_variant_adapter.rs
@@ -1,0 +1,48 @@
+use criterion::measurement::WallTime;
+use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion};
+use japanese_address_parser::parser::adapter::orthographical_variant_adapter::{
+    OrthographicalVariantAdapter, OrthographicalVariants, Variant,
+};
+
+pub fn bench_orthographical_variant_adapter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("orthographical_variant_adapter");
+    add_tests(
+        &mut group,
+        TestSuite {
+            expected: "松ケ崎東池ノ内町",
+            inputs: vec![
+                "松が崎東池ノ内町",
+                "松ヶ崎東池ノ内町",
+                "松ケ﨑東池ノ内町",
+                "松ケ﨑東池の内町",
+                "松ガ﨑東池の内町",
+            ],
+            variants_to_be_used: vec![Variant::ケ, Variant::崎, Variant::の],
+        },
+    );
+    group.finish();
+}
+
+fn add_tests(group: &mut BenchmarkGroup<WallTime>, test_suite: TestSuite) {
+    for input in test_suite.inputs {
+        let benchmark_id = BenchmarkId::new(test_suite.expected, input);
+        group.bench_with_input(benchmark_id, input, |b, input| {
+            b.iter_batched(
+                || OrthographicalVariantAdapter {
+                    variant_list: test_suite.variants_to_be_used.clone(),
+                },
+                |adapter| {
+                    let (region_name, _) = adapter.apply(input, test_suite.expected).unwrap();
+                    assert_eq!(region_name, test_suite.expected);
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+}
+
+struct TestSuite {
+    expected: &'static str,
+    inputs: Vec<&'static str>,
+    variants_to_be_used: Vec<Variant>,
+}

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -8,7 +8,7 @@ use crate::domain::geolonia::error::{Error, ParseErrorKind};
 use crate::tokenizer::Tokenizer;
 use serde::Serialize;
 
-pub(crate) mod adapter;
+pub mod adapter;
 
 impl<T> From<Tokenizer<T>> for Address {
     fn from(value: Tokenizer<T>) -> Self {


### PR DESCRIPTION
### 変更点
- `core`に対して`criterion`を導入し、ベンチマークテストを実行できるようにした。
- `OrthographicVariantAdapter`に対していくつかのケースを追加した。

### 備考
- ベンチマークテストから`parser::adapter`が見えなかったため、仕方なくpublicにしている。
- PRごとにベンチマークの結果を前後比較できるようにしたいが、次のPRで対応する。
