### PR TITLE
Parserの再設計: `Token`に`PartialOrd`を実装

### DIFF
--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -1,4 +1,6 @@
 use crate::domain::common::latlng::LatLng;
+use std::cmp::Ordering;
+use std::cmp::Ordering::{Equal, Greater, Less};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
@@ -6,6 +8,37 @@ pub enum Token {
     City(City),
     Town(Town),
     Rest(String),
+}
+
+impl PartialOrd for Token {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match self {
+            Token::Prefecture(_) => match other {
+                Token::Prefecture(_) => Some(Equal),
+                Token::City(_) => Some(Less),
+                Token::Town(_) => Some(Less),
+                Token::Rest(_) => Some(Less),
+            },
+            Token::City(_) => match other {
+                Token::Prefecture(_) => Some(Greater),
+                Token::City(_) => Some(Equal),
+                Token::Town(_) => Some(Less),
+                Token::Rest(_) => Some(Less),
+            },
+            Token::Town(_) => match other {
+                Token::Prefecture(_) => Some(Greater),
+                Token::City(_) => Some(Greater),
+                Token::Town(_) => Some(Equal),
+                Token::Rest(_) => Some(Less),
+            },
+            Token::Rest(_) => match other {
+                Token::Prefecture(_) => Some(Greater),
+                Token::City(_) => Some(Greater),
+                Token::Town(_) => Some(Greater),
+                Token::Rest(_) => Some(Equal),
+            },
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -28,4 +61,47 @@ pub(crate) struct Town {
 
 pub(crate) fn append_token(tokens: &[Token], token: Token) -> Vec<Token> {
     [tokens.to_owned(), vec![token]].concat()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::common::token::{City, Prefecture, Token, Town};
+
+    #[test]
+    fn sort_token_vector() {
+        let mut tokens = vec![
+            Token::Rest("2-1".to_string()),
+            Token::City(City {
+                city_name: "小金井市".to_string(),
+                representative_point: None,
+            }),
+            Token::Prefecture(Prefecture {
+                prefecture_name: "東京都".to_string(),
+                representative_point: None,
+            }),
+            Token::Town(Town {
+                town_name: "貫井北町四丁目".to_string(),
+                representative_point: None,
+            }),
+        ];
+        tokens.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        assert_eq!(
+            tokens,
+            vec![
+                Token::Prefecture(Prefecture {
+                    prefecture_name: "東京都".to_string(),
+                    representative_point: None,
+                }),
+                Token::City(City {
+                    city_name: "小金井市".to_string(),
+                    representative_point: None,
+                }),
+                Token::Town(Town {
+                    town_name: "貫井北町四丁目".to_string(),
+                    representative_point: None,
+                }),
+                Token::Rest("2-1".to_string()),
+            ]
+        );
+    }
 }


### PR DESCRIPTION
### 変更点
- Vec<Token>をソートできるように`Token`に`PartialOrd`を実装します

### 備考
- 現在の`Tokenizer`の実装であれば、`Vec<Token>`の要素は順序よく並んでいることが期待できるため、ソートし直すのは冗長な処理であるかもしれない。
