### PR TITLE
Tokenizerのリファクタ: `Tokenizer`から`town_name`を削除

### DIFF
--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::api::AsyncApi;
 #[cfg(feature = "blocking")]
 use crate::api::BlockingApi;
+use crate::domain::common::token::Token;
 use crate::domain::geolonia::entity::Address;
 use crate::domain::geolonia::error::{Error, ParseErrorKind};
 use crate::tokenizer::Tokenizer;
@@ -12,12 +13,16 @@ pub mod adapter;
 
 impl<T> From<Tokenizer<T>> for Address {
     fn from(value: Tokenizer<T>) -> Self {
-        Self {
-            prefecture: value.prefecture_name.unwrap_or("".to_string()),
-            city: value.city_name.unwrap_or("".to_string()),
-            town: value.town_name.unwrap_or("".to_string()),
-            rest: value.rest,
+        let mut address = Address::new("", "", "", value.rest.as_str());
+        for token in value.tokens {
+            match token {
+                Token::Prefecture(prefecture) => address.prefecture = prefecture.prefecture_name,
+                Token::City(city) => address.city = city.city_name,
+                Token::Town(town) => address.town = town.town_name,
+                _ => {}
+            }
         }
+        address
     }
 }
 

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -22,7 +22,7 @@ pub(crate) struct End;
 #[derive(Debug)]
 pub struct Tokenizer<State> {
     input: String,
-    tokens: Vec<Token>,
+    pub(crate) tokens: Vec<Token>,
     pub(crate) prefecture_name: Option<String>,
     pub(crate) city_name: Option<String>,
     pub(crate) town_name: Option<String>,

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -25,7 +25,6 @@ pub struct Tokenizer<State> {
     pub(crate) tokens: Vec<Token>,
     pub(crate) prefecture_name: Option<String>,
     pub(crate) city_name: Option<String>,
-    pub(crate) town_name: Option<String>,
     pub(crate) rest: String,
     _state: PhantomData<State>,
 }

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -25,7 +25,6 @@ impl Tokenizer<PrefectureNameFound> {
                         ),
                         prefecture_name: self.prefecture_name.clone(),
                         city_name: Some(candidate.clone()),
-                        town_name: None,
                         rest: self
                             .rest
                             .chars()
@@ -76,7 +75,6 @@ impl Tokenizer<PrefectureNameFound> {
                         ),
                         prefecture_name: self.prefecture_name.clone(),
                         city_name: Some(result.0),
-                        town_name: None,
                         rest: result.1,
                         _state: PhantomData::<CityNameFound>,
                     },
@@ -89,7 +87,6 @@ impl Tokenizer<PrefectureNameFound> {
             tokens: self.tokens.clone(),
             prefecture_name: self.prefecture_name.clone(),
             city_name: None,
-            town_name: None,
             rest: self.rest.clone(),
             _state: PhantomData::<CityNameNotFound>,
         })
@@ -112,7 +109,6 @@ mod tests {
             })],
             prefecture_name: Some("神奈川県".to_string()),
             city_name: None,
-            town_name: None,
             rest: "横浜市保土ケ谷区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };
@@ -139,7 +135,6 @@ mod tests {
             })],
             prefecture_name: Some("神奈川県".to_string()),
             city_name: None,
-            town_name: None,
             rest: "横浜市保土ヶ谷区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };
@@ -166,7 +161,6 @@ mod tests {
             })],
             prefecture_name: Some("神奈川県".to_string()),
             city_name: None,
-            town_name: None,
             rest: "京都市上京区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };

--- a/core/src/tokenizer/read_city_with_county_name_completion.rs
+++ b/core/src/tokenizer/read_city_with_county_name_completion.rs
@@ -25,7 +25,6 @@ impl Tokenizer<CityNameNotFound> {
                         ),
                         prefecture_name: self.prefecture_name.clone(),
                         city_name: Some(highest_match.clone()),
-                        town_name: None,
                         rest: complemented_address
                             .chars()
                             .skip(highest_match.chars().count())
@@ -40,7 +39,6 @@ impl Tokenizer<CityNameNotFound> {
             tokens: self.tokens.clone(),
             prefecture_name: self.prefecture_name.clone(),
             city_name: None,
-            town_name: None,
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
         })
@@ -97,7 +95,6 @@ mod tests {
             })],
             prefecture_name: Some("埼玉県".to_string()),
             city_name: None,
-            town_name: None,
             rest: "東秩父村大字御堂634番地".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -125,7 +122,6 @@ mod tests {
             })],
             prefecture_name: None,
             city_name: None,
-            town_name: None,
             rest: "永平寺町志比５－５".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -148,7 +144,6 @@ mod tests {
             })],
             prefecture_name: None,
             city_name: None,
-            town_name: None,
             rest: "池田町稲荷２８－７".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -171,7 +166,6 @@ mod tests {
             })],
             prefecture_name: None,
             city_name: None,
-            town_name: None,
             rest: "南越前町今庄７４－７－１".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -194,7 +188,6 @@ mod tests {
             })],
             prefecture_name: None,
             city_name: None,
