### PR TITLE
chimei-ruiju.orgへの対応: 住所のパースに成功した場合に位置情報を`ParsedAddress`に含めるようにする

### DIFF
--- a/core/src/domain/chimei_ruiju/entity.rs
+++ b/core/src/domain/chimei_ruiju/entity.rs
@@ -28,7 +28,7 @@ pub struct TownMaster {
     /// 街区リスト
     blocks: Vec<Block>,
     /// 緯度経度
-    coordinate: Coordinate,
+    pub(crate) coordinate: Coordinate,
 }
 
 #[allow(dead_code)]

--- a/core/src/domain/chimei_ruiju/entity.rs
+++ b/core/src/domain/chimei_ruiju/entity.rs
@@ -1,3 +1,4 @@
+use crate::domain::common::latlng::LatLng;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
@@ -17,7 +18,7 @@ pub struct CityMaster {
     /// 町名リスト
     pub(crate) towns: Vec<String>,
     /// 緯度経度
-    coordinate: Coordinate,
+    pub(crate) coordinate: Coordinate,
 }
 
 #[derive(Deserialize, Debug)]
@@ -50,4 +51,13 @@ pub struct Coordinate {
     pub(crate) latitude: f64,
     /// 経度
     pub(crate) longitude: f64,
+}
+
+impl Coordinate {
+    pub(crate) fn to_lat_lng(&self) -> LatLng {
+        LatLng {
+            latitude: self.latitude,
+            longitude: self.longitude,
+        }
+    }
 }

--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -73,7 +73,7 @@ impl Parser {
             }
         };
         // 町名の検出
-        let (_, tokenizer) = match tokenizer.read_town(city_master.towns) {
+        let (town_name, tokenizer) = match tokenizer.read_town(city_master.towns) {
             Ok(found) => found,
             Err(not_found) => {
                 if self.options.verbose {
@@ -81,6 +81,14 @@ impl Parser {
                 }
                 return not_found.tokens;
             }
+        };
+
+        // 町村マスタの取得
+        if let Ok(town_master) = interactor
+            .get_town_master(&prefecture, &city_name, &town_name)
+            .await
+        {
+            lat_lng.replace(town_master.coordinate.to_lat_lng());
         };
 
         log::info!("{:?}", lat_lng);

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -1,3 +1,4 @@
+use crate::domain::common::latlng::LatLng;
 use crate::domain::common::token::Token;
 use serde::Serialize;
 
@@ -180,6 +181,17 @@ impl From<Vec<Token>> for ParsedAddress {
             }
         }
 
+        parsed_address
+    }
+}
+
+impl From<(Vec<Token>, Option<LatLng>)> for ParsedAddress {
+    fn from((tokens, lat_lng): (Vec<Token>, Option<LatLng>)) -> Self {
+        let mut parsed_address = ParsedAddress::from(tokens);
+        if let Some(lat_lng) = lat_lng {
+            parsed_address.metadata.longitude = Some(lat_lng.longitude);
+            parsed_address.metadata.latitude = Some(lat_lng.latitude);
+        }
         parsed_address
     }
 }

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -88,11 +88,12 @@ impl Parser {
     /// }
     /// ```
     pub async fn parse(&self, address: &str) -> ParsedAddress {
-        let tokens = match self.options.data_source {
-            DataSource::ChimeiRuiju => self.parse_with_chimeiruiju(address).await,
-            DataSource::Geolonia => self.parse_with_geolonia(address).await,
-        };
-        ParsedAddress::from(tokens)
+        match self.options.data_source {
+            DataSource::ChimeiRuiju => {
+                ParsedAddress::from(self.parse_with_chimeiruiju(address).await)
+            }
+            DataSource::Geolonia => ParsedAddress::from(self.parse_with_geolonia(address).await),
+        }
     }
 }
 

--- a/core/src/interactor/chimei_ruiju.rs
+++ b/core/src/interactor/chimei_ruiju.rs
@@ -56,7 +56,6 @@ impl ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl {
         CityMasterRepository::get(&self.api_service, prefecture, city_name).await
     }
 
-    #[allow(dead_code)]
     async fn get_town_master(
         &self,
         prefecture: &Prefecture,

--- a/core/src/repository/chimei_ruiju/town.rs
+++ b/core/src/repository/chimei_ruiju/town.rs
@@ -3,11 +3,9 @@ use crate::domain::chimei_ruiju::error::ApiError;
 use crate::service::chimei_ruiju::ChimeiRuijuApiService;
 use jisx0401::Prefecture;
 
-#[allow(dead_code)]
 pub struct TownMasterRepository {}
 
 impl TownMasterRepository {
-    #[allow(dead_code)]
     pub async fn get(
         api_service: &ChimeiRuijuApiService,
         prefecture: &Prefecture,


### PR DESCRIPTION
### 変更点
- #426 
- ChimeiRuijuデータの都道府県マスタ・市区町村マスタ・町村マスタでそれぞれの地域の代表点の緯度経度を取得することができます。
- 住所のパースに成功した場合、その地域の緯度経度情報を`ParsedAddress`に含めるようにします。

### 備考
- この修正により、`experimental::Parser`を用いて簡易的なジオコーディングが可能になります。
