### PR TITLE
ParsedAddressの修正: `Parser#parse`のドキュメントの修正

### DIFF
--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -70,9 +70,9 @@ pub struct Parser {
 }
 
 impl Parser {
-    /// Parse address into token sequence.
+    /// Parse address into [ParsedAddress].
     ///
-    /// 住所をパースしトークン列に変換します。
+    /// 住所をパースし、[ParsedAddress]を返します。
     ///
     /// # Example
     /// ```

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -81,7 +81,11 @@ impl Parser {
     /// async fn example() {
     ///     let parser = Parser::default();
     ///     let result = parser.parse("埼玉県所沢市上山口2135").await;
-    ///     println!("{:?}", result);
+    ///     assert_eq!(result.prefecture, "埼玉県");
+    ///     assert_eq!(result.city, "所沢市");
+    ///     assert_eq!(result.town, "上山口");
+    ///     assert_eq!(result.rest, "2135");
+    ///     assert_eq!(result.metadata.depth, 3);
     /// }
     /// ```
     pub async fn parse(&self, address: &str) -> ParsedAddress {


### PR DESCRIPTION
### 変更点
- #470 で追加した`Parser#parse`のドキュメントが適切でなかったため修正します

### 備考
- マイルストーンの趣旨とは少しずれますが、ついでに直してしまおうと思います
