### PR TITLE
apiモジュールを非推奨化: `wasm`クレートの`Parser`を`api::AsyncApi`を使用しないものに差し替え

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,9 +1,7 @@
 #[cfg(feature = "nightly")]
 mod nightly;
 
-use japanese_address_parser::api::AsyncApi;
 use japanese_address_parser::parser;
-use std::sync::Arc;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
@@ -35,7 +33,7 @@ export class Parser {
 
 #[wasm_bindgen(skip_typescript)]
 pub struct Parser {
-    async_api: Arc<AsyncApi>,
+    parser: parser::Parser,
 }
 
 #[warn(clippy::new_without_default)]
@@ -46,12 +44,12 @@ impl Parser {
         #[cfg(feature = "debug")]
         console_error_panic_hook::set_once();
         Parser {
-            async_api: Arc::new(Default::default()),
+            parser: parser::Parser::default(),
         }
     }
 
     pub async fn parse(&self, address: &str) -> JsValue {
-        let result = parser::parse(self.async_api.clone(), address).await;
+        let result = self.parser.parse(address).await;
         serde_wasm_bindgen::to_value(&result).unwrap()
     }
 }


### PR DESCRIPTION
### 変更点
- #499 
- `api::AsyncApi`が非推奨になるため、`api::AsyncApi`を使用しない実装に差し替えます。
