### PR TITLE
Tokenizerのリファクタ: `Tokenizer`のメソッドの返り値を変更

### DIFF
--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -120,7 +120,8 @@ pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
         Ok(result) => result,
     };
     // 町名を特定
-    let Ok(tokenizer) = tokenizer.read_town(city.towns.iter().map(|x| x.name.clone()).collect())
+    let Ok((_, tokenizer)) =
+        tokenizer.read_town(city.towns.iter().map(|x| x.name.clone()).collect())
     else {
         return ParseResult {
             address: Address::from(tokenizer),
@@ -276,7 +277,8 @@ pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
         }
         Ok(result) => result,
     };
-    let Ok(tokenizer) = tokenizer.read_town(city.towns.iter().map(|x| x.name.clone()).collect())
+    let Ok((_, tokenizer)) =
+        tokenizer.read_town(city.towns.iter().map(|x| x.name.clone()).collect())
     else {
         return ParseResult {
             address: Address::from(tokenizer),

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -76,17 +76,14 @@ impl Parser {
 pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
     let tokenizer = Tokenizer::new(input);
     // 都道府県を特定
-    let Ok(tokenizer) = tokenizer.read_prefecture() else {
+    let Ok((prefecture_name, tokenizer)) = tokenizer.read_prefecture() else {
         return ParseResult {
             address: Address::from(tokenizer),
             error: Some(Error::new_parse_error(ParseErrorKind::Prefecture)),
         };
     };
     // その都道府県の市町村名リストを取得
-    let prefecture = match api
-        .get_prefecture_master(tokenizer.prefecture_name.as_ref().unwrap())
-        .await
-    {
+    let prefecture = match api.get_prefecture_master(&prefecture_name).await {
         Err(error) => {
             return ParseResult {
                 address: Address::from(tokenizer),
@@ -247,13 +244,13 @@ mod tests {
 #[cfg(feature = "blocking")]
 pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     let tokenizer = Tokenizer::new(input);
-    let Ok(tokenizer) = tokenizer.read_prefecture() else {
+    let Ok((prefecture_name, tokenizer)) = tokenizer.read_prefecture() else {
         return ParseResult {
             address: Address::from(tokenizer),
             error: Some(Error::new_parse_error(ParseErrorKind::Prefecture)),
         };
     };
-    let prefecture = match api.get_prefecture_master(tokenizer.prefecture_name.as_ref().unwrap()) {
+    let prefecture = match api.get_prefecture_master(&prefecture_name) {
         Err(error) => {
             return ParseResult {
                 address: Address::from(tokenizer),

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -93,7 +93,7 @@ pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
         Ok(result) => result,
     };
     // 市町村名を特定
-    let tokenizer = match tokenizer.read_city(&prefecture.cities) {
+    let (city_name, tokenizer) = match tokenizer.read_city(&prefecture.cities) {
         Ok(found) => found,
         Err(not_found) => {
             // 市区町村が特定できない場合かつフィーチャフラグが有効な場合、郡名が抜けている可能性を検討
@@ -110,13 +110,7 @@ pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
         }
     };
     // その市町村の町名リストを取得
-    let city = match api
-        .get_city_master(
-            tokenizer.prefecture_name.as_ref().unwrap(),
-            tokenizer.city_name.as_ref().unwrap(),
-        )
-        .await
-    {
+    let city = match api.get_city_master(&prefecture_name, &city_name).await {
         Err(error) => {
             return ParseResult {
                 address: Address::from(tokenizer),
@@ -259,7 +253,7 @@ pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
         }
         Ok(result) => result,
     };
-    let tokenizer = match tokenizer.read_city(&prefecture.cities) {
+    let (city_name, tokenizer) = match tokenizer.read_city(&prefecture.cities) {
         Ok(found) => found,
         Err(not_found) => {
             match not_found.read_city_with_county_name_completion(&prefecture.cities) {
@@ -273,10 +267,7 @@ pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
             }
         }
     };
-    let city = match api.get_city_master(
-        tokenizer.prefecture_name.as_ref().unwrap(),
-        tokenizer.city_name.as_ref().unwrap(),
-    ) {
+    let city = match api.get_city_master(&prefecture_name, &city_name) {
         Err(error) => {
             return ParseResult {
                 address: Address::from(tokenizer),

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -70,25 +70,30 @@ impl Tokenizer<Init> {
         }
     }
 
-    pub(crate) fn read_prefecture(&self) -> Result<Tokenizer<PrefectureNameFound>, Tokenizer<End>> {
+    pub(crate) fn read_prefecture(
+        &self,
+    ) -> Result<(String, Tokenizer<PrefectureNameFound>), Tokenizer<End>> {
         for prefecture_name in PREFECTURE_NAME_LIST {
             if self.rest.starts_with(prefecture_name) {
-                return Ok(Tokenizer {
-                    input: self.input.clone(),
-                    tokens: vec![Token::Prefecture(Prefecture {
-                        prefecture_name: prefecture_name.to_string(),
-                        representative_point: None,
-                    })],
-                    prefecture_name: Some(prefecture_name.to_string()),
-                    city_name: None,
-                    town_name: None,
-                    rest: self
-                        .rest
-                        .chars()
-                        .skip(prefecture_name.chars().count())
-                        .collect::<String>(),
-                    _state: PhantomData::<PrefectureNameFound>,
-                });
+                return Ok((
+                    prefecture_name.to_string(),
+                    Tokenizer {
+                        input: self.input.clone(),
+                        tokens: vec![Token::Prefecture(Prefecture {
+                            prefecture_name: prefecture_name.to_string(),
+                            representative_point: None,
+                        })],
+                        prefecture_name: Some(prefecture_name.to_string()),
+                        city_name: None,
+                        town_name: None,
+                        rest: self
+                            .rest
+                            .chars()
+                            .skip(prefecture_name.chars().count())
+                            .collect::<String>(),
+                        _state: PhantomData::<PrefectureNameFound>,
+                    },
+                ));
             }
         }
         Err(Tokenizer {
@@ -105,7 +110,6 @@ impl Tokenizer<Init> {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{Prefecture, Token};
     use crate::tokenizer::Tokenizer;
 
     #[test]
@@ -138,16 +142,10 @@ mod tests {
         let tokenizer = Tokenizer::new("東京都港区芝公園4丁目2-8");
         let result = tokenizer.read_prefecture();
         assert!(result.is_ok());
-        let tokenizer = result.unwrap();
+        let (prefecture_name, tokenizer) = result.unwrap();
+        assert_eq!(prefecture_name, "東京都");
         assert_eq!(tokenizer.input, "東京都港区芝公園4丁目2-8");
         assert_eq!(tokenizer.tokens.len(), 1);
-        assert_eq!(
-            tokenizer.tokens[0],
-            Token::Prefecture(Prefecture {
-                prefecture_name: "東京都".to_string(),
-                representative_point: None
-            })
-        );
         assert_eq!(tokenizer.rest, "港区芝公園4丁目2-8");
     }
 

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -13,79 +13,91 @@ impl Tokenizer<CityNameFound> {
     pub(crate) fn read_town(
         &self,
         candidates: Vec<String>,
-    ) -> Result<Tokenizer<TownNameFound>, Tokenizer<End>> {
+    ) -> Result<(String, Tokenizer<TownNameFound>), Tokenizer<End>> {
         let mut rest = format_fullwidth_number(&self.rest);
         if rest.contains("丁目") {
             rest = format_chome_with_arabic_numerals(&rest).unwrap_or(rest);
         }
         if let Some((town_name, rest)) = find_town(&rest, &candidates) {
-            return Ok(Tokenizer {
-                input: self.input.clone(),
-                tokens: append_token(
-                    &self.tokens,
-                    Token::Town(Town {
-                        town_name: town_name.clone(), // TODO: 以降に使用箇所があるためcloneしているが、本来不要なので使用箇所なくなったら削除する
-                        representative_point: None,
-                    }),
-                ),
-                prefecture_name: self.prefecture_name.clone(),
-                city_name: self.city_name.clone(),
-                town_name: Some(town_name),
-                rest: if cfg!(feature = "format-house-number") && format_house_number(&rest).is_ok()
-                {
-                    format_house_number(&rest).unwrap()
-                } else {
-                    rest
+            return Ok((
+                town_name.clone(),
+                Tokenizer {
+                    input: self.input.clone(),
+                    tokens: append_token(
+                        &self.tokens,
+                        Token::Town(Town {
+                            town_name: town_name.clone(), // TODO: 以降に使用箇所があるためcloneしているが、本来不要なので使用箇所なくなったら削除する
+                            representative_point: None,
+                        }),
+                    ),
+                    prefecture_name: self.prefecture_name.clone(),
+                    city_name: self.city_name.clone(),
+                    town_name: Some(town_name),
+                    rest: if cfg!(feature = "format-house-number")
+                        && format_house_number(&rest).is_ok()
+                    {
+                        format_house_number(&rest).unwrap()
+                    } else {
+                        rest
+                    },
+                    _state: PhantomData::<TownNameFound>,
                 },
-                _state: PhantomData::<TownNameFound>,
-            });
+            ));
         }
         // 「〇〇町L丁目M番N」ではなく「〇〇町L-M-N」と表記されているような場合
         rest = format_informal_town_name_notation(&rest).unwrap_or(rest);
         if let Some((town_name, rest)) = find_town(&rest, &candidates) {
-            return Ok(Tokenizer {
-                input: self.input.clone(),
-                tokens: append_token(
-                    &self.tokens,
-                    Token::Town(Town {
-                        town_name: town_name.clone(), // TODO: 以降に使用箇所があるためcloneしているが、本来不要なので使用箇所なくなったら削除する
-                        representative_point: None,
-                    }),
-                ),
-                prefecture_name: self.prefecture_name.clone(),
-                city_name: self.city_name.clone(),
-                town_name: Some(town_name),
-                rest: if cfg!(feature = "format-house-number") && format_house_number(&rest).is_ok()
-                {
-                    format_house_number(&rest).unwrap()
-                } else {
-                    rest
+            return Ok((
+                town_name.clone(),
+                Tokenizer {
+                    input: self.input.clone(),
+                    tokens: append_token(
+                        &self.tokens,
+                        Token::Town(Town {
+                            town_name: town_name.clone(), // TODO: 以降に使用箇所があるためcloneしているが、本来不要なので使用箇所なくなったら削除する
+                            representative_point: None,
+                        }),
+                    ),
+                    prefecture_name: self.prefecture_name.clone(),
+                    city_name: self.city_name.clone(),
+                    town_name: Some(town_name),
+                    rest: if cfg!(feature = "format-house-number")
+                        && format_house_number(&rest).is_ok()
+                    {
+                        format_house_number(&rest).unwrap()
+                    } else {
+                        rest
+                    },
+                    _state: PhantomData::<TownNameFound>,
                 },
-                _state: PhantomData::<TownNameFound>,
-            });
+            ));
         }
         // ここまでで町名の検出に成功しない場合は、「大字」の省略の可能性を検討する
         if let Some((town_name, rest)) = find_town(&format!("大字{}", rest), &candidates) {
-            return Ok(Tokenizer {
-                input: self.input.clone(),
-                tokens: append_token(
-                    &self.tokens,
-                    Token::Town(Town {
-                        town_name: town_name.clone(), // TODO: 以降に使用箇所があるためcloneしているが、本来不要なので使用箇所なくなったら削除する
-                        representative_point: None,
-                    }),
-                ),
-                prefecture_name: self.prefecture_name.clone(),
-                city_name: self.city_name.clone(),
-                town_name: Some(town_name),
-                rest: if cfg!(feature = "format-house-number") && format_house_number(&rest).is_ok()
-                {
-                    format_house_number(&rest).unwrap()
-                } else {
-                    rest
+            return Ok((
+                town_name.clone(),
+                Tokenizer {
+                    input: self.input.clone(),
+                    tokens: append_token(
+                        &self.tokens,
+                        Token::Town(Town {
+                            town_name: town_name.clone(), // TODO: 以降に使用箇所があるためcloneしているが、本来不要なので使用箇所なくなったら削除する
+                            representative_point: None,
+                        }),
+                    ),
+                    prefecture_name: self.prefecture_name.clone(),
+                    city_name: self.city_name.clone(),
+                    town_name: Some(town_name),
+                    rest: if cfg!(feature = "format-house-number")
+                        && format_house_number(&rest).is_ok()
+                    {
+                        format_house_number(&rest).unwrap()
+                    } else {
+                        rest
+                    },
+                    _state: PhantomData::<TownNameFound>,
                 },
-                _state: PhantomData::<TownNameFound>,
-            });
+            ));
         }
         Err(Tokenizer {
             input: self.input.clone(),
@@ -148,7 +160,7 @@ fn find_town(input: &str, candidates: &Vec<String>) -> Option<(String, String)> 
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::domain::common::token::{City, Prefecture, Token};
     use crate::tokenizer::{CityNameFound, Tokenizer};
     use std::marker::PhantomData;
 
@@ -180,16 +192,10 @@ mod tests {
             "三保松原町".to_string(),
         ]);
         assert!(result.is_ok());
-        let tokenizer = result.unwrap();
+        let (town_name, tokenizer) = result.unwrap();
+        assert_eq!(town_name, "旭町");
         assert_eq!(tokenizer.input, "静岡県静岡市清水区旭町6番8号");
         assert_eq!(tokenizer.tokens.len(), 3);
-        assert_eq!(
-            tokenizer.tokens[2],
-            Token::Town(Town {
-                town_name: "旭町".to_string(),
-                representative_point: None,
-            })
-        );
         assert_eq!(tokenizer.rest, "6番8号");
     }
 
@@ -221,16 +227,10 @@ mod tests {
             "一ツ橋二丁目".to_string(),
         ]);
         assert!(result.is_ok());
-        let tokenizer = result.unwrap();
+        let (town_name, tokenizer) = result.unwrap();
+        assert_eq!(town_name, "一ツ橋二丁目");
         assert_eq!(tokenizer.input, "東京都千代田区一ッ橋二丁目1番");
         assert_eq!(tokenizer.tokens.len(), 3);
-        assert_eq!(
-            tokenizer.tokens[2],
-            Token::Town(Town {
-                town_name: "一ツ橋二丁目".to_string(),
-                representative_point: None,
-            })
-        );
         assert_eq!(tokenizer.rest, "1番");
     }
 
@@ -263,16 +263,10 @@ mod tests {
             "本町新六丁目".to_string(),
         ]);
         assert!(result.is_ok());
-        let tokenizer = result.unwrap();
+        let (town_name, tokenizer) = result.unwrap();
+        assert_eq!(town_name, "本町二十二丁目");
         assert_eq!(tokenizer.input, "京都府京都市東山区本町22丁目489番");
         assert_eq!(tokenizer.tokens.len(), 3);
-        assert_eq!(
-            tokenizer.tokens[2],
-            Token::Town(Town {
-                town_name: "本町二十二丁目".to_string(),
-                representative_point: None,
-            })
-        );
         assert_eq!(tokenizer.rest, "489番");
     }
 
@@ -298,16 +292,10 @@ mod tests {
         };
         let result = tokenizer.read_town(vec!["大字大久野".to_string(), "大字平井".to_string()]);
         assert!(result.is_ok());
-        let tokenizer = result.unwrap();
+        let (town_name, tokenizer) = result.unwrap();
+        assert_eq!(town_name, "大字平井");
         assert_eq!(tokenizer.input, "東京都西多摩郡日の出町平井2780番地");
         assert_eq!(tokenizer.tokens.len(), 3);
-        assert_eq!(
-            tokenizer.tokens[2],
-            Token::Town(Town {
-                town_name: "大字平井".to_string(),
-                representative_point: None,
-            })
-        );
         assert_eq!(tokenizer.rest, "2780番地");
     }
 


### PR DESCRIPTION
### 変更点
- `Tokenizer<Prefecture>#read_prefecture`の返り値を修正しました。
  - `Tokenizer<PrefectureNamefound>`と共に特定した都道府県名をタプルで返すようにしました。
- `read_city()`, `read_city_with_county_name_completion()`, `read_town()`についても同様に修正しました。
