### PR TITLE
regexのフィーチャフラグ無効化: `std`と`unicode-perl`以外のフィーチャを無効化

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ eliminate-whitespaces = []
 [dependencies]
 itertools = "0.13.0"
 rapidfuzz = "0.5.0"
-regex = "1.10.2"
+regex = { version = "1.10.6", default-features = false, features = ["std"] }
 serde.workspace = true
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls"] }
 js-sys = "0.3.67"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ eliminate-whitespaces = []
 [dependencies]
 itertools = "0.13.0"
 rapidfuzz = "0.5.0"
-regex = { version = "1.10.6", default-features = false, features = ["std"] }
+regex = { version = "1.10.6", default-features = false, features = ["std", "unicode-perl"] }
 serde.workspace = true
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls"] }
 js-sys = "0.3.67"


### PR DESCRIPTION
### 変更点
- `default-features = false`を設定し、デフォルトフィーチャを無効化した
- ただ、公式ドキュメントに`std`は指定したほうがよいと書かれていたため、`std`だけは別途指定した
- また、正規表現`\D`の使用に必要なため、`unicode-perl`フィーチャも別途指定した

### その他
- #378 