### PR TITLE
chimei-ruiju.orgへの対応: `experimental`モジュールの`Parser`でChimeiRuijuを使ってパースできるようにした

### DIFF
--- a/core/src/experimental.rs
+++ b/core/src/experimental.rs
@@ -6,5 +6,6 @@
 //!
 //! If you are eager to use this module, please enable `experimental` feature flag.
 
+mod parse_with_chimeiruiju;
 mod parse_with_geolonia;
 pub mod parser;

--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -75,3 +75,111 @@ impl Parser {
         tokenizer.finish().tokens
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::experimental::parser::{DataSource, Parser, ParserOptions};
+
+    #[tokio::test]
+    async fn 都道府県名が誤っている場合() {
+        let parser = Parser {
+            options: ParserOptions {
+                data_source: DataSource::ChimeiRuiju,
+                correct_incomplete_city_names: false,
+                verbose: false,
+            },
+        };
+        let result = parser
+            .parse_with_geolonia("奈川県横浜市磯子区洋光台3-10-3")
+            .await;
+        assert_eq!(
+            result,
+            vec![Token::Rest("奈川県横浜市磯子区洋光台3-10-3".to_string())]
+        )
+    }
+
+    #[tokio::test]
+    async fn 市区町村名が誤っている場合() {
+        let parser = Parser {
+            options: ParserOptions {
+                data_source: DataSource::ChimeiRuiju,
+                correct_incomplete_city_names: false,
+                verbose: false,
+            },
+        };
+        let result = parser
+            .parse_with_geolonia("神奈川県横浜県磯子市洋光台3-10-3")
+            .await;
+        assert_eq!(
+            result,
+            vec![
+                Token::Prefecture(Prefecture {
+                    prefecture_name: "神奈川県".to_string(),
+                    representative_point: None,
+                }),
+                Token::Rest("横浜県磯子市洋光台3-10-3".to_string())
+            ]
+        )
+    }
+
+    #[tokio::test]
+    async fn 町名が誤っている場合() {
+        let parser = Parser {
+            options: ParserOptions {
+                data_source: DataSource::ChimeiRuiju,
+                correct_incomplete_city_names: false,
+                verbose: false,
+            },
+        };
+        let result = parser
+            .parse_with_geolonia("神奈川県横浜市磯子区陽光台3-10-3")
+            .await;
+        assert_eq!(
+            result,
+            vec![
+                Token::Prefecture(Prefecture {
+                    prefecture_name: "神奈川県".to_string(),
+                    representative_point: None,
+                }),
+                Token::City(City {
+                    city_name: "横浜市磯子区".to_string(),
+                    representative_point: None,
+                }),
+                Token::Rest("陽光台3-10-3".to_string())
+            ]
+        )
+    }
+
+    #[tokio::test]
+    async fn パースに成功した場合() {
+        let parser = Parser {
+            options: ParserOptions {
+                data_source: DataSource::ChimeiRuiju,
+                correct_incomplete_city_names: false,
+                verbose: false,
+            },
+        };
+        let result = parser
+            .parse_with_geolonia("神奈川県横浜市磯子区洋光台3-10-3")
+            .await;
+        assert_eq!(
+            result,
+            vec![
+                Token::Prefecture(Prefecture {
+                    prefecture_name: "神奈川県".to_string(),
+                    representative_point: None,
+                }),
+                Token::City(City {
+                    city_name: "横浜市磯子区".to_string(),
+                    representative_point: None,
+                }),
+                Token::Town(Town {
+                    town_name: "洋光台三丁目".to_string(),
+                    representative_point: None,
+                }),
+                Token::Rest("10-3".to_string())
+            ]
+        )
+    }
+}

