### PR TITLE
chimei-ruiju.orgへの対応: `Parser#parse_with_chimeiruiju`に対するテストコードを修正

### DIFF
--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -91,7 +91,7 @@ mod tests {
             },
         };
         let result = parser
-            .parse_with_geolonia("奈川県横浜市磯子区洋光台3-10-3")
+            .parse_with_chimeiruiju("奈川県横浜市磯子区洋光台3-10-3")
             .await;
         assert_eq!(
             result,
@@ -109,7 +109,7 @@ mod tests {
             },
         };
         let result = parser
-            .parse_with_geolonia("神奈川県横浜県磯子市洋光台3-10-3")
+            .parse_with_chimeiruiju("神奈川県横浜県磯子市洋光台3-10-3")
             .await;
         assert_eq!(
             result,
@@ -133,7 +133,7 @@ mod tests {
             },
         };
         let result = parser
-            .parse_with_geolonia("神奈川県横浜市磯子区陽光台3-10-3")
+            .parse_with_chimeiruiju("神奈川県横浜市磯子区陽光台3-10-3")
             .await;
         assert_eq!(
             result,
@@ -161,7 +161,7 @@ mod tests {
             },
         };
         let result = parser
-            .parse_with_geolonia("神奈川県横浜市磯子区洋光台3-10-3")
+            .parse_with_chimeiruiju("神奈川県横浜市磯子区洋光台3-10-3")
             .await;
         assert_eq!(
             result,


### PR DESCRIPTION
### 変更点
- #426 
- ChimeiRuijuではなくGeoloniaのデータを使うテストになっており、意図が異なるテストになっていたため修正します。
