### PR TITLE
Parserの再設計:`experimental`モジュールもdocs.rsに反映されるように設定

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,3 +44,8 @@ wasm-bindgen-test = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 mockito = "1.4.0" # mockitoがwasm32に対応していないため
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@
 //! - `eliminate-whitespaces`*(experimental)*: Enable elimination of whitespaces from given text
 //! - `experimental`: Enable experimental module
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #[cfg(all(target_family = "wasm", feature = "blocking"))]
 compile_error! {
     "The `blocking` feature is not supported with wasm target."
@@ -17,6 +18,7 @@ pub(crate) mod domain;
 #[deprecated(since = "0.1.6", note = "This module will be deleted in v0.2")]
 pub mod entity;
 #[cfg(feature = "experimental")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub mod experimental;
 mod formatter;
 pub mod parser;


### PR DESCRIPTION
### 変更点
- #470 
- `experimental`モジュールもdocs.rsに掲載されるように設定を追加

### 備考
- https://users.rust-lang.org/t/how-to-document-optional-features-in-api-docs/64577
