### PR TITLE
Tokenizerのリファクタ: 構造体`Tokenizer`にフィールド`tokens: Vec<Token>`を追加

### DIFF
--- a/core/src/domain/common/latlng.rs
+++ b/core/src/domain/common/latlng.rs
@@ -1,4 +1,4 @@
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct LatLng {
     /// 緯度
     latitude: f64,

--- a/core/src/domain/common/latlng.rs
+++ b/core/src/domain/common/latlng.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct LatLng {
     /// 緯度
     latitude: f64,

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -1,6 +1,6 @@
 use crate::domain::common::latlng::LatLng;
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     Prefecture(Prefecture),
     City(City),
@@ -8,25 +8,25 @@ pub enum Token {
     Rest(Rest),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Prefecture {
     pub(crate) prefecture_name: String,
     pub(crate) representative_point: Option<LatLng>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct City {
     city_name: String,
     representative_point: Option<LatLng>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Town {
     town_name: String,
     representative_point: Option<LatLng>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Rest {
     rest: String,
     representative_point: Option<LatLng>,

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -1,6 +1,6 @@
 use crate::domain::common::latlng::LatLng;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Token {
     Prefecture(Prefecture),
     City(City),
@@ -8,25 +8,25 @@ pub enum Token {
     Rest(Rest),
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct Prefecture {
     prefecture_name: String,
     representative_point: Option<LatLng>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct City {
     city_name: String,
     representative_point: Option<LatLng>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct Town {
     town_name: String,
     representative_point: Option<LatLng>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) struct Rest {
     rest: String,
     representative_point: Option<LatLng>,

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -16,8 +16,8 @@ pub(crate) struct Prefecture {
 
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct City {
-    city_name: String,
-    representative_point: Option<LatLng>,
+    pub(crate) city_name: String,
+    pub(crate) representative_point: Option<LatLng>,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -30,4 +30,8 @@ pub(crate) struct Town {
 pub(crate) struct Rest {
     rest: String,
     representative_point: Option<LatLng>,
+}
+
+pub(crate) fn append_token(tokens: &[Token], token: Token) -> Vec<Token> {
+    [tokens.to_owned(), vec![token]].concat()
 }

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -22,8 +22,8 @@ pub(crate) struct City {
 
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct Town {
-    town_name: String,
-    representative_point: Option<LatLng>,
+    pub(crate) town_name: String,
+    pub(crate) representative_point: Option<LatLng>,
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -10,8 +10,8 @@ pub enum Token {
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct Prefecture {
-    prefecture_name: String,
-    representative_point: Option<LatLng>,
+    pub(crate) prefecture_name: String,
+    pub(crate) representative_point: Option<LatLng>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -12,7 +12,7 @@ compile_error! {
 }
 
 pub mod api;
-mod domain;
+pub(crate) mod domain;
 #[deprecated(since = "0.1.6", note = "This module will be deleted in v0.2")]
 pub mod entity;
 mod formatter;

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -3,6 +3,7 @@ pub(crate) mod read_city_with_county_name_completion;
 pub(crate) mod read_prefecture;
 pub(crate) mod read_town;
 
+use crate::domain::common::token::Token;
 use std::marker::PhantomData;
 
 #[derive(Debug)]
@@ -21,6 +22,7 @@ pub(crate) struct End;
 #[derive(Debug)]
 pub struct Tokenizer<State> {
     input: String,
+    tokens: Vec<Token>,
     pub(crate) prefecture_name: Option<String>,
     pub(crate) city_name: Option<String>,
     pub(crate) town_name: Option<String>,

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -14,6 +14,7 @@ impl Tokenizer<PrefectureNameFound> {
             if self.rest.starts_with(candidate) {
                 return Ok(Tokenizer {
                     input: self.input.clone(),
+                    tokens: vec![],
                     prefecture_name: self.prefecture_name.clone(),
                     city_name: Some(candidate.clone()),
                     town_name: None,
@@ -55,6 +56,7 @@ impl Tokenizer<PrefectureNameFound> {
             if let Some(result) = adapter.apply(self.rest.as_str(), candidate) {
                 return Ok(Tokenizer {
                     input: self.input.clone(),
+                    tokens: vec![],
                     prefecture_name: self.prefecture_name.clone(),
                     city_name: Some(result.0),
                     town_name: None,
@@ -66,6 +68,7 @@ impl Tokenizer<PrefectureNameFound> {
 
         Err(Tokenizer {
             input: self.input.clone(),
+            tokens: vec![],
             prefecture_name: self.prefecture_name.clone(),
             city_name: None,
             town_name: None,
@@ -84,6 +87,7 @@ mod tests {
     fn read_city_成功() {
         let tokenizer = Tokenizer {
             input: "神奈川県横浜市保土ケ谷区川辺町2番地9".to_string(),
+            tokens: vec![],
             prefecture_name: Some("神奈川県".to_string()),
             city_name: None,
             town_name: None,
@@ -108,6 +112,7 @@ mod tests {
     fn read_city_orthographical_variant_adapterで成功() {
         let tokenizer = Tokenizer {
             input: "神奈川県横浜市保土ヶ谷区川辺町2番地9".to_string(), // 「ヶ」と「ケ」の表記ゆれ
+            tokens: vec![],
             prefecture_name: Some("神奈川県".to_string()),
             city_name: None,
             town_name: None,
@@ -132,6 +137,7 @@ mod tests {
     fn read_city_失敗() {
         let tokenizer = Tokenizer {
             input: "神奈川県京都市上京区川辺町2番地9".to_string(),
+            tokens: vec![],
             prefecture_name: Some("神奈川県".to_string()),
             city_name: None,
             town_name: None,

--- a/core/src/tokenizer/read_city_with_county_name_completion.rs
+++ b/core/src/tokenizer/read_city_with_county_name_completion.rs
@@ -13,6 +13,7 @@ impl Tokenizer<CityNameNotFound> {
             if let Ok(complemented_address) = complement_county_name(&self.rest, &highest_match) {
                 return Ok(Tokenizer {
                     input: self.input.clone(),
+                    tokens: vec![],
                     prefecture_name: self.prefecture_name.clone(),
                     city_name: Some(highest_match.clone()),
                     town_name: None,
@@ -26,6 +27,7 @@ impl Tokenizer<CityNameNotFound> {
         }
         Err(Tokenizer {
             input: self.input.clone(),
+            tokens: vec![],
             prefecture_name: self.prefecture_name.clone(),
             city_name: None,
             town_name: None,
@@ -78,6 +80,7 @@ mod tests {
     fn read_city_with_county_name_completion_秩父郡東秩父村() {
         let tokenizer = Tokenizer {
             input: "埼玉県東秩父村大字御堂634番地".to_string(), // 「秩父郡」が省略されている
+            tokens: vec![],
             prefecture_name: Some("埼玉県".to_string()),
             city_name: None,
             town_name: None,
@@ -103,6 +106,7 @@ mod tests {
     fn read_city_with_county_name_completion_吉田郡永平寺町() {
         let tokenizer = Tokenizer {
             input: "".to_string(),
+            tokens: vec![],
             prefecture_name: None,
             city_name: None,
             town_name: None,
@@ -120,6 +124,7 @@ mod tests {
     fn read_city_with_county_name_completion_今立郡池田町() {
         let tokenizer = Tokenizer {
             input: "".to_string(),
+            tokens: vec![],
             prefecture_name: None,
             city_name: None,
             town_name: None,
@@ -137,6 +142,7 @@ mod tests {
     fn read_city_with_county_name_completion_南条郡南越前町() {
         let tokenizer = Tokenizer {
             input: "".to_string(),
+            tokens: vec![],
             prefecture_name: None,
             city_name: None,
             town_name: None,
@@ -154,6 +160,7 @@ mod tests {
     fn read_city_with_county_name_completion_西村山郡河北町() {
         let tokenizer = Tokenizer {
             input: "".to_string(),
+            tokens: vec![],
             prefecture_name: None,
             city_name: None,
             town_name: None,
@@ -172,6 +179,7 @@ mod tests {
     fn read_city_with_county_name_completion_杵島郡大町町() {
         let tokenizer = Tokenizer {
             input: "".to_string(),
+            tokens: vec![],
             prefecture_name: None,
             city_name: None,
             town_name: None,
@@ -189,6 +197,7 @@ mod tests {
     fn read_city_with_county_name_completion_最上郡最上町() {
         let tokenizer = Tokenizer {
             input: "".to_string(),
+            tokens: vec![],
             prefecture_name: None,
             city_name: None,
             town_name: None,

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -1,7 +1,7 @@
-use std::marker::PhantomData;
-
+use crate::domain::common::token::{Prefecture, Token};
 use crate::tokenizer::{End, Init, PrefectureNameFound, Tokenizer};
 use crate::util::extension::StrExt;
+use std::marker::PhantomData;
 
 const PREFECTURE_NAME_LIST: [&str; 47] = [
     "北海道",
@@ -75,7 +75,10 @@ impl Tokenizer<Init> {
             if self.rest.starts_with(prefecture_name) {
                 return Ok(Tokenizer {
                     input: self.input.clone(),
-                    tokens: vec![],
+                    tokens: vec![Token::Prefecture(Prefecture {
+                        prefecture_name: prefecture_name.to_string(),
+                        representative_point: None,
+                    })],
                     prefecture_name: Some(prefecture_name.to_string()),
                     city_name: None,
                     town_name: None,
@@ -102,15 +105,14 @@ impl Tokenizer<Init> {
 
 #[cfg(test)]
 mod tests {
+    use crate::domain::common::token::{Prefecture, Token};
     use crate::tokenizer::Tokenizer;
 
     #[test]
     fn new() {
         let tokenizer = Tokenizer::new("東京都港区芝公園4丁目2-8");
         assert_eq!(tokenizer.input, "東京都港区芝公園4丁目2-8");
-        assert_eq!(tokenizer.prefecture_name, None);
-        assert_eq!(tokenizer.city_name, None);
-        assert_eq!(tokenizer.town_name, None);
+        assert_eq!(tokenizer.tokens, vec![]);
         assert_eq!(tokenizer.rest, "東京都港区芝公園4丁目2-8");
     }
 
@@ -118,9 +120,7 @@ mod tests {
     fn new_異字体セレクタ除去() {
         let tokenizer = Tokenizer::new("東京都葛\u{E0100}飾区立石5-13-1");
         assert_eq!(tokenizer.input, "東京都葛\u{E0100}飾区立石5-13-1");
-        assert_eq!(tokenizer.prefecture_name, None);
-        assert_eq!(tokenizer.city_name, None);
-        assert_eq!(tokenizer.town_name, None);
+        assert_eq!(tokenizer.tokens, vec![]);
         assert_eq!(tokenizer.rest, "東京都葛飾区立石5-13-1")
     }
 
@@ -129,9 +129,7 @@ mod tests {
     fn new_ホワイトスペース除却() {
         let tokenizer = Tokenizer::new("東京都 目黒区 下目黒 4‐1‐1");
         assert_eq!(tokenizer.input, "東京都 目黒区 下目黒 4‐1‐1");
-        assert_eq!(tokenizer.prefecture_name, None);
-        assert_eq!(tokenizer.city_name, None);
-        assert_eq!(tokenizer.town_name, None);
+        assert_eq!(tokenizer.tokens, vec![]);
         assert_eq!(tokenizer.rest, "東京都目黒区下目黒4‐1‐1")
     }
 
@@ -142,9 +140,14 @@ mod tests {
         assert!(result.is_ok());
         let tokenizer = result.unwrap();
         assert_eq!(tokenizer.input, "東京都港区芝公園4丁目2-8");
-        assert_eq!(tokenizer.prefecture_name, Some("東京都".to_string()));
-        assert_eq!(tokenizer.city_name, None);
-        assert_eq!(tokenizer.town_name, None);
+        assert_eq!(tokenizer.tokens.len(), 1);
+        assert_eq!(
+            tokenizer.tokens[0],
+            Token::Prefecture(Prefecture {
+                prefecture_name: "東京都".to_string(),
+                representative_point: None
+            })
+        );
         assert_eq!(tokenizer.rest, "港区芝公園4丁目2-8");
     }
 
@@ -155,9 +158,7 @@ mod tests {
         assert!(result.is_err());
         let tokenizer = result.unwrap_err();
         assert_eq!(tokenizer.input, "東今日都港区芝公園4丁目2-8");
-        assert_eq!(tokenizer.prefecture_name, None);
-        assert_eq!(tokenizer.city_name, None);
-        assert_eq!(tokenizer.town_name, None);
+        assert_eq!(tokenizer.tokens, vec![]);
         assert_eq!(tokenizer.rest, "東今日都港区芝公園4丁目2-8".to_string());
     }
 }

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -57,6 +57,7 @@ impl Tokenizer<Init> {
     pub(crate) fn new(input: &str) -> Self {
         Self {
             input: input.to_string(),
+            tokens: vec![],
             prefecture_name: None,
             city_name: None,
             town_name: None,
@@ -74,6 +75,7 @@ impl Tokenizer<Init> {
             if self.rest.starts_with(prefecture_name) {
                 return Ok(Tokenizer {
                     input: self.input.clone(),
+                    tokens: vec![],
                     prefecture_name: Some(prefecture_name.to_string()),
                     city_name: None,
                     town_name: None,
@@ -88,6 +90,7 @@ impl Tokenizer<Init> {
         }
         Err(Tokenizer {
             input: self.input.clone(),
+            tokens: vec![],
             prefecture_name: None,
             city_name: None,
             town_name: None,

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -20,6 +20,7 @@ impl Tokenizer<CityNameFound> {
         if let Some((town_name, rest)) = find_town(&rest, &candidates) {
             return Ok(Tokenizer {
                 input: self.input.clone(),
+                tokens: vec![],
                 prefecture_name: self.prefecture_name.clone(),
                 city_name: self.city_name.clone(),
                 town_name: Some(town_name),
@@ -37,6 +38,7 @@ impl Tokenizer<CityNameFound> {
         if let Some((town_name, rest)) = find_town(&rest, &candidates) {
             return Ok(Tokenizer {
                 input: self.input.clone(),
+                tokens: vec![],
                 prefecture_name: self.prefecture_name.clone(),
                 city_name: self.city_name.clone(),
                 town_name: Some(town_name),
@@ -53,6 +55,7 @@ impl Tokenizer<CityNameFound> {
         if let Some((town_name, rest)) = find_town(&format!("大字{}", rest), &candidates) {
             return Ok(Tokenizer {
                 input: self.input.clone(),
+                tokens: vec![],
                 prefecture_name: self.prefecture_name.clone(),
                 city_name: self.city_name.clone(),
                 town_name: Some(town_name),
@@ -67,6 +70,7 @@ impl Tokenizer<CityNameFound> {
         }
         Err(Tokenizer {
             input: self.input.clone(),
+            tokens: vec![],
             prefecture_name: self.prefecture_name.clone(),
             city_name: self.city_name.clone(),
             town_name: None,
@@ -132,6 +136,7 @@ mod tests {
     fn read_town_成功() {
         let tokenizer = Tokenizer {
             input: "静岡県静岡市清水区旭町6番8号".to_string(),
+            tokens: vec![],
             prefecture_name: Some("静岡県".to_string()),
             city_name: Some("静岡市清水区".to_string()),
             town_name: None,
@@ -158,6 +163,7 @@ mod tests {
     fn read_town_orthographical_variant_adapterで成功() {
         let tokenizer = Tokenizer {
             input: "東京都千代田区一ッ橋二丁目1番".to_string(), // 「ッ」と「ツ」の表記ゆれ
+            tokens: vec![],
             prefecture_name: Some("東京都".to_string()),
             city_name: Some("千代田区".to_string()),
             town_name: None,
@@ -184,6 +190,7 @@ mod tests {
     fn read_town_invalid_town_name_format_filterで成功() {
         let tokenizer = Tokenizer {
             input: "京都府京都市東山区本町22丁目489番".to_string(),
+            tokens: vec![],
             prefecture_name: Some("京都府".to_string()),
             city_name: Some("京都市東山区".to_string()),
             town_name: None,
@@ -211,6 +218,7 @@ mod tests {
     fn read_town_大字が省略されている場合_成功() {
         let tokenizer = Tokenizer {
             input: "東京都西多摩郡日の出町平井2780番地".to_string(), // 「大字」が省略されている
+            tokens: vec![],
             prefecture_name: Some("東京都".to_string()),
             city_name: Some("西多摩郡日の出町".to_string()),
             town_name: None,
@@ -231,6 +239,7 @@ mod tests {
     fn read_town_失敗() {
         let tokenizer = Tokenizer {
             input: "静岡県静岡市清水区".to_string(),
+            tokens: vec![],
             prefecture_name: Some("静岡県".to_string()),
             city_name: Some("静岡市清水区".to_string()),
             town_name: None,


### PR DESCRIPTION
### 変更点
- 構造体`Tokenizer`にフィールド`tokens: Vec<Token>`を追加しました。
- これまでは`prefecture_name`, `city_name`, `town_name`としてデータを格納していましたが、`tokens`にまとめてデータを格納するようにする予定です。
