### PR TITLE
Parserの再設計: デモページ`nightly.html`で新しいパーサーを使うように変更

### DIFF
--- a/public/nightly.html
+++ b/public/nightly.html
@@ -23,30 +23,31 @@
     <thead>
     <tr>
         <th>入力値</th>
-        <th>ステータス</th>
-        <th>address.prefecture</th>
-        <th>address.city</th>
-        <th>address.town</th>
-        <th>address.rest</th>
+        <th>depth<br><small>分析の深さ</small></th>
+        <th>prefecture<br><small>都道府県名</small></th>
+        <th>city<br><small>市区町村名</small></th>
+        <th>town<br><small>町名</small></th>
+        <th>rest<br><small>それ以降</small></th>
         <th>JSON</th>
     </tr>
     </thead>
     <tbody id="result">
     <tr>
         <td><p>東京都中央区日本橋一丁目1-1</p></td>
-        <td><p>成功</p></td>
+        <td><p>3</p></td>
         <td><p>東京都</p></td>
         <td><p>中央区</p></td>
         <td><p>日本橋一丁目</p></td>
         <td><p>1-1</p></td>
-        <td><code>{"address":{"prefecture":"東京都","city":"中央区","town":"日本橋一丁目","rest":"1-1"}}</code>
+        <td>
+            <code>{"prefecture":"東京都","city":"中央区","town":"日本橋一丁目","rest":"1番1号","metadata":{"depth":3}}</code>
         </td>
     </tr>
     </tbody>
 </table>
 <script src="table_util.js"></script>
 <script type="module">
-    import init, {Parser} from "../pkg/japanese_address_parser_nightly.js"
+    import init, {parse_experimental} from "../pkg/japanese_address_parser_nightly.js"
 
     const inputTextArea = document.getElementById("input")
 
@@ -54,10 +55,13 @@
         document.getElementById("exec").addEventListener("click", () => {
             const input = inputTextArea.value
             alert("input: " + input)
-            const parser = new Parser()
-            parser.parse(input).then(result => {
+            parse_experimental(input, {
+                dataSource: "geolonia",
+                correctIncompleteCityNames: true,
+                verbose: true,
+            }).then(result => {
                 document.getElementById("result").appendChild(
-                    createRow(input, result)
+                    createRowForNightlyPage(input, result)
                 )
             })
         })

--- a/public/nightly.html
+++ b/public/nightly.html
@@ -12,6 +12,15 @@
 <h2>YuukiToriyama/japanese-address-parser</h2>
 <p>Rust製の住所パーサーです</p>
 
+<h3>オプションを指定してください</h3>
+<div class="setting">
+    <input type="checkbox" id="auto_completion">
+    <label for="auto_completion">市区町村名の特定で完全一致するものが見つからなかった場合、あいまい検索を行ないます</label>
+    <br>
+    <input type="checkbox" id="enable_log_output">
+    <label for="enable_log_output">ブラウザコンソールへのログ出力を有効にします</label>
+</div>
+
 <h3>住所を入力してください</h3>
 <div class="input">
     <input class="address" id="input" type="text" placeholder="例) 東京都中央区日本橋一丁目1-1"/>
@@ -57,8 +66,8 @@
             alert("input: " + input)
             parse_experimental(input, {
                 dataSource: "geolonia",
-                correctIncompleteCityNames: true,
-                verbose: true,
+                correctIncompleteCityNames: document.getElementById("auto_completion").checked,
+                verbose: document.getElementById("enable_log_output").checked,
             }).then(result => {
                 document.getElementById("result").appendChild(
                     createRowForNightlyPage(input, result)

--- a/public/table_util.js
+++ b/public/table_util.js
@@ -14,6 +14,18 @@ const createRow = (input, parseResult) => {
     return tr
 }
 
+const createRowForNightlyPage = (input, parseResult) => {
+    const tr = document.createElement("tr")
+    tr.appendChild(createCell(`<p>${input}</p>`))
+    tr.appendChild(createCell(`<p>${parseResult.metadata.depth}</p>`))
+    tr.appendChild(createCell(`<p>${parseResult.prefecture}</p>`))
+    tr.appendChild(createCell(`<p>${parseResult.city}</p>`))
+    tr.appendChild(createCell(`<p>${parseResult.town}</p>`))
+    tr.appendChild(createCell(`<p>${parseResult.rest}</p>`))
+    tr.appendChild(createCell(`<code>${JSON.stringify(parseResult, null, null)}</code>`))
+    return tr
+}
+
 const createCell = (innerHtml) => {
     const td = document.createElement("td")
     td.innerHTML = innerHtml


### PR DESCRIPTION
### 変更点
- #470 
- デモページ`nightly.html`で新しいパーサーを使うように変更します
- オプションをページ上から変更できるようにします