### PR TITLE
不要な空白の除却: wasmクレートのnightlyフィーチャでホワイトスペースの除却を有効化

### DIFF
--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [features]
 debug = []
-nightly = ["japanese-address-parser/format-house-number"]
+nightly = ["japanese-address-parser/format-house-number", "japanese-address-parser/eliminate-whitespaces"]
 
 [dependencies]
 console_error_panic_hook = "0.1.7"


### PR DESCRIPTION
### 変更点
- #410 
- ホワイトスペースの除去機能を[wasmクレートのnightlyビルド](https://yuukitoriyama.github.io/japanese-address-parser/public/nightly.html)で試せるようにした。
