### PR TITLE
apiモジュールを非推奨化: 非推奨化するモジュールに`#[deprecated]`を付与

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ compile_error! {
     "The `blocking` feature is not supported with wasm target."
 }
 
+#[deprecated(since = "0.1.23", note = "This module will be deleted in v0.2")]
 pub mod api;
 pub(crate) mod domain;
 #[deprecated(since = "0.1.6", note = "This module will be deleted in v0.2")]

--- a/core/src/repository/geolonia.rs
+++ b/core/src/repository/geolonia.rs
@@ -1,4 +1,5 @@
 pub(crate) mod city;
+#[deprecated(since = "0.1.23", note = "This module will be deleted in v0.2")]
 pub mod city_master_api;
 pub(crate) mod prefecture;
 pub mod prefecture_master_api;

--- a/core/src/repository/geolonia.rs
+++ b/core/src/repository/geolonia.rs
@@ -2,4 +2,5 @@ pub(crate) mod city;
 #[deprecated(since = "0.1.23", note = "This module will be deleted in v0.2")]
 pub mod city_master_api;
 pub(crate) mod prefecture;
+#[deprecated(since = "0.1.23", note = "This module will be deleted in v0.2")]
 pub mod prefecture_master_api;


### PR DESCRIPTION
### 変更点
- #499 
- 非推奨化する以下のモジュールに`deprecated`アトリビュートを付与します。
  - `api`
  - `repository::geolonia::city_master_api`
  - `repository::geolonia::prefecture_master_api`
