### PR TITLE
Tokenizerのリファクタ: `Tokenizer`から`input`を削除

### DIFF
--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -21,7 +21,6 @@ pub(crate) struct End;
 
 #[derive(Debug)]
 pub struct Tokenizer<State> {
-    input: String,
     pub(crate) tokens: Vec<Token>,
     pub(crate) rest: String,
     _state: PhantomData<State>,

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -15,7 +15,6 @@ impl Tokenizer<PrefectureNameFound> {
                 return Ok((
                     candidate.to_string(),
                     Tokenizer {
-                        input: self.input.clone(),
                         tokens: append_token(
                             &self.tokens,
                             Token::City(City {
@@ -63,7 +62,6 @@ impl Tokenizer<PrefectureNameFound> {
                 return Ok((
                     result.0.clone(),
                     Tokenizer {
-                        input: self.input.clone(),
                         tokens: append_token(
                             &self.tokens,
                             Token::City(City {
@@ -79,7 +77,6 @@ impl Tokenizer<PrefectureNameFound> {
         }
 
         Err(Tokenizer {
-            input: self.input.clone(),
             tokens: self.tokens.clone(),
             rest: self.rest.clone(),
             _state: PhantomData::<CityNameNotFound>,
@@ -96,7 +93,6 @@ mod tests {
     #[test]
     fn read_city_成功() {
         let tokenizer = Tokenizer {
-            input: "神奈川県横浜市保土ケ谷区川辺町2番地9".to_string(),
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "神奈川県".to_string(),
                 representative_point: None,
@@ -112,7 +108,6 @@ mod tests {
         assert!(result.is_ok());
         let (city_name, tokenizer) = result.unwrap();
         assert_eq!(city_name, "横浜市保土ケ谷区");
-        assert_eq!(tokenizer.input, "神奈川県横浜市保土ケ谷区川辺町2番地9");
         assert_eq!(tokenizer.tokens.len(), 2);
         assert_eq!(tokenizer.rest, "川辺町2番地9");
     }
@@ -120,12 +115,11 @@ mod tests {
     #[test]
     fn read_city_orthographical_variant_adapterで成功() {
         let tokenizer = Tokenizer {
-            input: "神奈川県横浜市保土ヶ谷区川辺町2番地9".to_string(), // 「ヶ」と「ケ」の表記ゆれ
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "神奈川県".to_string(),
                 representative_point: None,
             })],
-            rest: "横浜市保土ヶ谷区川辺町2番地9".to_string(),
+            rest: "横浜市保土ヶ谷区川辺町2番地9".to_string(), // 「ヶ」と「ケ」の表記ゆれ
             _state: PhantomData::<PrefectureNameFound>,
         };
         let result = tokenizer.read_city(&vec![
@@ -136,7 +130,6 @@ mod tests {
         assert!(result.is_ok());
         let (city_name, tokenizer) = result.unwrap();
         assert_eq!(city_name, "横浜市保土ケ谷区".to_string());
-        assert_eq!(tokenizer.input, "神奈川県横浜市保土ヶ谷区川辺町2番地9");
         assert_eq!(tokenizer.tokens.len(), 2);
         assert_eq!(tokenizer.rest, "川辺町2番地9");
     }
@@ -144,7 +137,6 @@ mod tests {
     #[test]
     fn read_city_失敗() {
         let tokenizer = Tokenizer {
-            input: "神奈川県京都市上京区川辺町2番地9".to_string(),
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "神奈川県".to_string(),
                 representative_point: None,
@@ -159,7 +151,6 @@ mod tests {
         ]);
         assert!(result.is_err());
         let tokenizer = result.unwrap_err();
-        assert_eq!(tokenizer.input, "神奈川県京都市上京区川辺町2番地9");
         assert_eq!(tokenizer.tokens.len(), 1);
         assert_eq!(tokenizer.rest, "京都市上京区川辺町2番地9");
     }

--- a/core/src/tokenizer/read_city_with_county_name_completion.rs
+++ b/core/src/tokenizer/read_city_with_county_name_completion.rs
@@ -15,7 +15,6 @@ impl Tokenizer<CityNameNotFound> {
                 return Ok((
                     highest_match.clone(),
                     Tokenizer {
-                        input: self.input.clone(),
                         tokens: append_token(
                             &self.tokens,
                             Token::City(City {
@@ -33,7 +32,6 @@ impl Tokenizer<CityNameNotFound> {
             }
         }
         Err(Tokenizer {
-            input: self.input.clone(),
             tokens: self.tokens.clone(),
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
@@ -84,12 +82,11 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_秩父郡東秩父村() {
         let tokenizer = Tokenizer {
-            input: "埼玉県東秩父村大字御堂634番地".to_string(), // 「秩父郡」が省略されている
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "埼玉県".to_string(),
                 representative_point: None,
             })],
-            rest: "東秩父村大字御堂634番地".to_string(),
+            rest: "東秩父村大字御堂634番地".to_string(), // 「秩父郡」が省略されている
             _state: PhantomData::<CityNameNotFound>,
         };
         let result = tokenizer.read_city_with_county_name_completion(&vec![
@@ -101,7 +98,6 @@ mod tests {
         assert!(result.is_ok());
         let (city_name, tokenizer) = result.unwrap();
         assert_eq!(city_name, "秩父郡東秩父村");
-        assert_eq!(tokenizer.input, "埼玉県東秩父村大字御堂634番地");
         assert_eq!(tokenizer.tokens.len(), 2);
         assert_eq!(tokenizer.rest, "大字御堂634番地");
     }
@@ -109,7 +105,6 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_吉田郡永平寺町() {
         let tokenizer = Tokenizer {
-            input: "".to_string(),
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "福井県".to_string(),
                 representative_point: None,
@@ -129,7 +124,6 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_今立郡池田町() {
         let tokenizer = Tokenizer {
-            input: "".to_string(),
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "福井県".to_string(),
                 representative_point: None,
@@ -149,7 +143,6 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_南条郡南越前町() {
         let tokenizer = Tokenizer {
-            input: "".to_string(),
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "福井県".to_string(),
                 representative_point: None,
@@ -169,7 +162,6 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_西村山郡河北町() {
         let tokenizer = Tokenizer {
-            input: "".to_string(),
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "山形県".to_string(),
                 representative_point: None,
@@ -190,7 +182,6 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_杵島郡大町町() {
         let tokenizer = Tokenizer {
-            input: "".to_string(),
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "佐賀県".to_string(),
                 representative_point: None,
@@ -210,7 +201,6 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_最上郡最上町() {
         let tokenizer = Tokenizer {
-            input: "".to_string(),
             tokens: vec![Token::Prefecture(Prefecture {
                 prefecture_name: "山形県".to_string(),
                 representative_point: None,

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -56,7 +56,6 @@ const PREFECTURE_NAME_LIST: [&str; 47] = [
 impl Tokenizer<Init> {
     pub(crate) fn new(input: &str) -> Self {
         Self {
-            input: input.to_string(),
             tokens: vec![],
             rest: if cfg!(feature = "eliminate-whitespaces") {
                 input.strip_variation_selectors().strip_whitespaces()
@@ -75,7 +74,6 @@ impl Tokenizer<Init> {
                 return Ok((
                     prefecture_name.to_string(),
                     Tokenizer {
-                        input: self.input.clone(),
                         tokens: vec![Token::Prefecture(Prefecture {
                             prefecture_name: prefecture_name.to_string(),
                             representative_point: None,
@@ -91,7 +89,6 @@ impl Tokenizer<Init> {
             }
         }
         Err(Tokenizer {
-            input: self.input.clone(),
             tokens: vec![],
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
@@ -106,7 +103,6 @@ mod tests {
     #[test]
     fn new() {
         let tokenizer = Tokenizer::new("東京都港区芝公園4丁目2-8");
-        assert_eq!(tokenizer.input, "東京都港区芝公園4丁目2-8");
         assert_eq!(tokenizer.tokens, vec![]);
         assert_eq!(tokenizer.rest, "東京都港区芝公園4丁目2-8");
     }
@@ -114,7 +110,6 @@ mod tests {
     #[test]
     fn new_異字体セレクタ除去() {
         let tokenizer = Tokenizer::new("東京都葛\u{E0100}飾区立石5-13-1");
-        assert_eq!(tokenizer.input, "東京都葛\u{E0100}飾区立石5-13-1");
         assert_eq!(tokenizer.tokens, vec![]);
         assert_eq!(tokenizer.rest, "東京都葛飾区立石5-13-1")
     }
@@ -123,7 +118,6 @@ mod tests {
     #[cfg(feature = "eliminate-whitespaces")]
     fn new_ホワイトスペース除却() {
         let tokenizer = Tokenizer::new("東京都 目黒区 下目黒 4‐1‐1");
-        assert_eq!(tokenizer.input, "東京都 目黒区 下目黒 4‐1‐1");
         assert_eq!(tokenizer.tokens, vec![]);
         assert_eq!(tokenizer.rest, "東京都目黒区下目黒4‐1‐1")
     }
@@ -135,7 +129,6 @@ mod tests {
         assert!(result.is_ok());
         let (prefecture_name, tokenizer) = result.unwrap();
         assert_eq!(prefecture_name, "東京都");
-        assert_eq!(tokenizer.input, "東京都港区芝公園4丁目2-8");
         assert_eq!(tokenizer.tokens.len(), 1);
         assert_eq!(tokenizer.rest, "港区芝公園4丁目2-8");
     }
@@ -146,7 +139,6 @@ mod tests {
         let result = tokenizer.read_prefecture();
         assert!(result.is_err());
         let tokenizer = result.unwrap_err();
-        assert_eq!(tokenizer.input, "東今日都港区芝公園4丁目2-8");
         assert_eq!(tokenizer.tokens, vec![]);
         assert_eq!(tokenizer.rest, "東今日都港区芝公園4丁目2-8".to_string());
     }

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -22,7 +22,6 @@ impl Tokenizer<CityNameFound> {
             return Ok((
                 town_name.clone(),
                 Tokenizer {
-                    input: self.input.clone(),
                     tokens: append_token(
                         &self.tokens,
                         Token::Town(Town {
@@ -47,7 +46,6 @@ impl Tokenizer<CityNameFound> {
             return Ok((
                 town_name.clone(),
                 Tokenizer {
-                    input: self.input.clone(),
                     tokens: append_token(
                         &self.tokens,
                         Token::Town(Town {
@@ -71,7 +69,6 @@ impl Tokenizer<CityNameFound> {
             return Ok((
                 town_name.clone(),
                 Tokenizer {
-                    input: self.input.clone(),
                     tokens: append_token(
                         &self.tokens,
                         Token::Town(Town {
@@ -91,7 +88,6 @@ impl Tokenizer<CityNameFound> {
             ));
         }
         Err(Tokenizer {
-            input: self.input.clone(),
             tokens: self.tokens.clone(),
             rest: self.rest.clone(),
             _state: PhantomData::<End>,
@@ -155,7 +151,6 @@ mod tests {
     #[test]
     fn read_town_成功() {
         let tokenizer = Tokenizer {
-            input: "静岡県静岡市清水区旭町6番8号".to_string(),
             tokens: vec![
                 Token::Prefecture(Prefecture {
                     prefecture_name: "静岡県".to_string(),
@@ -179,7 +174,6 @@ mod tests {
         assert!(result.is_ok());
         let (town_name, tokenizer) = result.unwrap();
         assert_eq!(town_name, "旭町");
-        assert_eq!(tokenizer.input, "静岡県静岡市清水区旭町6番8号");
         assert_eq!(tokenizer.tokens.len(), 3);
         assert_eq!(tokenizer.rest, "6番8号");
     }
@@ -187,7 +181,6 @@ mod tests {
     #[test]
     fn read_town_orthographical_variant_adapterで成功() {
         let tokenizer = Tokenizer {
-            input: "東京都千代田区一ッ橋二丁目1番".to_string(), // 「ッ」と「ツ」の表記ゆれ
             tokens: vec![
                 Token::Prefecture(Prefecture {
                     prefecture_name: "東京都".to_string(),
@@ -198,7 +191,7 @@ mod tests {
                     representative_point: None,
                 }),
             ],
-            rest: "一ッ橋二丁目1番".to_string(),
+            rest: "一ッ橋二丁目1番".to_string(), // 「ッ」と「ツ」の表記ゆれ
             _state: PhantomData::<CityNameFound>,
         };
         let result = tokenizer.read_town(vec![
@@ -211,7 +204,6 @@ mod tests {
         assert!(result.is_ok());
         let (town_name, tokenizer) = result.unwrap();
         assert_eq!(town_name, "一ツ橋二丁目");
-        assert_eq!(tokenizer.input, "東京都千代田区一ッ橋二丁目1番");
         assert_eq!(tokenizer.tokens.len(), 3);
         assert_eq!(tokenizer.rest, "1番");
     }
@@ -219,7 +211,6 @@ mod tests {
     #[test]
     fn read_town_invalid_town_name_format_filterで成功() {
         let tokenizer = Tokenizer {
-            input: "京都府京都市東山区本町22丁目489番".to_string(),
             tokens: vec![
                 Token::Prefecture(Prefecture {
                     prefecture_name: "京都府".to_string(),
@@ -244,7 +235,6 @@ mod tests {
         assert!(result.is_ok());
         let (town_name, tokenizer) = result.unwrap();
         assert_eq!(town_name, "本町二十二丁目");
-        assert_eq!(tokenizer.input, "京都府京都市東山区本町22丁目489番");
         assert_eq!(tokenizer.tokens.len(), 3);
         assert_eq!(tokenizer.rest, "489番");
     }
@@ -252,7 +242,6 @@ mod tests {
     #[test]
     fn read_town_大字が省略されている場合_成功() {
         let tokenizer = Tokenizer {
-            input: "東京都西多摩郡日の出町平井2780番地".to_string(), // 「大字」が省略されている
             tokens: vec![
                 Token::Prefecture(Prefecture {
                     prefecture_name: "東京都".to_string(),
@@ -263,14 +252,13 @@ mod tests {
                     representative_point: None,
                 }),
             ],
-            rest: "平井2780番地".to_string(),
+            rest: "平井2780番地".to_string(), // 「大字」が省略されている
             _state: PhantomData::<CityNameFound>,
         };
         let result = tokenizer.read_town(vec!["大字大久野".to_string(), "大字平井".to_string()]);
         assert!(result.is_ok());
         let (town_name, tokenizer) = result.unwrap();
         assert_eq!(town_name, "大字平井");
-        assert_eq!(tokenizer.input, "東京都西多摩郡日の出町平井2780番地");
         assert_eq!(tokenizer.tokens.len(), 3);
         assert_eq!(tokenizer.rest, "2780番地");
     }
@@ -278,7 +266,6 @@ mod tests {
     #[test]
     fn read_town_失敗() {
         let tokenizer = Tokenizer {
-            input: "静岡県静岡市清水区".to_string(),
             tokens: vec![
                 Token::Prefecture(Prefecture {
                     prefecture_name: "静岡県".to_string(),
@@ -301,7 +288,6 @@ mod tests {
         ]);
         assert!(result.is_err());
         let tokenizer = result.unwrap_err();
-        assert_eq!(tokenizer.input, "静岡県静岡市清水区");
         assert_eq!(tokenizer.tokens.len(), 2);
         assert_eq!(tokenizer.rest, "");
     }


### PR DESCRIPTION
### 変更点
- 構造体Tokenizer`からフィールド`input`を削除します
