### PR TITLE
apiモジュールを非推奨化

### DIFF
--- a/core/src/interactor/geolonia.rs
+++ b/core/src/interactor/geolonia.rs
@@ -1,7 +1,8 @@
-use crate::api::city_master_api::CityMasterApi;
-use crate::api::prefecture_master_api::PrefectureMasterApi;
 use crate::domain::geolonia::entity::{City, Prefecture};
 use crate::domain::geolonia::error::Error;
+use crate::repository::geolonia::city::CityMasterRepository;
+use crate::repository::geolonia::prefecture::PrefectureMasterRepository;
+use crate::service::geolonia::GeoloniaApiService;
 
 #[allow(dead_code)]
 pub(crate) trait GeoloniaInteractor {
@@ -25,23 +26,22 @@ pub(crate) trait GeoloniaInteractor {
 }
 
 #[allow(dead_code)]
-pub(crate) struct GeoloniaInteractorImpl;
+pub(crate) struct GeoloniaInteractorImpl {
+    api_service: GeoloniaApiService,
+}
 
 impl GeoloniaInteractor for GeoloniaInteractorImpl {
     async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
-        let prefecture_master_api = PrefectureMasterApi::default();
-        prefecture_master_api.get(prefecture_name).await
+        PrefectureMasterRepository::get(&self.api_service, prefecture_name).await
     }
 
     #[cfg(feature = "blocking")]
     fn get_blocking_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
-        let prefecture_master_api = PrefectureMasterApi::default();
-        prefecture_master_api.get_blocking(prefecture_name)
+        PrefectureMasterRepository::get_blocking(&self.api_service, prefecture_name)
     }
 
     async fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
-        let city_master_api = CityMasterApi::default();
-        city_master_api.get(prefecture_name, city_name).await
+        CityMasterRepository::get(&self.api_service, prefecture_name, city_name).await
     }
 
     #[cfg(feature = "blocking")]
@@ -50,7 +50,6 @@ impl GeoloniaInteractor for GeoloniaInteractorImpl {
         prefecture_name: &str,
         city_name: &str,
     ) -> Result<City, Error> {
-        let city_master_api = CityMasterApi::default();
-        city_master_api.get_blocking(prefecture_name, city_name)
+        CityMasterRepository::get_blocking(&self.api_service, prefecture_name, city_name)
     }
 }

--- a/core/src/repository/geolonia.rs
+++ b/core/src/repository/geolonia.rs
@@ -1,2 +1,3 @@
+pub(crate) mod city;
 pub mod city_master_api;
 pub mod prefecture_master_api;

--- a/core/src/repository/geolonia.rs
+++ b/core/src/repository/geolonia.rs
@@ -1,3 +1,4 @@
 pub(crate) mod city;
 pub mod city_master_api;
+pub(crate) mod prefecture;
 pub mod prefecture_master_api;

--- a/core/src/repository/geolonia/city.rs
+++ b/core/src/repository/geolonia/city.rs
@@ -1,0 +1,102 @@
+use crate::domain::geolonia::entity::{City, Town};
+use crate::domain::geolonia::error::Error;
+use crate::service::geolonia::GeoloniaApiService;
+
+pub struct CityMasterRepository {}
+
+impl CityMasterRepository {
+    pub async fn get(
+        api_service: &GeoloniaApiService,
+        prefecture_name: &str,
+        city_name: &str,
+    ) -> Result<City, Error> {
+        let server_url = "https://geolonia.github.io/japanese-addresses/api/ja";
+        let endpoint = format!("{}/{}/{}.json", server_url, prefecture_name, city_name);
+        let towns = api_service.get::<Vec<Town>>(&endpoint).await?;
+        Ok(City {
+            name: city_name.to_string(),
+            towns,
+        })
+    }
+
+    #[cfg(feature = "blocking")]
+    pub fn get_blocking(
+        api_service: &GeoloniaApiService,
+        prefecture_name: &str,
+        city_name: &str,
+    ) -> Result<City, Error> {
+        let server_url = "https://geolonia.github.io/japanese-addresses/api/ja";
+        let endpoint = format!("{}/{}/{}.json", server_url, prefecture_name, city_name);
+        let towns = api_service.get_blocking::<Vec<Town>>(&endpoint)?;
+        Ok(City {
+            name: city_name.to_string(),
+            towns,
+        })
+    }
+}
+
+#[cfg(all(test, not(feature = "blocking")))]
+mod async_tests {
+    use crate::domain::geolonia::entity::Town;
+    use crate::repository::geolonia::city::CityMasterRepository;
+    use crate::service::geolonia::GeoloniaApiService;
+
+    #[tokio::test]
+    async fn 非同期_石川県羽咋郡志賀町_成功() {
+        let api_service = GeoloniaApiService {};
+        let result = CityMasterRepository::get(&api_service, "石川県", "羽咋郡志賀町").await;
+        let city = result.unwrap();
+        assert_eq!(city.name, "羽咋郡志賀町");
+        let town = Town {
+            name: "末吉".to_string(),
+            koaza: "千古".to_string(),
+            lat: Some(37.006235),
+            lng: Some(136.779155),
+        };
+        assert!(city.towns.contains(&town));
+    }
+
+    #[tokio::test]
+    async fn 非同期_誤った市区町村名_失敗() {
+        let api_service = GeoloniaApiService {};
+        let result = CityMasterRepository::get(&api_service, "石川県", "敦賀市").await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().error_message,
+            "https://geolonia.github.io/japanese-addresses/api/ja/石川県/敦賀市.jsonを取得できませんでした"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "blocking"))]
+mod blocking_tests {
+    use crate::domain::geolonia::entity::Town;
+    use crate::repository::geolonia::city::CityMasterRepository;
+    use crate::service::geolonia::GeoloniaApiService;
+
+    #[test]
+    fn 同期_石川県羽咋郡志賀町_成功() {
+        let api_service = GeoloniaApiService {};
+        let result = CityMasterRepository::get_blocking(&api_service, "石川県", "羽咋郡志賀町");
+        let city = result.unwrap();
+        assert_eq!(city.name, "羽咋郡志賀町");
+        let town = Town {
+            name: "末吉".to_string(),
+            koaza: "千古".to_string(),
+            lat: Some(37.006235),
+            lng: Some(136.779155),
+        };
+        assert!(city.towns.contains(&town));
+    }
+
+    #[test]
+    fn 同期_誤った市区町村名_失敗() {
+        let api_service = GeoloniaApiService {};
+        let result = CityMasterRepository::get_blocking(&api_service, "石川県", "敦賀市");
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().error_message,
+            "https://geolonia.github.io/japanese-addresses/api/ja/石川県/敦賀市.jsonを取得できませんでした",
+        );
+    }
+}

