### PR TITLE
Tokenのリファクタ: `Token::Town`に格納する値の型を`Town`から`String`に変更

### DIFF
--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -53,12 +53,6 @@ pub(crate) struct City {
     pub(crate) representative_point: Option<LatLng>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub(crate) struct Town {
-    pub(crate) town_name: String,
-    pub(crate) representative_point: Option<LatLng>,
-}
-
 pub(crate) fn append_token(tokens: &[Token], token: Token) -> Vec<Token> {
     [tokens.to_owned(), vec![token]].concat()
 }

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering::{Equal, Greater, Less};
 pub enum Token {
     Prefecture(Prefecture),
     City(City),
-    Town(Town),
+    Town(String),
     Rest(String),
 }
 
@@ -65,7 +65,7 @@ pub(crate) fn append_token(tokens: &[Token], token: Token) -> Vec<Token> {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::domain::common::token::{City, Prefecture, Token};
 
     #[test]
     fn sort_token_vector() {
@@ -79,10 +79,7 @@ mod tests {
                 prefecture_name: "東京都".to_string(),
                 representative_point: None,
             }),
-            Token::Town(Town {
-                town_name: "貫井北町四丁目".to_string(),
-                representative_point: None,
-            }),
+            Token::Town("貫井北町四丁目".to_string()),
         ];
         tokens.sort_by(|a, b| a.partial_cmp(b).unwrap());
         assert_eq!(
@@ -96,10 +93,7 @@ mod tests {
                     city_name: "小金井市".to_string(),
                     representative_point: None,
                 }),
-                Token::Town(Town {
-                    town_name: "貫井北町四丁目".to_string(),
-                    representative_point: None,
-                }),
+                Token::Town("貫井北町四丁目".to_string()),
                 Token::Rest("2-1".to_string()),
             ]
         );

--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -100,7 +100,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::domain::common::token::{City, Prefecture, Token};
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -196,10 +196,7 @@ mod tests {
                     city_name: "横浜市磯子区".to_string(),
                     representative_point: None,
                 }),
-                Token::Town(Town {
-                    town_name: "洋光台三丁目".to_string(),
-                    representative_point: None,
-                }),
+                Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())
             ]
         )

--- a/core/src/experimental/parse_with_geolonia.rs
+++ b/core/src/experimental/parse_with_geolonia.rs
@@ -86,7 +86,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::domain::common::token::{City, Prefecture, Token};
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -182,10 +182,7 @@ mod tests {
                     city_name: "横浜市磯子区".to_string(),
                     representative_point: None,
                 }),
-                Token::Town(Town {
-                    town_name: "洋光台三丁目".to_string(),
-                    representative_point: None,
-                }),
+                Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())
             ]
         )

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -168,13 +168,9 @@ impl From<Vec<Token>> for ParsedAddress {
                         parsed_address.metadata.longitude = Some(lat_lng.longitude);
                     }
                 }
-                Token::Town(town) => {
-                    parsed_address.town = town.town_name;
+                Token::Town(town_name) => {
+                    parsed_address.town = town_name;
                     parsed_address.metadata.depth = 3;
-                    if let Some(lat_lng) = town.representative_point {
-                        parsed_address.metadata.latitude = Some(lat_lng.latitude);
-                        parsed_address.metadata.longitude = Some(lat_lng.longitude);
-                    }
                 }
                 Token::Rest(rest) => {
                     parsed_address.rest = rest;
@@ -200,7 +196,7 @@ impl From<(Vec<Token>, Option<LatLng>)> for ParsedAddress {
 #[cfg(test)]
 mod tests {
     use crate::domain::common::latlng::LatLng;
-    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::domain::common::token::{City, Prefecture, Token};
     use crate::experimental::parser::{Metadata, ParsedAddress};
 
     #[test]
@@ -307,16 +303,14 @@ mod tests {
                     longitude: 35.708143,
                 }),
             }),
-            Token::Town(Town {
-                town_name: "本駒込六丁目".to_string(),
-                representative_point: Some(LatLng {
-                    latitude: 139.738043,
-                    longitude: 35.72791,
-                }),
-            }),
+            Token::Town("本駒込六丁目".to_string()),
             Token::Rest("16-3".to_string()),
         ];
-        let parsed_address = ParsedAddress::from(tokens);
+        let lat_lng = Some(LatLng {
+            latitude: 139.738043,
+            longitude: 35.72791,
+        });
+        let parsed_address = ParsedAddress::from((tokens, lat_lng));
         assert_eq!(
             parsed_address,
             ParsedAddress {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -18,7 +18,7 @@ impl From<Tokenizer<End>> for Address {
             match token {
                 Token::Prefecture(prefecture) => address.prefecture = prefecture.prefecture_name,
                 Token::City(city) => address.city = city.city_name,
-                Token::Town(town) => address.town = town.town_name,
+                Token::Town(town_name) => address.town = town_name,
                 Token::Rest(rest) => address.rest = rest,
             }
         }

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -1,4 +1,4 @@
-use crate::domain::common::token::{append_token, Token, Town};
+use crate::domain::common::token::{append_token, Token};
 use crate::formatter::chome_with_arabic_numerals::format_chome_with_arabic_numerals;
 use crate::formatter::fullwidth_character::format_fullwidth_number;
 use crate::formatter::house_number::format_house_number;
@@ -39,13 +39,7 @@ impl Tokenizer<CityNameFound> {
         Ok((
             town_name.clone(),
             Tokenizer {
-                tokens: append_token(
-                    &self.tokens,
-                    Token::Town(Town {
-                        town_name,
-                        representative_point: None,
-                    }),
-                ),
+                tokens: append_token(&self.tokens, Token::Town(town_name)),
                 rest: if cfg!(feature = "format-house-number") && format_house_number(&rest).is_ok()
                 {
                     format_house_number(&rest).unwrap()


### PR DESCRIPTION
### 変更点
- #498 
- 従来は町名とその代表点の緯度経度をもたせた`Town`という構造体を持たせていたが、`Tokenizer`では緯度経度の情報は扱わないので、単に町名の`String`だけをもたせるようにします
