### PR TITLE
`read_prefecture()`をjisx0401ベースの実装に修正

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ regex = { version = "1.10.6", default-features = false, features = ["std", "unic
 serde.workspace = true
 reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls"] }
 js-sys = "0.3.67"
+jisx0401 = "0.1.0-beta.3"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -18,12 +18,12 @@ impl Tokenizer<Init> {
 
     pub(crate) fn read_prefecture(
         &self,
-    ) -> Result<(String, Tokenizer<PrefectureNameFound>), Tokenizer<End>> {
+    ) -> Result<(jisx0401::Prefecture, Tokenizer<PrefectureNameFound>), Tokenizer<End>> {
         match find_prefecture(&self.rest) {
             Some(prefecture) => {
                 let prefecture_name = prefecture.name_ja();
                 Ok((
-                    prefecture_name.to_string(),
+                    prefecture.clone(),
                     Tokenizer {
                         tokens: vec![Token::Prefecture(Prefecture {
                             prefecture_name: prefecture_name.to_string(),
@@ -51,6 +51,7 @@ fn find_prefecture(input: &str) -> Option<&jisx0401::Prefecture> {
 mod tests {
     use crate::domain::common::token::Token;
     use crate::tokenizer::Tokenizer;
+    use jisx0401::Prefecture;
 
     #[test]
     fn new() {
@@ -79,8 +80,8 @@ mod tests {
         let tokenizer = Tokenizer::new("東京都港区芝公園4丁目2-8");
         let result = tokenizer.read_prefecture();
         assert!(result.is_ok());
-        let (prefecture_name, tokenizer) = result.unwrap();
-        assert_eq!(prefecture_name, "東京都");
+        let (prefecture, tokenizer) = result.unwrap();
+        assert_eq!(prefecture, Prefecture::TOKYO);
         assert_eq!(tokenizer.tokens.len(), 1);
         assert_eq!(tokenizer.rest, "港区芝公園4丁目2-8");
     }

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -3,56 +3,6 @@ use crate::tokenizer::{End, Init, PrefectureNameFound, Tokenizer};
 use crate::util::extension::StrExt;
 use std::marker::PhantomData;
 
-const PREFECTURE_NAME_LIST: [&str; 47] = [
-    "北海道",
-    "青森県",
-    "岩手県",
-    "宮城県",
-    "秋田県",
-    "山形県",
-    "福島県",
-    "茨城県",
-    "栃木県",
-    "群馬県",
-    "埼玉県",
-    "千葉県",
-    "東京都",
-    "神奈川県",
-    "新潟県",
-    "富山県",
-    "石川県",
-    "福井県",
-    "山梨県",
-    "長野県",
-    "岐阜県",
-    "静岡県",
-    "愛知県",
-    "三重県",
-    "滋賀県",
-    "京都府",
-    "大阪府",
-    "兵庫県",
-    "奈良県",
-    "和歌山県",
-    "鳥取県",
-    "島根県",
-    "岡山県",
-    "広島県",
-    "山口県",
-    "徳島県",
-    "香川県",
-    "愛媛県",
-    "高知県",
-    "福岡県",
-    "佐賀県",
-    "長崎県",
-    "熊本県",
-    "大分県",
-    "宮崎県",
-    "鹿児島県",
-    "沖縄県",
-];
-
 impl Tokenizer<Init> {
     pub(crate) fn new(input: &str) -> Self {
         Self {
@@ -69,9 +19,10 @@ impl Tokenizer<Init> {
     pub(crate) fn read_prefecture(
         &self,
     ) -> Result<(String, Tokenizer<PrefectureNameFound>), Tokenizer<End>> {
-        for prefecture_name in PREFECTURE_NAME_LIST {
-            if self.rest.starts_with(prefecture_name) {
-                return Ok((
+        match find_prefecture(&self.rest) {
+            Some(prefecture) => {
+                let prefecture_name = prefecture.name_ja();
+                Ok((
                     prefecture_name.to_string(),
                     Tokenizer {
                         tokens: vec![Token::Prefecture(Prefecture {
@@ -85,11 +36,15 @@ impl Tokenizer<Init> {
                             .collect::<String>(),
                         _state: PhantomData::<PrefectureNameFound>,
                     },
-                ));
+                ))
             }
+            None => Err(self.finish()),
         }
-        Err(self.finish())
     }
+}
+
+fn find_prefecture(input: &str) -> Option<&jisx0401::Prefecture> {
+    jisx0401::Prefecture::values().find(|&prefecture| input.starts_with(prefecture.name_ja()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### 変更点
- `read_prefecture()`をjisx0401ベースの実装に修正します
- 返り値を変更し、Stringではなく`jisx0401::Prefecture`を返すように変更します