### PR TITLE
Tokenizerのリファクタ: `Token`を定義

### DIFF
--- a/core/src/domain.rs
+++ b/core/src/domain.rs
@@ -1,1 +1,2 @@
+pub mod common;
 pub mod geolonia;

--- a/core/src/domain/common.rs
+++ b/core/src/domain/common.rs
@@ -1,0 +1,1 @@
+pub mod latlng;

--- a/core/src/domain/common.rs
+++ b/core/src/domain/common.rs
@@ -1,1 +1,2 @@
 pub mod latlng;
+pub mod token;

--- a/core/src/domain/common/latlng.rs
+++ b/core/src/domain/common/latlng.rs
@@ -1,0 +1,7 @@
+#[derive(Debug)]
+pub struct LatLng {
+    /// 緯度
+    latitude: f64,
+    /// 軽度
+    longitude: f64,
+}

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -7,22 +7,22 @@ pub enum Token {
     Rest(Rest),
 }
 
-struct Prefecture {
+pub(crate) struct Prefecture {
     prefecture_name: String,
     representative_point: Option<LatLng>,
 }
 
-struct City {
+pub(crate) struct City {
     city_name: String,
     representative_point: Option<LatLng>,
 }
 
-struct Town {
+pub(crate) struct Town {
     town_name: String,
     representative_point: Option<LatLng>,
 }
 
-struct Rest {
+pub(crate) struct Rest {
     rest: String,
     representative_point: Option<LatLng>,
 }

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -1,0 +1,28 @@
+use crate::domain::common::latlng::LatLng;
+
+pub enum Token {
+    Prefecture(Prefecture),
+    City(City),
+    Town(Town),
+    Rest(Rest),
+}
+
+struct Prefecture {
+    prefecture_name: String,
+    representative_point: Option<LatLng>,
+}
+
+struct City {
+    city_name: String,
+    representative_point: Option<LatLng>,
+}
+
+struct Town {
+    town_name: String,
+    representative_point: Option<LatLng>,
+}
+
+struct Rest {
+    rest: String,
+    representative_point: Option<LatLng>,
+}

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -1,5 +1,6 @@
 use crate::domain::common::latlng::LatLng;
 
+#[derive(Debug)]
 pub enum Token {
     Prefecture(Prefecture),
     City(City),
@@ -7,21 +8,25 @@ pub enum Token {
     Rest(Rest),
 }
 
+#[derive(Debug)]
 pub(crate) struct Prefecture {
     prefecture_name: String,
     representative_point: Option<LatLng>,
 }
 
+#[derive(Debug)]
 pub(crate) struct City {
     city_name: String,
     representative_point: Option<LatLng>,
 }
 
+#[derive(Debug)]
 pub(crate) struct Town {
     town_name: String,
     representative_point: Option<LatLng>,
 }
 
+#[derive(Debug)]
 pub(crate) struct Rest {
     rest: String,
     representative_point: Option<LatLng>,


### PR DESCRIPTION
### 変更点
- 住所を「都道府県」、「市区町村」、「町名」、「それ以降」に分割した場合の各要素を表すための列挙体`Token`を定義した。
- `Tokenizer`で使用する予定。
