### PR TITLE
表記ゆれアダプタのリファクタ: PR作成時にベンチマークテストが走るように設定

### DIFF
--- a/.github/workflows/code-quality-check.yaml
+++ b/.github/workflows/code-quality-check.yaml
@@ -27,3 +27,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branchName: ${{ github.base_ref }}
           cwd: 'core'
+          benchName: 'core_benchmark'

--- a/.github/workflows/code-quality-check.yaml
+++ b/.github/workflows/code-quality-check.yaml
@@ -21,3 +21,8 @@ jobs:
           reporter: 'github-pr-review'
           filter_mode: 'nofilter'
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run benchmark
+        uses: boa-dev/criterion-compare-action@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branchName: ${{ github.base_ref }}

--- a/.github/workflows/code-quality-check.yaml
+++ b/.github/workflows/code-quality-check.yaml
@@ -2,6 +2,9 @@ name: Code quality check
 
 on:
   pull_request:
+    paths:
+      - '**.rs'
+      - '**/Cargo.toml'
 
 jobs:
   build:

--- a/.github/workflows/code-quality-check.yaml
+++ b/.github/workflows/code-quality-check.yaml
@@ -26,3 +26,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branchName: ${{ github.base_ref }}
+          cwd: 'core'

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.73.0"
 
 [lib]
 crate-type = ["rlib", "cdylib"]
+bench = false
 
 [features]
 default = ["city-name-correction"]


### PR DESCRIPTION
### 変更点
- #396 
- `code-quality-check.yaml`にベンチマークを実行するステップを追加した。

### 備考
- https://github.com/boa-dev/criterion-compare-action を使用したが、 https://github.com/benchmark-action/github-action-benchmark に差し替えるかもしれない。