-            town_name: None,
             rest: "河北町大字吉田字馬場261".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -218,7 +211,6 @@ mod tests {
             })],
             prefecture_name: None,
             city_name: None,
-            town_name: None,
             rest: "大町町大字大町5017番地".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -241,7 +233,6 @@ mod tests {
             })],
             prefecture_name: None,
             city_name: None,
-            town_name: None,
             rest: "最上町法田2672-2".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -60,7 +60,6 @@ impl Tokenizer<Init> {
             tokens: vec![],
             prefecture_name: None,
             city_name: None,
-            town_name: None,
             rest: if cfg!(feature = "eliminate-whitespaces") {
                 input.strip_variation_selectors().strip_whitespaces()
             } else {
@@ -85,7 +84,6 @@ impl Tokenizer<Init> {
                         })],
                         prefecture_name: Some(prefecture_name.to_string()),
                         city_name: None,
-                        town_name: None,
                         rest: self
                             .rest
                             .chars()
@@ -101,7 +99,6 @@ impl Tokenizer<Init> {
             tokens: vec![],
             prefecture_name: None,
             city_name: None,
-            town_name: None,
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
         })

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -32,7 +32,6 @@ impl Tokenizer<CityNameFound> {
                     ),
                     prefecture_name: self.prefecture_name.clone(),
                     city_name: self.city_name.clone(),
-                    town_name: Some(town_name),
                     rest: if cfg!(feature = "format-house-number")
                         && format_house_number(&rest).is_ok()
                     {
@@ -60,7 +59,6 @@ impl Tokenizer<CityNameFound> {
                     ),
                     prefecture_name: self.prefecture_name.clone(),
                     city_name: self.city_name.clone(),
-                    town_name: Some(town_name),
                     rest: if cfg!(feature = "format-house-number")
                         && format_house_number(&rest).is_ok()
                     {
@@ -87,7 +85,6 @@ impl Tokenizer<CityNameFound> {
                     ),
                     prefecture_name: self.prefecture_name.clone(),
                     city_name: self.city_name.clone(),
-                    town_name: Some(town_name),
                     rest: if cfg!(feature = "format-house-number")
                         && format_house_number(&rest).is_ok()
                     {
@@ -104,7 +101,6 @@ impl Tokenizer<CityNameFound> {
             tokens: self.tokens.clone(),
             prefecture_name: self.prefecture_name.clone(),
             city_name: self.city_name.clone(),
-            town_name: None,
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
         })
@@ -180,7 +176,6 @@ mod tests {
             ],
             prefecture_name: Some("静岡県".to_string()),
             city_name: Some("静岡市清水区".to_string()),
-            town_name: None,
             rest: "旭町6番8号".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -215,7 +210,6 @@ mod tests {
             ],
             prefecture_name: Some("東京都".to_string()),
             city_name: Some("千代田区".to_string()),
-            town_name: None,
             rest: "一ッ橋二丁目1番".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -250,7 +244,6 @@ mod tests {
             ],
             prefecture_name: Some("京都府".to_string()),
             city_name: Some("京都市東山区".to_string()),
-            town_name: None,
             rest: "本町22丁目489番".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -286,7 +279,6 @@ mod tests {
             ],
             prefecture_name: Some("東京都".to_string()),
             city_name: Some("西多摩郡日の出町".to_string()),
-            town_name: None,
             rest: "平井2780番地".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -315,7 +307,6 @@ mod tests {
             ],
             prefecture_name: Some("静岡県".to_string()),
             city_name: Some("静岡市清水区".to_string()),
-            town_name: None,
             rest: "".to_string(),
             _state: PhantomData::<CityNameFound>,
         };

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -26,7 +26,7 @@ impl Tokenizer<CityNameFound> {
                     tokens: append_token(
                         &self.tokens,
                         Token::Town(Town {
-                            town_name: town_name.clone(), // TODO: 以降に使用箇所があるためcloneしているが、本来不要なので使用箇所なくなったら削除する
+                            town_name,
                             representative_point: None,
                         }),
                     ),
@@ -53,7 +53,7 @@ impl Tokenizer<CityNameFound> {
                     tokens: append_token(
                         &self.tokens,
                         Token::Town(Town {
-                            town_name: town_name.clone(), // TODO: 以降に使用箇所があるためcloneしているが、本来不要なので使用箇所なくなったら削除する
+                            town_name,
                             representative_point: None,
                         }),
                     ),
@@ -79,7 +79,7 @@ impl Tokenizer<CityNameFound> {
                     tokens: append_token(
                         &self.tokens,
                         Token::Town(Town {
-                            town_name: town_name.clone(), // TODO: 以降に使用箇所があるためcloneしているが、本来不要なので使用箇所なくなったら削除する
+                            town_name,
                             representative_point: None,
                         }),
                     ),


### PR DESCRIPTION
### 変更点
- 構造体`Tokenizer`からフィールド`town_name`を削除します
