### PR TITLE
Tokenのリファクタ: `Token::City`に格納する値の型を`City`から`String`に変更

### DIFF
--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -47,12 +47,6 @@ pub(crate) struct Prefecture {
     pub(crate) representative_point: Option<LatLng>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub(crate) struct City {
-    pub(crate) city_name: String,
-    pub(crate) representative_point: Option<LatLng>,
-}
-
 pub(crate) fn append_token(tokens: &[Token], token: Token) -> Vec<Token> {
     [tokens.to_owned(), vec![token]].concat()
 }

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering::{Equal, Greater, Less};
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     Prefecture(Prefecture),
-    City(City),
+    City(String),
     Town(String),
     Rest(String),
 }
@@ -59,16 +59,13 @@ pub(crate) fn append_token(tokens: &[Token], token: Token) -> Vec<Token> {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
 
     #[test]
     fn sort_token_vector() {
         let mut tokens = vec![
             Token::Rest("2-1".to_string()),
-            Token::City(City {
-                city_name: "小金井市".to_string(),
-                representative_point: None,
-            }),
+            Token::City("小金井市".to_string()),
             Token::Prefecture(Prefecture {
                 prefecture_name: "東京都".to_string(),
                 representative_point: None,
@@ -83,10 +80,7 @@ mod tests {
                     prefecture_name: "東京都".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "小金井市".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("小金井市".to_string()),
                 Token::Town("貫井北町四丁目".to_string()),
                 Token::Rest("2-1".to_string()),
             ]

--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -100,7 +100,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -164,10 +164,7 @@ mod tests {
                     prefecture_name: "神奈川県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "横浜市磯子区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("横浜市磯子区".to_string()),
                 Token::Rest("陽光台3-10-3".to_string())
             ]
         )
@@ -192,10 +189,7 @@ mod tests {
                     prefecture_name: "神奈川県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "横浜市磯子区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("横浜市磯子区".to_string()),
                 Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())
             ]

--- a/core/src/experimental/parse_with_geolonia.rs
+++ b/core/src/experimental/parse_with_geolonia.rs
@@ -86,7 +86,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -150,10 +150,7 @@ mod tests {
                     prefecture_name: "神奈川県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "横浜市磯子区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("横浜市磯子区".to_string()),
                 Token::Rest("陽光台3-10-3".to_string())
             ]
         )
@@ -178,10 +175,7 @@ mod tests {
                     prefecture_name: "神奈川県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "横浜市磯子区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("横浜市磯子区".to_string()),
                 Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())
             ]

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -160,13 +160,9 @@ impl From<Vec<Token>> for ParsedAddress {
                         parsed_address.metadata.longitude = Some(lat_lng.longitude);
                     }
                 }
-                Token::City(city) => {
-                    parsed_address.city = city.city_name;
+                Token::City(city_name) => {
+                    parsed_address.city = city_name;
                     parsed_address.metadata.depth = 2;
-                    if let Some(lat_lng) = city.representative_point {
-                        parsed_address.metadata.latitude = Some(lat_lng.latitude);
-                        parsed_address.metadata.longitude = Some(lat_lng.longitude);
-                    }
                 }
                 Token::Town(town_name) => {
                     parsed_address.town = town_name;
@@ -196,7 +192,7 @@ impl From<(Vec<Token>, Option<LatLng>)> for ParsedAddress {
 #[cfg(test)]
 mod tests {
     use crate::domain::common::latlng::LatLng;
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
     use crate::experimental::parser::{Metadata, ParsedAddress};
 
     #[test]
@@ -260,16 +256,14 @@ mod tests {
                     longitude: 35.68532,
                 }),
             }),
-            Token::City(City {
-                city_name: "台東区".to_string(),
-                representative_point: Some(LatLng {
-                    latitude: 139.764379,
-                    longitude: 35.711162,
-                }),
-            }),
+            Token::City("台東区".to_string()),
             Token::Rest("".to_string()),
         ];
-        let parsed_address = ParsedAddress::from(tokens);
+        let lat_lng = Some(LatLng {
+            latitude: 139.764379,
+            longitude: 35.711162,
+        });
+        let parsed_address = ParsedAddress::from((tokens, lat_lng));
         assert_eq!(
             parsed_address,
             ParsedAddress {
@@ -296,13 +290,7 @@ mod tests {
                     longitude: 35.68532,
                 }),
             }),
