### PR TITLE
表記ゆれアダプタのリファクタ: 処理を整理

### DIFF
--- a/core/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/core/src/parser/adapter/orthographical_variant_adapter.rs
@@ -99,7 +99,7 @@ impl OrthographicalVariantAdapter {
                             ));
                         } else {
                             // マッチしなければsemi_candidatesに置き換え後の文字列をpush
-                            semi_candidates.push(edited_region_name.clone());
+                            semi_candidates.push(edited_region_name);
                         };
                     }
                 }

--- a/core/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/core/src/parser/adapter/orthographical_variant_adapter.rs
@@ -66,21 +66,20 @@ pub struct OrthographicalVariantAdapter {
 
 impl OrthographicalVariantAdapter {
     pub fn apply(self, input: &str, region_name: &str) -> Option<(String, String)> {
-        let mut filtered_variant_list: Vec<Variant> = vec![];
         // 必要なパターンのみを選別する
-        for variant in self.variant_list.clone() {
-            if variant.iter().any(|character| input.contains(character)) {
-                filtered_variant_list.push(variant);
-            }
-        }
-        if filtered_variant_list.is_empty() {
+        let variant_list: Vec<&Variant> = self
+            .variant_list
+            .iter()
+            .filter(|v| v.iter().any(|c| input.contains(c)))
+            .collect();
+        if variant_list.is_empty() {
             return None;
         }
 
         // マッチ候補を容れておくためのVector
         let mut candidates: Vec<String> = vec![region_name.to_string()];
         // パターンを一つづつ検証していく
-        for variant in filtered_variant_list {
+        for variant in variant_list {
             let mut semi_candidates: Vec<String> = vec![];
             // variantから順列を作成
             // ["ケ", "ヶ", "が"] -> (ケ, ヶ), (ケ, が), (ヶ, ケ), (ヶ, が), (が, ケ), (が, ヶ)

--- a/core/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/core/src/parser/adapter/orthographical_variant_adapter.rs
@@ -84,24 +84,22 @@ impl OrthographicalVariantAdapter {
             // variantから順列を作成
             // ["ケ", "ヶ", "が"] -> (ケ, ヶ), (ケ, が), (ヶ, ケ), (ヶ, が), (が, ケ), (が, ヶ)
             for permutation in variant.iter().permutations(2) {
-                for candidate in &candidates {
+                for candidate in candidates.iter().filter(|c| c.contains(permutation[0])) {
                     // マッチ候補の中でパターンに引っかかるものがあれば文字を置き換えてマッチを試す
-                    if candidate.contains(permutation[0]) {
-                        let edited_region_name = candidate.replace(permutation[0], permutation[1]);
-                        if input.starts_with(&edited_region_name) {
-                            // マッチすれば早期リターン
-                            return Some((
-                                region_name.to_string(),
-                                input
-                                    .chars()
-                                    .skip(edited_region_name.chars().count())
-                                    .collect(),
-                            ));
-                        } else {
-                            // マッチしなければsemi_candidatesに置き換え後の文字列をpush
-                            semi_candidates.push(edited_region_name);
-                        };
-                    }
+                    let edited_region_name = candidate.replace(permutation[0], permutation[1]);
+                    if input.starts_with(&edited_region_name) {
+                        // マッチすれば早期リターン
+                        return Some((
+                            region_name.to_string(),
+                            input
+                                .chars()
+                                .skip(edited_region_name.chars().count())
+                                .collect(),
+                        ));
+                    } else {
+                        // マッチしなければsemi_candidatesに置き換え後の文字列をpush
+                        semi_candidates.push(edited_region_name);
+                    };
                 }
             }
             candidates = semi_candidates;


### PR DESCRIPTION
### 変更点
- #396 
- `OrthographicalVariantAdapter`について、コードの意味を変えない範囲でリファクタを行なった
  - ミュータブルな変数を使用しないようにした
  - 不要なcloneを削除
  - ネストの簡略化
