### PR TITLE
chimei-ruiju.orgへの対応: `ChimeiRujiuInteractor`のメソッドの引数を変更

### DIFF
--- a/core/src/interactor.rs
+++ b/core/src/interactor.rs
@@ -22,7 +22,7 @@ pub(crate) trait ChimeiRuijuInteractor {
     /// 町名マスタを取得
     async fn get_town_master(
         &self,
-        prefecture_name: &str,
+        prefecture: &Prefecture,
         city_name: &str,
         town_name: &str,
     ) -> Result<TownMaster, ApiError>;
@@ -59,11 +59,10 @@ impl ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl {
 
     async fn get_town_master(
         &self,
-        prefecture_name: &str,
+        prefecture: &Prefecture,
         city_name: &str,
         town_name: &str,
     ) -> Result<TownMaster, ApiError> {
-        let prefecture = Prefecture::try_from(prefecture_name).unwrap();
-        TownMasterRepository::get(&self.api_service, &prefecture, city_name, town_name).await
+        TownMasterRepository::get(&self.api_service, prefecture, city_name, town_name).await
     }
 }

--- a/core/src/interactor.rs
+++ b/core/src/interactor.rs
@@ -16,7 +16,7 @@ pub(crate) trait ChimeiRuijuInteractor {
     /// 市区町村マスタを取得
     async fn get_city_master(
         &self,
-        prefecture_name: &str,
+        prefecture: &Prefecture,
         city_name: &str,
     ) -> Result<CityMaster, ApiError>;
     /// 町名マスタを取得
@@ -51,11 +51,10 @@ impl ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl {
 
     async fn get_city_master(
         &self,
-        prefecture_name: &str,
+        prefecture: &Prefecture,
         city_name: &str,
     ) -> Result<CityMaster, ApiError> {
-        let prefecture = Prefecture::try_from(prefecture_name).unwrap();
-        CityMasterRepository::get(&self.api_service, &prefecture, city_name).await
+        CityMasterRepository::get(&self.api_service, prefecture, city_name).await
     }
 
     async fn get_town_master(

--- a/core/src/interactor.rs
+++ b/core/src/interactor.rs
@@ -11,7 +11,7 @@ pub(crate) trait ChimeiRuijuInteractor {
     /// 都道府県マスタを取得
     async fn get_prefecture_master(
         &self,
-        prefecture_name: &str,
+        prefecture: &Prefecture,
     ) -> Result<PrefectureMaster, ApiError>;
     /// 市区町村マスタを取得
     async fn get_city_master(
@@ -44,10 +44,9 @@ impl Default for ChimeiRuijuInteractorImpl {
 impl ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl {
     async fn get_prefecture_master(
         &self,
-        prefecture_name: &str,
+        prefecture: &Prefecture,
     ) -> Result<PrefectureMaster, ApiError> {
-        let prefecture = Prefecture::try_from(prefecture_name).unwrap();
-        PrefectureMasterRepository::get(&self.api_service, &prefecture).await
+        PrefectureMasterRepository::get(&self.api_service, prefecture).await
     }
 
     async fn get_city_master(


### PR DESCRIPTION
### 変更点
- 引数を変更し、`&str`ではなく`&jisx0401::Prefecture`を渡すようにしました