--- a/core/src/repository/geolonia/prefecture.rs
+++ b/core/src/repository/geolonia/prefecture.rs
@@ -1,0 +1,120 @@
+use crate::domain::geolonia::entity::Prefecture;
+use crate::domain::geolonia::error::Error;
+use crate::service::geolonia::GeoloniaApiService;
+
+pub struct PrefectureMasterRepository {}
+
+impl PrefectureMasterRepository {
+    pub async fn get(
+        api_service: &GeoloniaApiService,
+        prefecture_name: &str,
+    ) -> Result<Prefecture, Error> {
+        let server_url = "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist";
+        let endpoint = format!("{}/{}/master.json", server_url, prefecture_name);
+        api_service.get::<Prefecture>(&endpoint).await
+    }
+
+    #[cfg(feature = "blocking")]
+    pub fn get_blocking(
+        api_service: &GeoloniaApiService,
+        prefecture_name: &str,
+    ) -> Result<Prefecture, Error> {
+        let server_url = "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist";
+        let endpoint = format!("{}/{}/master.json", server_url, prefecture_name);
+        api_service.get_blocking::<Prefecture>(&endpoint)
+    }
+}
+
+#[cfg(all(test, not(feature = "blocking")))]
+mod tests {
+    use crate::repository::geolonia::prefecture::PrefectureMasterRepository;
+    use crate::repository::geolonia::prefecture_master_api::PrefectureMasterApi;
+    use crate::service::geolonia::GeoloniaApiService;
+
+    #[tokio::test]
+    async fn 非同期_富山県_成功() {
+        let api_service = GeoloniaApiService {};
+        let result = PrefectureMasterRepository::get(&api_service, "富山県").await;
+        let prefecture = result.unwrap();
+        assert_eq!(prefecture.name, "富山県");
+        let cities = vec![
+            "富山市",
+            "高岡市",
+            "魚津市",
+            "氷見市",
+            "滑川市",
+            "黒部市",
+            "砺波市",
+            "小矢部市",
+            "南砺市",
+            "射水市",
+            "中新川郡舟橋村",
+            "中新川郡上市町",
+            "中新川郡立山町",
+            "下新川郡入善町",
+            "下新川郡朝日町",
+        ];
+        for city in cities {
+            assert!(prefecture.cities.contains(&city.to_string()));
+        }
+    }
+
+    #[tokio::test]
+    async fn 非同期_誤った都道府県名_失敗() {
+        let prefecture_master_api: PrefectureMasterApi = Default::default();
+        let result = prefecture_master_api.get("大阪都").await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().error_message,
+            format!(
+                "{}/大阪都/master.jsonを取得できませんでした",
+                prefecture_master_api.server_url
+            )
+        );
+    }
+}
+
+#[cfg(all(test, feature = "blocking"))]
+mod blocking_tests {
+    use crate::repository::geolonia::prefecture::PrefectureMasterRepository;
+    use crate::service::geolonia::GeoloniaApiService;
+
+    #[test]
+    fn 同期_富山県_成功() {
+        let api_service = GeoloniaApiService {};
+        let result = PrefectureMasterRepository::get_blocking(&api_service, "富山県");
+        let prefecture = result.unwrap();
+        assert_eq!(prefecture.name, "富山県");
+        let cities = vec![
+            "富山市",
+            "高岡市",
+            "魚津市",
+            "氷見市",
+            "滑川市",
+            "黒部市",
+            "砺波市",
+            "小矢部市",
+            "南砺市",
+            "射水市",
+            "中新川郡舟橋村",
+            "中新川郡上市町",
+            "中新川郡立山町",
+            "下新川郡入善町",
+            "下新川郡朝日町",
+        ];
+        for city in cities {
+            assert!(prefecture.cities.contains(&city.to_string()));
+        }
+    }
+
+    #[test]
+    fn 同期_誤った都道府県名_失敗() {
+        let api_service = GeoloniaApiService {};
+        let result = PrefectureMasterRepository::get_blocking(&api_service, "大阪都");
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().error_message,
+            "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist/大阪都/master.jsonを取得できませんでした",
+        );
+    }
+}


### PR DESCRIPTION
### 変更点
- #499 
- `PrefectureMasterApi`および`CityMasterApi`を置き換える目的で、`PrefectureMasterRepository`および`CityMasterRepository`を追加します。
- #503 で追加した`GeoloniaInteractor`の実装も後者をベースとした実装に修正します。
