### PR TITLE
chimei-ruiju.org: Clippyの警告を抑制

### DIFF
--- a/core/src/domain.rs
+++ b/core/src/domain.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "experimental")]
 pub mod chimei_ruiju;
 pub mod common;
 pub mod geolonia;

--- a/core/src/domain/chimei_ruiju/entity.rs
+++ b/core/src/domain/chimei_ruiju/entity.rs
@@ -30,6 +30,7 @@ pub struct TownMaster {
     coordinate: Coordinate,
 }
 
+#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 pub struct Block {
     /// 小字・通称名
@@ -42,6 +43,7 @@ pub struct Block {
     coordinate: Coordinate,
 }
 
+#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 pub struct Coordinate {
     /// 緯度

--- a/core/src/interactor.rs
+++ b/core/src/interactor.rs
@@ -1,1 +1,2 @@
+#[cfg(feature = "experimental")]
 pub mod chimei_ruiju;

--- a/core/src/interactor/chimei_ruiju.rs
+++ b/core/src/interactor/chimei_ruiju.rs
@@ -19,6 +19,7 @@ pub(crate) trait ChimeiRuijuInteractor {
         city_name: &str,
     ) -> Result<CityMaster, ApiError>;
     /// 町名マスタを取得
+    #[allow(dead_code)]
     async fn get_town_master(
         &self,
         prefecture: &Prefecture,
@@ -55,6 +56,7 @@ impl ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl {
         CityMasterRepository::get(&self.api_service, prefecture, city_name).await
     }
 
+    #[allow(dead_code)]
     async fn get_town_master(
         &self,
         prefecture: &Prefecture,

--- a/core/src/repository.rs
+++ b/core/src/repository.rs
@@ -1,2 +1,3 @@
+#[cfg(feature = "experimental")]
 pub mod chimei_ruiju;
 pub mod geolonia;

--- a/core/src/repository/chimei_ruiju/city.rs
+++ b/core/src/repository/chimei_ruiju/city.rs
@@ -51,6 +51,7 @@ mod async_tests {
 
 #[cfg(feature = "blocking")]
 impl CityMasterRepository {
+    #[allow(dead_code)]
     pub fn get_blocking(
         api_service: &ChimeiRuijuApiService,
         prefecture: &Prefecture,

--- a/core/src/repository/chimei_ruiju/prefecture.rs
+++ b/core/src/repository/chimei_ruiju/prefecture.rs
@@ -132,6 +132,7 @@ mod async_tests {
 
 #[cfg(feature = "blocking")]
 impl PrefectureMasterRepository {
+    #[allow(dead_code)]
     pub fn get_blocking(
         api_service: &ChimeiRuijuApiService,
         prefecture: Prefecture,

--- a/core/src/repository/chimei_ruiju/town.rs
+++ b/core/src/repository/chimei_ruiju/town.rs
@@ -7,6 +7,7 @@ use jisx0401::Prefecture;
 pub struct TownMasterRepository {}
 
 impl TownMasterRepository {
+    #[allow(dead_code)]
     pub async fn get(
         api_service: &ChimeiRuijuApiService,
         prefecture: &Prefecture,
@@ -42,6 +43,7 @@ mod async_tests {
 
 #[cfg(feature = "blocking")]
 impl TownMasterRepository {
+    #[allow(dead_code)]
     pub fn get_blocking(
         api_service: &ChimeiRuijuApiService,
         prefecture: &Prefecture,

--- a/core/src/service.rs
+++ b/core/src/service.rs
@@ -1,2 +1,3 @@
+#[cfg(feature = "experimental")]
 pub mod chimei_ruiju;
 pub mod geolonia;


### PR DESCRIPTION
### 変更点
- #426 
- clippyの警告を抑制するために、現在使用箇所がないが今後使用予定のものに`#[allow(dead_code)]`を付与します。
- また、`experimental`モジュールで使用されているものについては、フィーチャフラグ`experimental`が有効な場合のみビルドされるように設定します。