-            Token::City(City {
-                city_name: "文京区".to_string(),
-                representative_point: Some(LatLng {
-                    latitude: 139.749542,
-                    longitude: 35.708143,
-                }),
-            }),
+            Token::City("文京区".to_string()),
             Token::Town("本駒込六丁目".to_string()),
             Token::Rest("16-3".to_string()),
         ];

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -17,7 +17,7 @@ impl From<Tokenizer<End>> for Address {
         for token in value.tokens {
             match token {
                 Token::Prefecture(prefecture) => address.prefecture = prefecture.prefecture_name,
-                Token::City(city) => address.city = city.city_name,
+                Token::City(city_name) => address.city = city_name,
                 Token::Town(town_name) => address.town = town_name,
                 Token::Rest(rest) => address.rest = rest,
             }

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -1,4 +1,4 @@
-use crate::domain::common::token::{append_token, City, Token};
+use crate::domain::common::token::{append_token, Token};
 use crate::parser::adapter::orthographical_variant_adapter::{
     OrthographicalVariantAdapter, OrthographicalVariants, Variant,
 };
@@ -17,13 +17,7 @@ impl Tokenizer<PrefectureNameFound> {
             return Ok((
                 found.to_string(),
                 Tokenizer {
-                    tokens: append_token(
-                        &self.tokens,
-                        Token::City(City {
-                            city_name: found.to_string(),
-                            representative_point: None,
-                        }),
-                    ),
+                    tokens: append_token(&self.tokens, Token::City(found.to_string())),
                     rest: self
                         .rest
                         .chars()
@@ -69,13 +63,7 @@ impl Tokenizer<PrefectureNameFound> {
                 return Ok((
                     city_name.clone(),
                     Tokenizer {
-                        tokens: append_token(
-                            &self.tokens,
-                            Token::City(City {
-                                city_name,
-                                representative_point: None,
-                            }),
-                        ),
+                        tokens: append_token(&self.tokens, Token::City(city_name)),
                         rest,
                         _state: PhantomData::<CityNameFound>,
                     },

--- a/core/src/tokenizer/read_city_with_county_name_completion.rs
+++ b/core/src/tokenizer/read_city_with_county_name_completion.rs
@@ -1,4 +1,4 @@
-use crate::domain::common::token::{append_token, City, Token};
+use crate::domain::common::token::{append_token, Token};
 use crate::tokenizer::{CityNameFound, CityNameNotFound, End, Tokenizer};
 use crate::util::sequence_matcher::SequenceMatcher;
 use std::marker::PhantomData;
@@ -15,13 +15,7 @@ impl Tokenizer<CityNameNotFound> {
                 return Ok((
                     highest_match.clone(),
                     Tokenizer {
-                        tokens: append_token(
-                            &self.tokens,
-                            Token::City(City {
-                                city_name: highest_match.clone(),
-                                representative_point: None,
-                            }),
-                        ),
+                        tokens: append_token(&self.tokens, Token::City(highest_match.clone())),
                         rest: complemented_address
                             .chars()
                             .skip(highest_match.chars().count())

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -101,7 +101,7 @@ fn find_town(input: &str, candidates: &Vec<String>) -> Option<(String, String)> 
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
     use crate::tokenizer::{CityNameFound, Tokenizer};
     use std::marker::PhantomData;
 
@@ -113,10 +113,7 @@ mod tests {
                     prefecture_name: "静岡県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "静岡市清水区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("静岡市清水区".to_string()),
             ],
             rest: "旭町6番8号".to_string(),
             _state: PhantomData::<CityNameFound>,
@@ -143,10 +140,7 @@ mod tests {
                     prefecture_name: "東京都".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "千代田区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("千代田区".to_string()),
             ],
             rest: "一ッ橋二丁目1番".to_string(), // 「ッ」と「ツ」の表記ゆれ
             _state: PhantomData::<CityNameFound>,
@@ -173,10 +167,7 @@ mod tests {
                     prefecture_name: "京都府".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "京都市東山区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("京都市東山区".to_string()),
             ],
             rest: "本町22丁目489番".to_string(),
             _state: PhantomData::<CityNameFound>,
@@ -204,10 +195,7 @@ mod tests {
                     prefecture_name: "東京都".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "西多摩郡日の出町".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("西多摩郡日の出町".to_string()),
             ],
             rest: "平井2780番地".to_string(), // 「大字」が省略されている
             _state: PhantomData::<CityNameFound>,
@@ -228,10 +216,7 @@ mod tests {
                     prefecture_name: "静岡県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "静岡市清水区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("静岡市清水区".to_string()),
             ],
             rest: "".to_string(),
             _state: PhantomData::<CityNameFound>,


### PR DESCRIPTION
### 変更点
- #498 
- 従来は市区町村名とその代表点の緯度経度をもたせた`City`という構造体を持たせていたが、Tokenizerでは緯度経度の情報は扱わないので、単に市区町村名のStringだけをもたせるようにします
