### PR TITLE
chimei-ruiju.orgへの対応: repository層のリファクタ

### DIFF
--- a/core/src/repository/chimei_ruiju/city.rs
+++ b/core/src/repository/chimei_ruiju/city.rs
@@ -54,7 +54,7 @@ mod async_tests {
 #[cfg(feature = "blocking")]
 impl CityMasterRepository {
     pub fn get_blocking(
-        &self,
+        api_service: &ChimeiRuijuApiService,
         prefecture: &Prefecture,
         city_name: &str,
     ) -> Result<CityMaster, ApiError> {
@@ -63,7 +63,7 @@ impl CityMasterRepository {
             prefecture.name_en(),
             city_name
         );
-        self.api_service.get_blocking::<CityMaster>(&url)
+        api_service.get_blocking::<CityMaster>(&url)
     }
 }
 
@@ -75,10 +75,9 @@ mod blocking_tests {
 
     #[test]
     fn 埼玉県比企郡嵐山町() {
-        let repository = CityMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository.get_blocking(&Prefecture::SAITAMA, "比企郡嵐山町");
+        let api_service = ChimeiRuijuApiService {};
+        let result =
+            CityMasterRepository::get_blocking(&api_service, &Prefecture::SAITAMA, "比企郡嵐山町");
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "比企郡嵐山町");
@@ -112,10 +111,9 @@ mod blocking_tests {
 
     #[test]
     fn 岐阜県不破郡関ケ原町() {
-        let repository = CityMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository.get_blocking(&Prefecture::GIFU, "不破郡関ケ原町");
+        let api_service = ChimeiRuijuApiService {};
+        let result =
+            CityMasterRepository::get_blocking(&api_service, &Prefecture::GIFU, "不破郡関ケ原町");
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "不破郡関ケ原町");

--- a/core/src/repository/chimei_ruiju/city.rs
+++ b/core/src/repository/chimei_ruiju/city.rs
@@ -9,7 +9,7 @@ pub struct CityMasterRepository {
 
 impl CityMasterRepository {
     pub async fn get(
-        &self,
+        api_service: &ChimeiRuijuApiService,
         prefecture: &Prefecture,
         city_name: &str,
     ) -> Result<CityMaster, ApiError> {
@@ -18,7 +18,7 @@ impl CityMasterRepository {
             prefecture.name_en(),
             city_name
         );
-        self.api_service.get::<CityMaster>(&url).await
+        api_service.get::<CityMaster>(&url).await
     }
 }
 
@@ -30,10 +30,9 @@ mod async_tests {
 
     #[tokio::test]
     async fn 神奈川県愛甲郡清川村() {
-        let repository = CityMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository.get(&Prefecture::KANAGAWA, "愛甲郡清川村").await;
+        let api_service = ChimeiRuijuApiService {};
+        let result =
+            CityMasterRepository::get(&api_service, &Prefecture::KANAGAWA, "愛甲郡清川村").await;
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "愛甲郡清川村");
@@ -42,10 +41,9 @@ mod async_tests {
 
     #[tokio::test]
     async fn 京都府乙訓郡大山崎町() {
-        let repository = CityMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository.get(&Prefecture::KYOTO, "乙訓郡大山崎町").await;
+        let api_service = ChimeiRuijuApiService {};
+        let result =
+            CityMasterRepository::get(&api_service, &Prefecture::KYOTO, "乙訓郡大山崎町").await;
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "乙訓郡大山崎町");

--- a/core/src/repository/chimei_ruiju/city.rs
+++ b/core/src/repository/chimei_ruiju/city.rs
@@ -3,9 +3,7 @@ use crate::domain::chimei_ruiju::error::ApiError;
 use crate::service::chimei_ruiju::ChimeiRuijuApiService;
 use jisx0401::Prefecture;
 
-pub struct CityMasterRepository {
-    api_service: ChimeiRuijuApiService,
-}
+pub struct CityMasterRepository {}
 
 impl CityMasterRepository {
     pub async fn get(

--- a/core/src/repository/chimei_ruiju/prefecture.rs
+++ b/core/src/repository/chimei_ruiju/prefecture.rs
@@ -8,12 +8,15 @@ pub struct PrefectureMasterRepository {
 }
 
 impl PrefectureMasterRepository {
-    pub async fn get(&self, prefecture: &Prefecture) -> Result<PrefectureMaster, ApiError> {
+    pub async fn get(
+        api_service: &ChimeiRuijuApiService,
+        prefecture: &Prefecture,
+    ) -> Result<PrefectureMaster, ApiError> {
         let url = format!(
             "https://{}.chimei-ruiju.org/master.json",
             prefecture.name_en()
         );
-        self.api_service.get::<PrefectureMaster>(&url).await
+        api_service.get::<PrefectureMaster>(&url).await
     }
 }
 
@@ -25,10 +28,8 @@ mod async_tests {
 
     #[tokio::test]
     async fn 東京都() {
-        let repository = PrefectureMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository.get(&Prefecture::TOKYO).await;
+        let api_service = ChimeiRuijuApiService {};
+        let result = PrefectureMasterRepository::get(&api_service, &Prefecture::TOKYO).await;
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "東京都");
@@ -103,10 +104,8 @@ mod async_tests {
 
     #[tokio::test]
     async fn 富山県() {
-        let repository = PrefectureMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository.get(&Prefecture::TOYAMA).await;
+        let api_service = ChimeiRuijuApiService {};
+        let result = PrefectureMasterRepository::get(&api_service, &Prefecture::TOYAMA).await;
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "富山県");

--- a/core/src/repository/chimei_ruiju/prefecture.rs
+++ b/core/src/repository/chimei_ruiju/prefecture.rs
@@ -134,12 +134,15 @@ mod async_tests {
 
 #[cfg(feature = "blocking")]
 impl PrefectureMasterRepository {
-    pub fn get_blocking(&self, prefecture: Prefecture) -> Result<PrefectureMaster, ApiError> {
+    pub fn get_blocking(
+        api_service: &ChimeiRuijuApiService,
+        prefecture: Prefecture,
+    ) -> Result<PrefectureMaster, ApiError> {
         let url = format!(
             "https://{}.chimei-ruiju.org/master.json",
             prefecture.name_en()
         );
-        self.api_service.get_blocking::<PrefectureMaster>(&url)
+        api_service.get_blocking::<PrefectureMaster>(&url)
     }
 }
 
@@ -151,10 +154,8 @@ mod blocking_tests {
 
     #[tokio::test]
     async fn 高知県() {
-        let repository = PrefectureMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository.get(&Prefecture::KOCHI).await;
+        let api_service = ChimeiRuijuApiService {};
+        let result = PrefectureMasterRepository::get(&api_service, &Prefecture::KOCHI).await;
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "高知県");
@@ -201,10 +202,8 @@ mod blocking_tests {
 
     #[tokio::test]
     async fn 佐賀県() {
-        let repository = PrefectureMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository.get(&Prefecture::SAGA).await;
+        let api_service = ChimeiRuijuApiService {};
+        let result = PrefectureMasterRepository::get(&api_service, &Prefecture::SAGA).await;
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "佐賀県");

--- a/core/src/repository/chimei_ruiju/prefecture.rs
+++ b/core/src/repository/chimei_ruiju/prefecture.rs
@@ -3,9 +3,7 @@ use crate::domain::chimei_ruiju::error::ApiError;
 use crate::service::chimei_ruiju::ChimeiRuijuApiService;
 use jisx0401::Prefecture;
 
-pub struct PrefectureMasterRepository {
-    api_service: ChimeiRuijuApiService,
-}
+pub struct PrefectureMasterRepository {}
 
 impl PrefectureMasterRepository {
     pub async fn get(

--- a/core/src/repository/chimei_ruiju/town.rs
+++ b/core/src/repository/chimei_ruiju/town.rs
@@ -10,7 +10,7 @@ pub struct TownMasterRepository {
 
 impl TownMasterRepository {
     pub async fn get(
-        &self,
+        api_service: &ChimeiRuijuApiService,
         prefecture: &Prefecture,
         city_name: &str,
         town_name: &str,
@@ -21,7 +21,7 @@ impl TownMasterRepository {
             city_name,
             town_name
         );
-        self.api_service.get::<TownMaster>(&url).await
+        api_service.get::<TownMaster>(&url).await
     }
 }
 
@@ -33,12 +33,9 @@ mod async_tests {
 
     #[tokio::test]
     async fn 東京都千代田区千代田() {
-        let repository = TownMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository
-            .get(&Prefecture::TOKYO, "千代田区", "千代田")
-            .await;
+        let api_service = ChimeiRuijuApiService {};
+        let result =
+            TownMasterRepository::get(&api_service, &Prefecture::TOKYO, "千代田区", "千代田").await;
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "千代田");

--- a/core/src/repository/chimei_ruiju/town.rs
+++ b/core/src/repository/chimei_ruiju/town.rs
@@ -4,9 +4,7 @@ use crate::service::chimei_ruiju::ChimeiRuijuApiService;
 use jisx0401::Prefecture;
 
 #[allow(dead_code)]
-pub struct TownMasterRepository {
-    api_service: ChimeiRuijuApiService,
-}
+pub struct TownMasterRepository {}
 
 impl TownMasterRepository {
     pub async fn get(

--- a/core/src/repository/chimei_ruiju/town.rs
+++ b/core/src/repository/chimei_ruiju/town.rs
@@ -45,7 +45,7 @@ mod async_tests {
 #[cfg(feature = "blocking")]
 impl TownMasterRepository {
     pub fn get_blocking(
-        &self,
+        api_service: &ChimeiRuijuApiService,
         prefecture: &Prefecture,
         city_name: &str,
         town_name: &str,
@@ -56,7 +56,7 @@ impl TownMasterRepository {
             city_name,
             town_name
         );
-        self.api_service.get_blocking::<TownMaster>(&url)
+        api_service.get_blocking::<TownMaster>(&url)
     }
 }
 
@@ -68,10 +68,13 @@ mod blocking_tests {
 
     #[test]
     fn 京都府京都市伏見区魚屋町() {
-        let repository = TownMasterRepository {
-            api_service: ChimeiRuijuApiService {},
-        };
-        let result = repository.get_blocking(&Prefecture::KYOTO, "京都市伏見区", "魚屋町");
+        let api_service = ChimeiRuijuApiService {};
+        let result = TownMasterRepository::get_blocking(
+            &api_service,
+            &Prefecture::KYOTO,
+            "京都市伏見区",
+            "魚屋町",
+        );
         assert!(result.is_ok());
         let entity = result.unwrap();
         assert_eq!(entity.name, "魚屋町");


### PR DESCRIPTION
### 変更点
- #426 
- `PrefectureMasterRepositoy`, `CityMasterRepository`, `TownMasterRepository`のメソッドをそれぞれ関連関数に変更しました。
- それぞれで`ChimeiRuijuApiService`を初期化するのではなく、別の箇所で初期化したインスタンスを参照として渡す作りにしたい意図があります。

以下のようなコードを考えています。

```rust
pub struct Parser {
    api_service: LazyCell<ChimeiRuijuApiService>,
}

impl Default for Parser {
    fn default() -> Self {
        Self {
            api_service: LazyCell::new(|| ChimeiRuijuApiService {}),
        }
    }
}

impl Parser {
    pub async fn parse<T: Into<String>>(&self, address: T) -> ParseResult {
        // (中略)
        let prefecture_master = match PrefectureMasterRepository::get(&self.api_service, &Prefecture::Hoge).await {
                Err(_error) => todo!
                Ok(result) => result,
        };
        // (中略)
        let city_master = match CityMasterRepository::get(&self.api_service, &Prefecture::Hoge, "piyo市").await {
                Err(_error) => todo!
                Ok(result) => result,
        };
        // (中略)
        let town_master = match CityMasterRepository::get(&self.api_service, &Prefecture::Hoge, "piyo市", "fuga町").await {
                Err(_error) => todo!
                Ok(result) => result,
        };
        // (中略)
        ParseResult {
            address: Address::from(tokenizer),
            error: None,
        }
    }
}
```