--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -1,0 +1,77 @@
+use crate::domain::common::token::Token;
+use crate::experimental::parser::Parser;
+use crate::interactor::{ChimeiRuijuInteractor, ChimeiRuijuInteractorImpl};
+use crate::tokenizer::Tokenizer;
+
+impl Parser {
+    pub(crate) async fn parse_with_chimeiruiju(&self, address: &str) -> Vec<Token> {
+        let interactor = ChimeiRuijuInteractorImpl::default();
+        let tokenizer = Tokenizer::new(address);
+
+        // 都道府県名の検出
+        let (prefecture, tokenizer) = match tokenizer.read_prefecture() {
+            Ok(found) => found,
+            Err(not_found) => {
+                if self.options.verbose {
+                    log::error!("都道府県名の検出に失敗しました")
+                }
+                return not_found.tokens;
+            }
+        };
+
+        // 市区町村名の検出
+        let prefecture_master = match interactor.get_prefecture_master(&prefecture).await {
+            Ok(result) => result,
+            Err(error) => {
+                if self.options.verbose {
+                    log::error!("{}", error)
+                }
+                return tokenizer.finish().tokens;
+            }
+        };
+        let (city_name, tokenizer) = match tokenizer.read_city(&prefecture_master.cities) {
+            Ok(found) => found,
+            Err(not_found) => {
+                if self.options.correct_incomplete_city_names {
+                    match not_found.read_city_with_county_name_completion(&prefecture_master.cities)
+                    {
+                        Ok(result) => result,
+                        Err(not_found) => {
+                            if self.options.verbose {
+                                log::error!("市区町村名の検出に失敗しました")
+                            }
+                            return not_found.tokens;
+                        }
+                    }
+                } else {
+                    if self.options.verbose {
+                        log::error!("市区町村名の検出に失敗しました")
+                    }
+                    return not_found.finish().tokens;
+                }
+            }
+        };
+
+        // 町名の検出
+        let city_master = match interactor.get_city_master(&prefecture, &city_name).await {
+            Ok(result) => result,
+            Err(error) => {
+                if self.options.verbose {
+                    log::error!("{}", error)
+                }
+                return tokenizer.finish().tokens;
+            }
+        };
+        let (_, tokenizer) = match tokenizer.read_town(city_master.towns) {
+            Ok(found) => found,
+            Err(not_found) => {
+                if self.options.verbose {
+                    log::error!("町名の検出に失敗しました")
+                }
+                return not_found.tokens;
+            }
+        };
+
+        tokenizer.finish().tokens
+    }
+}

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -4,20 +4,15 @@ use serde::Serialize;
 /// Data source for Parser
 ///
 /// パーサーで使用するデータソースを指定します。
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum DataSource {
     /// ChimeiRuiju 住所データ
     /// <https://github.com/Cocon/chimei-ruiju>
     ChimeiRuiju,
     /// Geolonia 住所データ
     /// <https://github.com/geolonia/japanese-addresses>
+    #[default]
     Geolonia,
-}
-
-impl Default for DataSource {
-    fn default() -> Self {
-        DataSource::Geolonia
-    }
 }
 
 /// Options for Parser

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -6,6 +6,9 @@ use serde::Serialize;
 /// パーサーで使用するデータソースを指定します。
 #[derive(Debug)]
 pub enum DataSource {
+    /// ChimeiRuiju 住所データ
+    /// <https://github.com/Cocon/chimei-ruiju>
+    ChimeiRuiju,
     /// Geolonia 住所データ
     /// <https://github.com/geolonia/japanese-addresses>
     Geolonia,
@@ -90,6 +93,7 @@ impl Parser {
     /// ```
     pub async fn parse(&self, address: &str) -> ParsedAddress {
         let tokens = match self.options.data_source {
+            DataSource::ChimeiRuiju => self.parse_with_chimeiruiju(address).await,
             DataSource::Geolonia => self.parse_with_geolonia(address).await,
         };
         ParsedAddress::from(tokens)

--- a/core/src/interactor.rs
+++ b/core/src/interactor.rs
@@ -6,7 +6,6 @@ use crate::repository::chimei_ruiju::town::TownMasterRepository;
 use crate::service::chimei_ruiju::ChimeiRuijuApiService;
 use jisx0401::Prefecture;
 
-#[allow(dead_code)]
 pub(crate) trait ChimeiRuijuInteractor {
     /// 都道府県マスタを取得
     async fn get_prefecture_master(
@@ -28,7 +27,6 @@ pub(crate) trait ChimeiRuijuInteractor {
     ) -> Result<TownMaster, ApiError>;
 }
 
-#[allow(dead_code)]
 pub(crate) struct ChimeiRuijuInteractorImpl {
     api_service: ChimeiRuijuApiService,
 }


### PR DESCRIPTION
### 変更点
- #426 
- `parse_with_chimeiruiju()`を追加します。
- `experimental::Parser`において`DataSource::ChimeiRuiju`を指定することで、ChimeiRuijuを使ってパースをできるようにします。