### PR TITLE
Tokenizerのリファクタ: `Tokenizer`から`city_name`を削除

### DIFF
--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -24,7 +24,6 @@ pub struct Tokenizer<State> {
     input: String,
     pub(crate) tokens: Vec<Token>,
     pub(crate) prefecture_name: Option<String>,
-    pub(crate) city_name: Option<String>,
     pub(crate) rest: String,
     _state: PhantomData<State>,
 }

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -24,7 +24,6 @@ impl Tokenizer<PrefectureNameFound> {
                             }),
                         ),
                         prefecture_name: self.prefecture_name.clone(),
-                        city_name: Some(candidate.clone()),
                         rest: self
                             .rest
                             .chars()
@@ -69,12 +68,11 @@ impl Tokenizer<PrefectureNameFound> {
                         tokens: append_token(
                             &self.tokens,
                             Token::City(City {
-                                city_name: result.0.clone(), // TODO: 以降に使用箇所があるためcloneしているが本来不要なので使用箇所なくなったら削除する
+                                city_name: result.0,
                                 representative_point: None,
                             }),
                         ),
                         prefecture_name: self.prefecture_name.clone(),
-                        city_name: Some(result.0),
                         rest: result.1,
                         _state: PhantomData::<CityNameFound>,
                     },
@@ -86,7 +84,6 @@ impl Tokenizer<PrefectureNameFound> {
             input: self.input.clone(),
             tokens: self.tokens.clone(),
             prefecture_name: self.prefecture_name.clone(),
-            city_name: None,
             rest: self.rest.clone(),
             _state: PhantomData::<CityNameNotFound>,
         })
@@ -108,7 +105,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: Some("神奈川県".to_string()),
-            city_name: None,
             rest: "横浜市保土ケ谷区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };
@@ -134,7 +130,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: Some("神奈川県".to_string()),
-            city_name: None,
             rest: "横浜市保土ヶ谷区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };
@@ -160,7 +155,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: Some("神奈川県".to_string()),
-            city_name: None,
             rest: "京都市上京区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };

--- a/core/src/tokenizer/read_city_with_county_name_completion.rs
+++ b/core/src/tokenizer/read_city_with_county_name_completion.rs
@@ -24,7 +24,6 @@ impl Tokenizer<CityNameNotFound> {
                             }),
                         ),
                         prefecture_name: self.prefecture_name.clone(),
-                        city_name: Some(highest_match.clone()),
                         rest: complemented_address
                             .chars()
                             .skip(highest_match.chars().count())
@@ -38,7 +37,6 @@ impl Tokenizer<CityNameNotFound> {
             input: self.input.clone(),
             tokens: self.tokens.clone(),
             prefecture_name: self.prefecture_name.clone(),
-            city_name: None,
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
         })
@@ -94,7 +92,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: Some("埼玉県".to_string()),
-            city_name: None,
             rest: "東秩父村大字御堂634番地".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -121,7 +118,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: None,
-            city_name: None,
             rest: "永平寺町志比５－５".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -143,7 +139,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: None,
-            city_name: None,
             rest: "池田町稲荷２８－７".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -165,7 +160,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: None,
-            city_name: None,
             rest: "南越前町今庄７４－７－１".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -187,7 +181,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: None,
-            city_name: None,
             rest: "河北町大字吉田字馬場261".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -210,7 +203,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: None,
-            city_name: None,
             rest: "大町町大字大町5017番地".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -232,7 +224,6 @@ mod tests {
                 representative_point: None,
             })],
             prefecture_name: None,
-            city_name: None,
             rest: "最上町法田2672-2".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -59,7 +59,6 @@ impl Tokenizer<Init> {
             input: input.to_string(),
             tokens: vec![],
             prefecture_name: None,
-            city_name: None,
             rest: if cfg!(feature = "eliminate-whitespaces") {
                 input.strip_variation_selectors().strip_whitespaces()
             } else {
@@ -83,7 +82,6 @@ impl Tokenizer<Init> {
                             representative_point: None,
                         })],
                         prefecture_name: Some(prefecture_name.to_string()),
-                        city_name: None,
                         rest: self
                             .rest
                             .chars()
@@ -98,7 +96,6 @@ impl Tokenizer<Init> {
             input: self.input.clone(),
             tokens: vec![],
             prefecture_name: None,
-            city_name: None,
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
         })

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -31,7 +31,6 @@ impl Tokenizer<CityNameFound> {
                         }),
                     ),
                     prefecture_name: self.prefecture_name.clone(),
-                    city_name: self.city_name.clone(),
                     rest: if cfg!(feature = "format-house-number")
                         && format_house_number(&rest).is_ok()
                     {
@@ -58,7 +57,6 @@ impl Tokenizer<CityNameFound> {
                         }),
                     ),
                     prefecture_name: self.prefecture_name.clone(),
-                    city_name: self.city_name.clone(),
                     rest: if cfg!(feature = "format-house-number")
                         && format_house_number(&rest).is_ok()
                     {
@@ -84,7 +82,6 @@ impl Tokenizer<CityNameFound> {
                         }),
                     ),
                     prefecture_name: self.prefecture_name.clone(),
-                    city_name: self.city_name.clone(),
                     rest: if cfg!(feature = "format-house-number")
                         && format_house_number(&rest).is_ok()
                     {
@@ -100,7 +97,6 @@ impl Tokenizer<CityNameFound> {
             input: self.input.clone(),
             tokens: self.tokens.clone(),
             prefecture_name: self.prefecture_name.clone(),
-            city_name: self.city_name.clone(),
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
         })
@@ -175,7 +171,6 @@ mod tests {
                 }),
             ],
             prefecture_name: Some("静岡県".to_string()),
-            city_name: Some("静岡市清水区".to_string()),
             rest: "旭町6番8号".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -209,7 +204,6 @@ mod tests {
                 }),
             ],
             prefecture_name: Some("東京都".to_string()),
-            city_name: Some("千代田区".to_string()),
             rest: "一ッ橋二丁目1番".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -243,7 +237,6 @@ mod tests {
                 }),
             ],
             prefecture_name: Some("京都府".to_string()),
-            city_name: Some("京都市東山区".to_string()),
             rest: "本町22丁目489番".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -278,7 +271,6 @@ mod tests {
                 }),
             ],
             prefecture_name: Some("東京都".to_string()),
-            city_name: Some("西多摩郡日の出町".to_string()),
             rest: "平井2780番地".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -306,7 +298,6 @@ mod tests {
                 }),
             ],
             prefecture_name: Some("静岡県".to_string()),
-            city_name: Some("静岡市清水区".to_string()),
             rest: "".to_string(),
             _state: PhantomData::<CityNameFound>,
         };


### PR DESCRIPTION
### 変更点
- 構造体`Tokenizer`からフィールド`city_name`を削除します
