### PR TITLE
Parserの再設計: wasmクレートに`parse_experimental()`を実装

### DIFF
--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -1,4 +1,5 @@
 use crate::domain::common::token::Token;
+use serde::Serialize;
 
 /// Data source for Parser
 ///
@@ -85,7 +86,7 @@ impl Parser {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize)]
 pub struct ParsedAddress {
     /// 都道府県名
     prefecture: String,
@@ -99,7 +100,7 @@ pub struct ParsedAddress {
     metadata: Metadata,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize)]
 pub struct Metadata {
     /// 緯度
     ///

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -11,6 +11,12 @@ pub enum DataSource {
     Geolonia,
 }
 
+impl Default for DataSource {
+    fn default() -> Self {
+        DataSource::Geolonia
+    }
+}
+
 /// Options for Parser
 ///
 /// パーサーのオプションを指定します。

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,7 +15,13 @@ crate-type = ["cdylib"]
 
 [features]
 debug = []
-nightly = ["japanese-address-parser/format-house-number", "japanese-address-parser/eliminate-whitespaces", "japanese-address-parser/experimental"]
+nightly = [
+    "japanese-address-parser/format-house-number",
+    "japanese-address-parser/eliminate-whitespaces",
+    "japanese-address-parser/experimental",
+    "dep:log",
+    "dep:console_log"
+]
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
@@ -23,3 +29,6 @@ japanese-address-parser = { path = "../core" }
 serde-wasm-bindgen = "0.6.1"
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
+# 以下は`nightly`が有効な場合のみ使用される
+log = { workspace = true, optional = true }
+console_log = { version = "1.0.0", features = ["color"], optional = true }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -19,6 +19,7 @@ nightly = [
     "japanese-address-parser/format-house-number",
     "japanese-address-parser/eliminate-whitespaces",
     "japanese-address-parser/experimental",
+    "dep:serde",
     "dep:log",
     "dep:console_log"
 ]
@@ -30,5 +31,6 @@ serde-wasm-bindgen = "0.6.1"
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 # 以下は`nightly`が有効な場合のみ使用される
+serde = { workspace = true, optional = true }
 log = { workspace = true, optional = true }
 console_log = { version = "1.0.0", features = ["color"], optional = true }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 [features]
 debug = []
-nightly = ["japanese-address-parser/format-house-number", "japanese-address-parser/eliminate-whitespaces"]
+nightly = ["japanese-address-parser/format-house-number", "japanese-address-parser/eliminate-whitespaces", "japanese-address-parser/experimental"]
 
 [dependencies]
 console_error_panic_hook = "0.1.7"

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "nightly")]
+mod nightly;
+
 use japanese_address_parser::api::AsyncApi;
 use japanese_address_parser::parser;
 use std::sync::Arc;

--- a/wasm/src/nightly.rs
+++ b/wasm/src/nightly.rs
@@ -1,6 +1,79 @@
+use japanese_address_parser::experimental::parser::{DataSource, Parser, ParserOptions};
+use serde::Deserialize;
 use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+
+#[wasm_bindgen(typescript_custom_section)]
+const TYPESCRIPT_TYPE: &'static str = r#"
+export function parse_experimental(
+    address: string,
+    options: ParseOptions
+): Promise<ParsedAddress>;
+
+export interface ParseOptions {
+    dataSource: "geolonia";
+    correctIncompleteCityNames: boolean | null;
+    verbose: boolean | null;
+}
+
+export interface Metadata {
+    latitude: number | undefined;
+    longitude: number | undefined;
+    depth: number;
+}
+
+export interface ParsedAddress {
+    prefecture: string;
+    city: string;
+    town: string;
+    rest: string;
+    metadata: Metadata;
+}"#;
 
 #[wasm_bindgen(start)]
 fn start() {
     console_log::init_with_level(log::Level::Trace).expect("could not initialize log");
+}
+
+#[derive(Deserialize)]
+pub struct Options {
+    #[serde(alias = "dataSource")]
+    data_source: String,
+    #[serde(alias = "correctIncompleteCityNames")]
+    correct_incomplete_city_names: Option<bool>,
+    #[serde(alias = "verbose")]
+    verbose: Option<bool>,
+}
+
+#[wasm_bindgen(skip_typescript)]
+pub async fn parse_experimental(address: &str, options: JsValue) -> JsValue {
+    let parser_options: ParserOptions = match serde_wasm_bindgen::from_value::<Options>(options) {
+        Err(error) => {
+            log::warn!(
+                "オプションが指定されていないか、指定されたオプションの形式が正しくありません"
+            );
+            log::error!("{}", error);
+            ParserOptions::default()
+        }
+        Ok(options) => ParserOptions {
+            data_source: if options.data_source == "geolonia" {
+                DataSource::Geolonia
+            } else {
+                DataSource::default()
+            },
+            correct_incomplete_city_names: match options.correct_incomplete_city_names {
+                Some(boolean) => boolean,
+                _ => true,
+            },
+            verbose: match options.verbose {
+                Some(boolean) => boolean,
+                _ => true,
+            },
+        },
+    };
+    let parser = Parser {
+        options: parser_options,
+    };
+    let result = parser.parse(address).await;
+    serde_wasm_bindgen::to_value(&result).expect("could not serialize struct into json")
 }

--- a/wasm/src/nightly.rs
+++ b/wasm/src/nightly.rs
@@ -45,7 +45,7 @@ pub struct Options {
     verbose: Option<bool>,
 }
 
-#[wasm_bindgen(skip_typescript)]
+#[wasm_bindgen(skip_typescript, skip_jsdoc)]
 pub async fn parse_experimental(address: &str, options: JsValue) -> JsValue {
     let parser_options: ParserOptions = match serde_wasm_bindgen::from_value::<Options>(options) {
         Err(error) => {

--- a/wasm/src/nightly.rs
+++ b/wasm/src/nightly.rs
@@ -1,0 +1,6 @@
+use wasm_bindgen::prelude::wasm_bindgen;
+
+#[wasm_bindgen(start)]
+fn start() {
+    console_log::init_with_level(log::Level::Trace).expect("could not initialize log");
+}


### PR DESCRIPTION
### 変更点
- #470 
- coreクレートに定義した新しいパーサーを使って、wasmクレートに`parse_experimental()`を追加します

### 備考
- `wasm-pack build --target web --scope toriyama --out-name japanese_address_parser_nightly --features nightly`でビルドできる
- フロントエンドは次のPRで修正する
