### PR TITLE
不要な空白の除却をrelease/v0.1.14にマージ

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,7 @@ default = ["city-name-correction"]
 blocking = ["reqwest/blocking"]
 city-name-correction = []
 format-house-number = []
+eliminate-whitespaces = []
 
 [dependencies]
 itertools = "0.13.0"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,7 @@
 //! - `blocking`: Provide method that works synchronously
 //! - `city-name-correction`*(enabled by default)*: Enable autocorrection if ambiguous city name was typed
 //! - `format-house-number`: Enable normalization of addresses after town name
+//! - `eliminate-whitespaces`*(experimental)*: Enable elimination of whitespaces from given text
 
 #[cfg(all(target_family = "wasm", feature = "blocking"))]
 compile_error! {

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -60,7 +60,11 @@ impl Tokenizer<Init> {
             prefecture_name: None,
             city_name: None,
             town_name: None,
-            rest: input.strip_variation_selectors(),
+            rest: if cfg!(feature = "eliminate-whitespaces") {
+                input.strip_variation_selectors().strip_whitespaces()
+            } else {
+                input.strip_variation_selectors()
+            },
             _state: PhantomData,
         }
     }
@@ -115,6 +119,17 @@ mod tests {
         assert_eq!(tokenizer.city_name, None);
         assert_eq!(tokenizer.town_name, None);
         assert_eq!(tokenizer.rest, "東京都葛飾区立石5-13-1")
+    }
+
+    #[test]
+    #[cfg(feature = "eliminate-whitespaces")]
+    fn new_ホワイトスペース除却() {
+        let tokenizer = Tokenizer::new("東京都 目黒区 下目黒 4‐1‐1");
+        assert_eq!(tokenizer.input, "東京都 目黒区 下目黒 4‐1‐1");
+        assert_eq!(tokenizer.prefecture_name, None);
+        assert_eq!(tokenizer.city_name, None);
+        assert_eq!(tokenizer.town_name, None);
+        assert_eq!(tokenizer.rest, "東京都目黒区下目黒4‐1‐1")
     }
 
     #[test]

--- a/core/src/util/extension.rs
+++ b/core/src/util/extension.rs
@@ -10,10 +10,15 @@ impl CharExt for char {
 }
 
 pub(crate) trait StrExt {
+    fn strip_whitespaces(&self) -> String;
     fn strip_variation_selectors(&self) -> String;
 }
 
 impl StrExt for str {
+    /// 文字列からホワイトスペースを取り除きます
+    fn strip_whitespaces(&self) -> String {
+        self.chars().filter(|c| !c.is_whitespace()).collect()
+    }
     /// 文字列から異字体セレクタを取り除きます
     fn strip_variation_selectors(&self) -> String {
         self.chars()
@@ -58,5 +63,17 @@ mod tests {
         let variant = "\u{8328}\u{E0100}\u{57CE}";
         assert_ne!(normal, variant);
         assert_eq!(normal, variant.strip_variation_selectors());
+    }
+
+    #[test]
+    fn strip_whitespaces() {
+        assert_eq!("四谷1丁目".strip_whitespaces(), "四谷1丁目");
+        assert_eq!("四谷 1丁目".strip_whitespaces(), "四谷1丁目");
+        assert_eq!("四谷  1丁目".strip_whitespaces(), "四谷1丁目");
+        assert_eq!("四谷 1 丁 目".strip_whitespaces(), "四谷1丁目");
+        assert_eq!("神田３丁目".strip_whitespaces(), "神田３丁目");
+        assert_eq!("神田　３丁目".strip_whitespaces(), "神田３丁目");
+        assert_eq!("神田　　３丁目".strip_whitespaces(), "神田３丁目");
+        assert_eq!("神田　３　丁目".strip_whitespaces(), "神田３丁目");
     }
 }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [features]
 debug = []
-nightly = ["japanese-address-parser/format-house-number"]
+nightly = ["japanese-address-parser/format-house-number", "japanese-address-parser/eliminate-whitespaces"]
 
 [dependencies]
 console_error_panic_hook = "0.1.7"


### PR DESCRIPTION
### 変更点
- fix #410 
- 「東京都　中野区　中野　4-11-19」のような文字列が入力された場合、ホワイトスペースを取り除き「東京都中野区中野4-11-19」として扱う機能を試験的機能として導入しました。
- デフォルトでは無効になっており、フィーチャフラグ`eliminate-whitespaces`を指定した場合に有効になります。

### 備考
- 試験的機能のため、次のメジャー/マイナーバージョンアップで廃止される可能性があります
