### PR TITLE
Tokenizerのリファクタ: `Tokenizer`から`prefecture_name`を削除

### DIFF
--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -23,7 +23,6 @@ pub(crate) struct End;
 pub struct Tokenizer<State> {
     input: String,
     pub(crate) tokens: Vec<Token>,
-    pub(crate) prefecture_name: Option<String>,
     pub(crate) rest: String,
     _state: PhantomData<State>,
 }

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -27,3 +27,14 @@ pub struct Tokenizer<State> {
     pub(crate) rest: String,
     _state: PhantomData<State>,
 }
+
+impl<T> Tokenizer<T> {
+    fn get_prefecture_name(&self) -> Option<&str> {
+        for token in &self.tokens {
+            if let Token::Prefecture(prefecture) = token {
+                return Some(&prefecture.prefecture_name);
+            };
+        }
+        None
+    }
+}

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -34,27 +34,27 @@ impl Tokenizer<PrefectureNameFound> {
                 ));
             }
             let mut variant_list = vec![Variant::ケ];
-            match self.prefecture_name.clone().unwrap().as_str() {
-                "青森県" => {
+            match self.get_prefecture_name() {
+                Some("青森県") => {
                     variant_list.push(Variant::舘);
                 }
-                "宮城県" => {
+                Some("宮城県") => {
                     variant_list.push(Variant::竈);
                 }
-                "茨城県" => {
+                Some("茨城県") => {
                     variant_list.push(Variant::龍);
                     variant_list.push(Variant::嶋);
                 }
-                "東京都" => {
+                Some("東京都") => {
                     variant_list.push(Variant::檜);
                 }
-                "兵庫県" => {
+                Some("兵庫県") => {
                     variant_list.push(Variant::塚);
                 }
-                "高知県" => {
+                Some("高知県") => {
                     variant_list.push(Variant::梼);
                 }
-                "福岡県" => {
+                Some("福岡県") => {
                     variant_list.push(Variant::恵);
                 }
                 _ => {}

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -23,7 +23,6 @@ impl Tokenizer<PrefectureNameFound> {
                                 representative_point: None,
                             }),
                         ),
-                        prefecture_name: self.prefecture_name.clone(),
                         rest: self
                             .rest
                             .chars()
@@ -72,7 +71,6 @@ impl Tokenizer<PrefectureNameFound> {
                                 representative_point: None,
                             }),
                         ),
-                        prefecture_name: self.prefecture_name.clone(),
                         rest: result.1,
                         _state: PhantomData::<CityNameFound>,
                     },
@@ -83,7 +81,6 @@ impl Tokenizer<PrefectureNameFound> {
         Err(Tokenizer {
             input: self.input.clone(),
             tokens: self.tokens.clone(),
-            prefecture_name: self.prefecture_name.clone(),
             rest: self.rest.clone(),
             _state: PhantomData::<CityNameNotFound>,
         })
@@ -104,7 +101,6 @@ mod tests {
                 prefecture_name: "神奈川県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: Some("神奈川県".to_string()),
             rest: "横浜市保土ケ谷区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };
@@ -129,7 +125,6 @@ mod tests {
                 prefecture_name: "神奈川県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: Some("神奈川県".to_string()),
             rest: "横浜市保土ヶ谷区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };
@@ -154,7 +149,6 @@ mod tests {
                 prefecture_name: "神奈川県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: Some("神奈川県".to_string()),
             rest: "京都市上京区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };

--- a/core/src/tokenizer/read_city_with_county_name_completion.rs
+++ b/core/src/tokenizer/read_city_with_county_name_completion.rs
@@ -23,7 +23,6 @@ impl Tokenizer<CityNameNotFound> {
                                 representative_point: None,
                             }),
                         ),
-                        prefecture_name: self.prefecture_name.clone(),
                         rest: complemented_address
                             .chars()
                             .skip(highest_match.chars().count())
@@ -36,7 +35,6 @@ impl Tokenizer<CityNameNotFound> {
         Err(Tokenizer {
             input: self.input.clone(),
             tokens: self.tokens.clone(),
-            prefecture_name: self.prefecture_name.clone(),
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
         })
@@ -91,7 +89,6 @@ mod tests {
                 prefecture_name: "埼玉県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: Some("埼玉県".to_string()),
             rest: "東秩父村大字御堂634番地".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -117,7 +114,6 @@ mod tests {
                 prefecture_name: "福井県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: None,
             rest: "永平寺町志比５－５".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -138,7 +134,6 @@ mod tests {
                 prefecture_name: "福井県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: None,
             rest: "池田町稲荷２８－７".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -159,7 +154,6 @@ mod tests {
                 prefecture_name: "福井県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: None,
             rest: "南越前町今庄７４－７－１".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -180,7 +174,6 @@ mod tests {
                 prefecture_name: "山形県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: None,
             rest: "河北町大字吉田字馬場261".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -202,7 +195,6 @@ mod tests {
                 prefecture_name: "佐賀県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: None,
             rest: "大町町大字大町5017番地".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -223,7 +215,6 @@ mod tests {
                 prefecture_name: "山形県".to_string(),
                 representative_point: None,
             })],
-            prefecture_name: None,
             rest: "最上町法田2672-2".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -58,7 +58,6 @@ impl Tokenizer<Init> {
         Self {
             input: input.to_string(),
             tokens: vec![],
-            prefecture_name: None,
             rest: if cfg!(feature = "eliminate-whitespaces") {
                 input.strip_variation_selectors().strip_whitespaces()
             } else {
@@ -81,7 +80,6 @@ impl Tokenizer<Init> {
                             prefecture_name: prefecture_name.to_string(),
                             representative_point: None,
                         })],
-                        prefecture_name: Some(prefecture_name.to_string()),
                         rest: self
                             .rest
                             .chars()
@@ -95,7 +93,6 @@ impl Tokenizer<Init> {
         Err(Tokenizer {
             input: self.input.clone(),
             tokens: vec![],
-            prefecture_name: None,
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
         })

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -30,7 +30,6 @@ impl Tokenizer<CityNameFound> {
                             representative_point: None,
                         }),
                     ),
-                    prefecture_name: self.prefecture_name.clone(),
                     rest: if cfg!(feature = "format-house-number")
                         && format_house_number(&rest).is_ok()
                     {
@@ -56,7 +55,6 @@ impl Tokenizer<CityNameFound> {
                             representative_point: None,
                         }),
                     ),
-                    prefecture_name: self.prefecture_name.clone(),
                     rest: if cfg!(feature = "format-house-number")
                         && format_house_number(&rest).is_ok()
                     {
@@ -81,7 +79,6 @@ impl Tokenizer<CityNameFound> {
                             representative_point: None,
                         }),
                     ),
-                    prefecture_name: self.prefecture_name.clone(),
                     rest: if cfg!(feature = "format-house-number")
                         && format_house_number(&rest).is_ok()
                     {
@@ -96,7 +93,6 @@ impl Tokenizer<CityNameFound> {
         Err(Tokenizer {
             input: self.input.clone(),
             tokens: self.tokens.clone(),
-            prefecture_name: self.prefecture_name.clone(),
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
         })
@@ -170,7 +166,6 @@ mod tests {
                     representative_point: None,
                 }),
             ],
-            prefecture_name: Some("静岡県".to_string()),
             rest: "旭町6番8号".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -203,7 +198,6 @@ mod tests {
                     representative_point: None,
                 }),
             ],
-            prefecture_name: Some("東京都".to_string()),
             rest: "一ッ橋二丁目1番".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -236,7 +230,6 @@ mod tests {
                     representative_point: None,
                 }),
             ],
-            prefecture_name: Some("京都府".to_string()),
             rest: "本町22丁目489番".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -270,7 +263,6 @@ mod tests {
                     representative_point: None,
                 }),
             ],
-            prefecture_name: Some("東京都".to_string()),
             rest: "平井2780番地".to_string(),
             _state: PhantomData::<CityNameFound>,
         };
@@ -297,7 +289,6 @@ mod tests {
                     representative_point: None,
                 }),
             ],
-            prefecture_name: Some("静岡県".to_string()),
             rest: "".to_string(),
             _state: PhantomData::<CityNameFound>,
         };


### PR DESCRIPTION
### 変更点
- 構造体`Tokenizer`からフィールド`prefecture_name`を削除します