### PR TITLE
regexのフィーチャフラグ無効化をrelease/v0.1.16にマージ

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ eliminate-whitespaces = []
 [dependencies]
 itertools = "0.13.0"
 rapidfuzz = "0.5.0"
-regex = "1.10.2"
+regex = { version = "1.10.6", default-features = false, features = ["std"] }
 serde.workspace = true
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls"] }
 js-sys = "0.3.67"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,7 +24,7 @@ eliminate-whitespaces = []
 [dependencies]
 itertools = "0.13.0"
 rapidfuzz = "0.5.0"
-regex = { version = "1.10.6", default-features = false, features = ["std"] }
+regex = { version = "1.10.6", default-features = false, features = ["std", "unicode-perl"] }
 serde.workspace = true
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls"] }
 js-sys = "0.3.67"


### PR DESCRIPTION
### 変更点
- fix #378 
- `regex`のデフォルトフィーチャを無効化し、必要な`std`,`unicode-perl`フィーチャのみを有効化しました
- 破壊的な変更はありません