### PR TITLE
Tokenのリファクタをrelease/v0.1.23にマージ

### DIFF
--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -5,7 +5,7 @@ use std::cmp::Ordering::{Equal, Greater, Less};
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
     Prefecture(Prefecture),
-    City(City),
+    City(String),
     Town(String),
     Rest(String),
 }
@@ -47,28 +47,19 @@ pub(crate) struct Prefecture {
     pub(crate) representative_point: Option<LatLng>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub(crate) struct City {
-    pub(crate) city_name: String,
-    pub(crate) representative_point: Option<LatLng>,
-}
-
 pub(crate) fn append_token(tokens: &[Token], token: Token) -> Vec<Token> {
     [tokens.to_owned(), vec![token]].concat()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
 
     #[test]
     fn sort_token_vector() {
         let mut tokens = vec![
             Token::Rest("2-1".to_string()),
-            Token::City(City {
-                city_name: "小金井市".to_string(),
-                representative_point: None,
-            }),
+            Token::City("小金井市".to_string()),
             Token::Prefecture(Prefecture {
                 prefecture_name: "東京都".to_string(),
                 representative_point: None,
@@ -83,10 +74,7 @@ mod tests {
                     prefecture_name: "東京都".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "小金井市".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("小金井市".to_string()),
                 Token::Town("貫井北町四丁目".to_string()),
                 Token::Rest("2-1".to_string()),
             ]

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -6,7 +6,7 @@ use std::cmp::Ordering::{Equal, Greater, Less};
 pub enum Token {
     Prefecture(Prefecture),
     City(City),
-    Town(Town),
+    Town(String),
     Rest(String),
 }
 
@@ -53,19 +53,13 @@ pub(crate) struct City {
     pub(crate) representative_point: Option<LatLng>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub(crate) struct Town {
-    pub(crate) town_name: String,
-    pub(crate) representative_point: Option<LatLng>,
-}
-
 pub(crate) fn append_token(tokens: &[Token], token: Token) -> Vec<Token> {
     [tokens.to_owned(), vec![token]].concat()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::domain::common::token::{City, Prefecture, Token};
 
     #[test]
     fn sort_token_vector() {
@@ -79,10 +73,7 @@ mod tests {
                 prefecture_name: "東京都".to_string(),
                 representative_point: None,
             }),
-            Token::Town(Town {
-                town_name: "貫井北町四丁目".to_string(),
-                representative_point: None,
-            }),
+            Token::Town("貫井北町四丁目".to_string()),
         ];
         tokens.sort_by(|a, b| a.partial_cmp(b).unwrap());
         assert_eq!(
@@ -96,10 +87,7 @@ mod tests {
                     city_name: "小金井市".to_string(),
                     representative_point: None,
                 }),
-                Token::Town(Town {
-                    town_name: "貫井北町四丁目".to_string(),
-                    representative_point: None,
-                }),
+                Token::Town("貫井北町四丁目".to_string()),
                 Token::Rest("2-1".to_string()),
             ]
         );

--- a/core/src/domain/common/token.rs
+++ b/core/src/domain/common/token.rs
@@ -1,10 +1,9 @@
-use crate::domain::common::latlng::LatLng;
 use std::cmp::Ordering;
 use std::cmp::Ordering::{Equal, Greater, Less};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Token {
-    Prefecture(Prefecture),
+    Prefecture(String),
     City(String),
     Town(String),
     Rest(String),
@@ -41,39 +40,27 @@ impl PartialOrd for Token {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub(crate) struct Prefecture {
-    pub(crate) prefecture_name: String,
-    pub(crate) representative_point: Option<LatLng>,
-}
-
 pub(crate) fn append_token(tokens: &[Token], token: Token) -> Vec<Token> {
     [tokens.to_owned(), vec![token]].concat()
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{Prefecture, Token};
+    use crate::domain::common::token::Token;
 
     #[test]
     fn sort_token_vector() {
         let mut tokens = vec![
             Token::Rest("2-1".to_string()),
             Token::City("小金井市".to_string()),
-            Token::Prefecture(Prefecture {
-                prefecture_name: "東京都".to_string(),
-                representative_point: None,
-            }),
+            Token::Prefecture("東京都".to_string()),
             Token::Town("貫井北町四丁目".to_string()),
         ];
         tokens.sort_by(|a, b| a.partial_cmp(b).unwrap());
         assert_eq!(
             tokens,
             vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "東京都".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("東京都".to_string()),
                 Token::City("小金井市".to_string()),
                 Token::Town("貫井北町四丁目".to_string()),
                 Token::Rest("2-1".to_string()),

--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -100,7 +100,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{Prefecture, Token};
+    use crate::domain::common::token::Token;
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -136,10 +136,7 @@ mod tests {
         assert_eq!(
             tokens,
             vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "神奈川県".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("神奈川県".to_string()),
                 Token::Rest("横浜県磯子市洋光台3-10-3".to_string())
             ]
         )
@@ -160,10 +157,7 @@ mod tests {
         assert_eq!(
             tokens,
             vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "神奈川県".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("神奈川県".to_string()),
                 Token::City("横浜市磯子区".to_string()),
                 Token::Rest("陽光台3-10-3".to_string())
             ]
@@ -185,10 +179,7 @@ mod tests {
         assert_eq!(
             tokens,
             vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "神奈川県".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("神奈川県".to_string()),
                 Token::City("横浜市磯子区".to_string()),
                 Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())

--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -100,7 +100,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -164,10 +164,7 @@ mod tests {
                     prefecture_name: "神奈川県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "横浜市磯子区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("横浜市磯子区".to_string()),
                 Token::Rest("陽光台3-10-3".to_string())
             ]
         )
@@ -192,10 +189,7 @@ mod tests {
                     prefecture_name: "神奈川県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "横浜市磯子区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("横浜市磯子区".to_string()),
                 Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())
             ]

--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -100,7 +100,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::domain::common::token::{City, Prefecture, Token};
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -196,10 +196,7 @@ mod tests {
                     city_name: "横浜市磯子区".to_string(),
                     representative_point: None,
                 }),
-                Token::Town(Town {
-                    town_name: "洋光台三丁目".to_string(),
-                    representative_point: None,
-                }),
+                Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())
             ]
         )

--- a/core/src/experimental/parse_with_geolonia.rs
+++ b/core/src/experimental/parse_with_geolonia.rs
@@ -86,7 +86,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::domain::common::token::{City, Prefecture, Token};
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -182,10 +182,7 @@ mod tests {
                     city_name: "横浜市磯子区".to_string(),
                     representative_point: None,
                 }),
-                Token::Town(Town {
-                    town_name: "洋光台三丁目".to_string(),
-                    representative_point: None,
-                }),
+                Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())
             ]
         )

--- a/core/src/experimental/parse_with_geolonia.rs
+++ b/core/src/experimental/parse_with_geolonia.rs
@@ -86,7 +86,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{Prefecture, Token};
+    use crate::domain::common::token::Token;
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -122,10 +122,7 @@ mod tests {
         assert_eq!(
             result,
             vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "神奈川県".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("神奈川県".to_string()),
                 Token::Rest("横浜県磯子市洋光台3-10-3".to_string())
             ]
         )
@@ -146,10 +143,7 @@ mod tests {
         assert_eq!(
             result,
             vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "神奈川県".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("神奈川県".to_string()),
                 Token::City("横浜市磯子区".to_string()),
                 Token::Rest("陽光台3-10-3".to_string())
             ]
@@ -171,10 +165,7 @@ mod tests {
         assert_eq!(
             result,
             vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "神奈川県".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("神奈川県".to_string()),
                 Token::City("横浜市磯子区".to_string()),
                 Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())

--- a/core/src/experimental/parse_with_geolonia.rs
+++ b/core/src/experimental/parse_with_geolonia.rs
@@ -86,7 +86,7 @@ impl Parser {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
     use crate::experimental::parser::{DataSource, Parser, ParserOptions};
 
     #[tokio::test]
@@ -150,10 +150,7 @@ mod tests {
                     prefecture_name: "神奈川県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "横浜市磯子区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("横浜市磯子区".to_string()),
                 Token::Rest("陽光台3-10-3".to_string())
             ]
         )
@@ -178,10 +175,7 @@ mod tests {
                     prefecture_name: "神奈川県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "横浜市磯子区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("横浜市磯子区".to_string()),
                 Token::Town("洋光台三丁目".to_string()),
                 Token::Rest("10-3".to_string())
             ]

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -152,13 +152,9 @@ impl From<Vec<Token>> for ParsedAddress {
 
         for token in value {
             match token {
-                Token::Prefecture(prefecture) => {
-                    parsed_address.prefecture = prefecture.prefecture_name;
+                Token::Prefecture(prefecture_name) => {
+                    parsed_address.prefecture = prefecture_name;
                     parsed_address.metadata.depth = 1;
-                    if let Some(lat_lng) = prefecture.representative_point {
-                        parsed_address.metadata.latitude = Some(lat_lng.latitude);
-                        parsed_address.metadata.longitude = Some(lat_lng.longitude);
-                    }
                 }
                 Token::City(city_name) => {
                     parsed_address.city = city_name;
@@ -192,7 +188,7 @@ impl From<(Vec<Token>, Option<LatLng>)> for ParsedAddress {
 #[cfg(test)]
 mod tests {
     use crate::domain::common::latlng::LatLng;
-    use crate::domain::common::token::{Prefecture, Token};
+    use crate::domain::common::token::Token;
     use crate::experimental::parser::{Metadata, ParsedAddress};
 
     #[test]
@@ -220,16 +216,14 @@ mod tests {
     #[test]
     fn conversion_depthが1() {
         let tokens = vec![
-            Token::Prefecture(Prefecture {
-                prefecture_name: "東京都".to_string(),
-                representative_point: Some(LatLng {
-                    latitude: 139.748264,
-                    longitude: 35.68532,
-                }),
-            }),
+            Token::Prefecture("東京都".to_string()),
             Token::Rest("".to_string()),
         ];
-        let parsed_address = ParsedAddress::from(tokens);
+        let lat_lng = Some(LatLng {
+            latitude: 139.748264,
+            longitude: 35.68532,
+        });
+        let parsed_address = ParsedAddress::from((tokens, lat_lng));
         assert_eq!(
             parsed_address,
             ParsedAddress {
@@ -249,13 +243,7 @@ mod tests {
     #[test]
     fn conversion_depthが2() {
         let tokens = vec![
-            Token::Prefecture(Prefecture {
-                prefecture_name: "東京都".to_string(),
-                representative_point: Some(LatLng {
-                    latitude: 139.748264,
-                    longitude: 35.68532,
-                }),
-            }),
+            Token::Prefecture("東京都".to_string()),
             Token::City("台東区".to_string()),
             Token::Rest("".to_string()),
         ];
@@ -283,13 +271,7 @@ mod tests {
     #[test]
     fn conversion_depthが3() {
         let tokens = vec![
-            Token::Prefecture(Prefecture {
-                prefecture_name: "東京都".to_string(),
-                representative_point: Some(LatLng {
-                    latitude: 139.748264,
-                    longitude: 35.68532,
-                }),
-            }),
+            Token::Prefecture("東京都".to_string()),
             Token::City("文京区".to_string()),
             Token::Town("本駒込六丁目".to_string()),
             Token::Rest("16-3".to_string()),

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -168,13 +168,9 @@ impl From<Vec<Token>> for ParsedAddress {
                         parsed_address.metadata.longitude = Some(lat_lng.longitude);
                     }
                 }
-                Token::Town(town) => {
-                    parsed_address.town = town.town_name;
+                Token::Town(town_name) => {
+                    parsed_address.town = town_name;
                     parsed_address.metadata.depth = 3;
-                    if let Some(lat_lng) = town.representative_point {
-                        parsed_address.metadata.latitude = Some(lat_lng.latitude);
-                        parsed_address.metadata.longitude = Some(lat_lng.longitude);
-                    }
                 }
                 Token::Rest(rest) => {
                     parsed_address.rest = rest;
@@ -200,7 +196,7 @@ impl From<(Vec<Token>, Option<LatLng>)> for ParsedAddress {
 #[cfg(test)]
 mod tests {
     use crate::domain::common::latlng::LatLng;
-    use crate::domain::common::token::{City, Prefecture, Token, Town};
+    use crate::domain::common::token::{City, Prefecture, Token};
     use crate::experimental::parser::{Metadata, ParsedAddress};
 
     #[test]
@@ -307,16 +303,14 @@ mod tests {
                     longitude: 35.708143,
                 }),
             }),
-            Token::Town(Town {
-                town_name: "本駒込六丁目".to_string(),
-                representative_point: Some(LatLng {
-                    latitude: 139.738043,
-                    longitude: 35.72791,
-                }),
-            }),
+            Token::Town("本駒込六丁目".to_string()),
             Token::Rest("16-3".to_string()),
         ];
-        let parsed_address = ParsedAddress::from(tokens);
+        let lat_lng = Some(LatLng {
+            latitude: 139.738043,
+            longitude: 35.72791,
+        });
+        let parsed_address = ParsedAddress::from((tokens, lat_lng));
         assert_eq!(
             parsed_address,
             ParsedAddress {

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -160,13 +160,9 @@ impl From<Vec<Token>> for ParsedAddress {
                         parsed_address.metadata.longitude = Some(lat_lng.longitude);
                     }
                 }
-                Token::City(city) => {
-                    parsed_address.city = city.city_name;
+                Token::City(city_name) => {
+                    parsed_address.city = city_name;
                     parsed_address.metadata.depth = 2;
-                    if let Some(lat_lng) = city.representative_point {
-                        parsed_address.metadata.latitude = Some(lat_lng.latitude);
-                        parsed_address.metadata.longitude = Some(lat_lng.longitude);
-                    }
                 }
                 Token::Town(town_name) => {
                     parsed_address.town = town_name;
@@ -196,7 +192,7 @@ impl From<(Vec<Token>, Option<LatLng>)> for ParsedAddress {
 #[cfg(test)]
 mod tests {
     use crate::domain::common::latlng::LatLng;
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
     use crate::experimental::parser::{Metadata, ParsedAddress};
 
     #[test]
@@ -260,16 +256,14 @@ mod tests {
                     longitude: 35.68532,
                 }),
             }),
-            Token::City(City {
-                city_name: "台東区".to_string(),
-                representative_point: Some(LatLng {
-                    latitude: 139.764379,
-                    longitude: 35.711162,
-                }),
-            }),
+            Token::City("台東区".to_string()),
             Token::Rest("".to_string()),
         ];
-        let parsed_address = ParsedAddress::from(tokens);
+        let lat_lng = Some(LatLng {
+            latitude: 139.764379,
+            longitude: 35.711162,
+        });
+        let parsed_address = ParsedAddress::from((tokens, lat_lng));
         assert_eq!(
             parsed_address,
             ParsedAddress {
@@ -296,13 +290,7 @@ mod tests {
                     longitude: 35.68532,
                 }),
             }),
-            Token::City(City {
-                city_name: "文京区".to_string(),
-                representative_point: Some(LatLng {
-                    latitude: 139.749542,
-                    longitude: 35.708143,
-                }),
-            }),
+            Token::City("文京区".to_string()),
             Token::Town("本駒込六丁目".to_string()),
             Token::Rest("16-3".to_string()),
         ];

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -16,7 +16,7 @@ impl From<Tokenizer<End>> for Address {
         let mut address = Address::new("", "", "", "");
         for token in value.tokens {
             match token {
-                Token::Prefecture(prefecture) => address.prefecture = prefecture.prefecture_name,
+                Token::Prefecture(prefecture_name) => address.prefecture = prefecture_name,
                 Token::City(city_name) => address.city = city_name,
                 Token::Town(town_name) => address.town = town_name,
                 Token::Rest(rest) => address.rest = rest,

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -17,7 +17,7 @@ impl From<Tokenizer<End>> for Address {
         for token in value.tokens {
             match token {
                 Token::Prefecture(prefecture) => address.prefecture = prefecture.prefecture_name,
-                Token::City(city) => address.city = city.city_name,
+                Token::City(city_name) => address.city = city_name,
                 Token::Town(town_name) => address.town = town_name,
                 Token::Rest(rest) => address.rest = rest,
             }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -18,7 +18,7 @@ impl From<Tokenizer<End>> for Address {
             match token {
                 Token::Prefecture(prefecture) => address.prefecture = prefecture.prefecture_name,
                 Token::City(city) => address.city = city.city_name,
-                Token::Town(town) => address.town = town.town_name,
+                Token::Town(town_name) => address.town = town_name,
                 Token::Rest(rest) => address.rest = rest,
             }
         }

--- a/core/src/tokenizer.rs
+++ b/core/src/tokenizer.rs
@@ -29,8 +29,8 @@ pub struct Tokenizer<State> {
 impl<T> Tokenizer<T> {
     fn get_prefecture_name(&self) -> Option<&str> {
         for token in &self.tokens {
-            if let Token::Prefecture(prefecture) = token {
-                return Some(&prefecture.prefecture_name);
+            if let Token::Prefecture(prefecture_name) = token {
+                return Some(prefecture_name);
             };
         }
         None

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -81,17 +81,14 @@ impl Tokenizer<PrefectureNameFound> {
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{Prefecture, Token};
+    use crate::domain::common::token::Token;
     use crate::tokenizer::{PrefectureNameFound, Tokenizer};
     use std::marker::PhantomData;
 
     #[test]
     fn read_city_成功() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "神奈川県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("神奈川県".to_string())],
             rest: "横浜市保土ケ谷区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };
@@ -110,10 +107,7 @@ mod tests {
     #[test]
     fn read_city_orthographical_variant_adapterで成功() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "神奈川県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("神奈川県".to_string())],
             rest: "横浜市保土ヶ谷区川辺町2番地9".to_string(), // 「ヶ」と「ケ」の表記ゆれ
             _state: PhantomData::<PrefectureNameFound>,
         };
@@ -132,10 +126,7 @@ mod tests {
     #[test]
     fn read_city_失敗() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "神奈川県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("神奈川県".to_string())],
             rest: "京都市上京区川辺町2番地9".to_string(),
             _state: PhantomData::<PrefectureNameFound>,
         };

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -1,4 +1,4 @@
-use crate::domain::common::token::{append_token, City, Token};
+use crate::domain::common::token::{append_token, Token};
 use crate::parser::adapter::orthographical_variant_adapter::{
     OrthographicalVariantAdapter, OrthographicalVariants, Variant,
 };
@@ -17,13 +17,7 @@ impl Tokenizer<PrefectureNameFound> {
             return Ok((
                 found.to_string(),
                 Tokenizer {
-                    tokens: append_token(
-                        &self.tokens,
-                        Token::City(City {
-                            city_name: found.to_string(),
-                            representative_point: None,
-                        }),
-                    ),
+                    tokens: append_token(&self.tokens, Token::City(found.to_string())),
                     rest: self
                         .rest
                         .chars()
@@ -69,13 +63,7 @@ impl Tokenizer<PrefectureNameFound> {
                 return Ok((
                     city_name.clone(),
                     Tokenizer {
-                        tokens: append_token(
-                            &self.tokens,
-                            Token::City(City {
-                                city_name,
-                                representative_point: None,
-                            }),
-                        ),
+                        tokens: append_token(&self.tokens, Token::City(city_name)),
                         rest,
                         _state: PhantomData::<CityNameFound>,
                     },

--- a/core/src/tokenizer/read_city_with_county_name_completion.rs
+++ b/core/src/tokenizer/read_city_with_county_name_completion.rs
@@ -42,7 +42,7 @@ fn complement_county_name(vague_address: &str, with: &str) -> Result<String, &'s
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{Prefecture, Token};
+    use crate::domain::common::token::Token;
     use crate::domain::geolonia;
     use crate::tokenizer::read_city_with_county_name_completion::complement_county_name;
     use crate::tokenizer::{CityNameNotFound, Tokenizer};
@@ -72,10 +72,7 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_秩父郡東秩父村() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "埼玉県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("埼玉県".to_string())],
             rest: "東秩父村大字御堂634番地".to_string(), // 「秩父郡」が省略されている
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -95,10 +92,7 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_吉田郡永平寺町() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "福井県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("福井県".to_string())],
             rest: "永平寺町志比５－５".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -114,10 +108,7 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_今立郡池田町() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "福井県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("福井県".to_string())],
             rest: "池田町稲荷２８－７".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -133,10 +124,7 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_南条郡南越前町() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "福井県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("福井県".to_string())],
             rest: "南越前町今庄７４－７－１".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -152,10 +140,7 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_西村山郡河北町() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "山形県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("山形県".to_string())],
             rest: "河北町大字吉田字馬場261".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -172,10 +157,7 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_杵島郡大町町() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "佐賀県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("佐賀県".to_string())],
             rest: "大町町大字大町5017番地".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };
@@ -191,10 +173,7 @@ mod tests {
     #[test]
     fn read_city_with_county_name_completion_最上郡最上町() {
         let tokenizer = Tokenizer {
-            tokens: vec![Token::Prefecture(Prefecture {
-                prefecture_name: "山形県".to_string(),
-                representative_point: None,
-            })],
+            tokens: vec![Token::Prefecture("山形県".to_string())],
             rest: "最上町法田2672-2".to_string(),
             _state: PhantomData::<CityNameNotFound>,
         };

--- a/core/src/tokenizer/read_city_with_county_name_completion.rs
+++ b/core/src/tokenizer/read_city_with_county_name_completion.rs
@@ -1,4 +1,4 @@
-use crate::domain::common::token::{append_token, City, Token};
+use crate::domain::common::token::{append_token, Token};
 use crate::tokenizer::{CityNameFound, CityNameNotFound, End, Tokenizer};
 use crate::util::sequence_matcher::SequenceMatcher;
 use std::marker::PhantomData;
@@ -15,13 +15,7 @@ impl Tokenizer<CityNameNotFound> {
                 return Ok((
                     highest_match.clone(),
                     Tokenizer {
-                        tokens: append_token(
-                            &self.tokens,
-                            Token::City(City {
-                                city_name: highest_match.clone(),
-                                representative_point: None,
-                            }),
-                        ),
+                        tokens: append_token(&self.tokens, Token::City(highest_match.clone())),
                         rest: complemented_address
                             .chars()
                             .skip(highest_match.chars().count())

--- a/core/src/tokenizer/read_prefecture.rs
+++ b/core/src/tokenizer/read_prefecture.rs
@@ -1,4 +1,4 @@
-use crate::domain::common::token::{Prefecture, Token};
+use crate::domain::common::token::Token;
 use crate::tokenizer::{End, Init, PrefectureNameFound, Tokenizer};
 use crate::util::extension::StrExt;
 use std::marker::PhantomData;
@@ -25,10 +25,7 @@ impl Tokenizer<Init> {
                 Ok((
                     prefecture.clone(),
                     Tokenizer {
-                        tokens: vec![Token::Prefecture(Prefecture {
-                            prefecture_name: prefecture_name.to_string(),
-                            representative_point: None,
-                        })],
+                        tokens: vec![Token::Prefecture(prefecture_name.to_string())],
                         rest: self
                             .rest
                             .chars()

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -101,7 +101,7 @@ fn find_town(input: &str, candidates: &Vec<String>) -> Option<(String, String)> 
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{Prefecture, Token};
+    use crate::domain::common::token::Token;
     use crate::tokenizer::{CityNameFound, Tokenizer};
     use std::marker::PhantomData;
 
@@ -109,10 +109,7 @@ mod tests {
     fn read_town_成功() {
         let tokenizer = Tokenizer {
             tokens: vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "静岡県".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("静岡県".to_string()),
                 Token::City("静岡市清水区".to_string()),
             ],
             rest: "旭町6番8号".to_string(),
@@ -136,10 +133,7 @@ mod tests {
     fn read_town_orthographical_variant_adapterで成功() {
         let tokenizer = Tokenizer {
             tokens: vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "東京都".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("東京都".to_string()),
                 Token::City("千代田区".to_string()),
             ],
             rest: "一ッ橋二丁目1番".to_string(), // 「ッ」と「ツ」の表記ゆれ
@@ -163,10 +157,7 @@ mod tests {
     fn read_town_invalid_town_name_format_filterで成功() {
         let tokenizer = Tokenizer {
             tokens: vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "京都府".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("京都府".to_string()),
                 Token::City("京都市東山区".to_string()),
             ],
             rest: "本町22丁目489番".to_string(),
@@ -191,10 +182,7 @@ mod tests {
     fn read_town_大字が省略されている場合_成功() {
         let tokenizer = Tokenizer {
             tokens: vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "東京都".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("東京都".to_string()),
                 Token::City("西多摩郡日の出町".to_string()),
             ],
             rest: "平井2780番地".to_string(), // 「大字」が省略されている
@@ -212,10 +200,7 @@ mod tests {
     fn read_town_失敗() {
         let tokenizer = Tokenizer {
             tokens: vec![
-                Token::Prefecture(Prefecture {
-                    prefecture_name: "静岡県".to_string(),
-                    representative_point: None,
-                }),
+                Token::Prefecture("静岡県".to_string()),
                 Token::City("静岡市清水区".to_string()),
             ],
             rest: "".to_string(),

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -101,7 +101,7 @@ fn find_town(input: &str, candidates: &Vec<String>) -> Option<(String, String)> 
 
 #[cfg(test)]
 mod tests {
-    use crate::domain::common::token::{City, Prefecture, Token};
+    use crate::domain::common::token::{Prefecture, Token};
     use crate::tokenizer::{CityNameFound, Tokenizer};
     use std::marker::PhantomData;
 
@@ -113,10 +113,7 @@ mod tests {
                     prefecture_name: "静岡県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "静岡市清水区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("静岡市清水区".to_string()),
             ],
             rest: "旭町6番8号".to_string(),
             _state: PhantomData::<CityNameFound>,
@@ -143,10 +140,7 @@ mod tests {
                     prefecture_name: "東京都".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "千代田区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("千代田区".to_string()),
             ],
             rest: "一ッ橋二丁目1番".to_string(), // 「ッ」と「ツ」の表記ゆれ
             _state: PhantomData::<CityNameFound>,
@@ -173,10 +167,7 @@ mod tests {
                     prefecture_name: "京都府".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "京都市東山区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("京都市東山区".to_string()),
             ],
             rest: "本町22丁目489番".to_string(),
             _state: PhantomData::<CityNameFound>,
@@ -204,10 +195,7 @@ mod tests {
                     prefecture_name: "東京都".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "西多摩郡日の出町".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("西多摩郡日の出町".to_string()),
             ],
             rest: "平井2780番地".to_string(), // 「大字」が省略されている
             _state: PhantomData::<CityNameFound>,
@@ -228,10 +216,7 @@ mod tests {
                     prefecture_name: "静岡県".to_string(),
                     representative_point: None,
                 }),
-                Token::City(City {
-                    city_name: "静岡市清水区".to_string(),
-                    representative_point: None,
-                }),
+                Token::City("静岡市清水区".to_string()),
             ],
             rest: "".to_string(),
             _state: PhantomData::<CityNameFound>,

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -1,4 +1,4 @@
-use crate::domain::common::token::{append_token, Token, Town};
+use crate::domain::common::token::{append_token, Token};
 use crate::formatter::chome_with_arabic_numerals::format_chome_with_arabic_numerals;
 use crate::formatter::fullwidth_character::format_fullwidth_number;
 use crate::formatter::house_number::format_house_number;
@@ -39,13 +39,7 @@ impl Tokenizer<CityNameFound> {
         Ok((
             town_name.clone(),
             Tokenizer {
-                tokens: append_token(
-                    &self.tokens,
-                    Token::Town(Town {
-                        town_name,
-                        representative_point: None,
-                    }),
-                ),
+                tokens: append_token(&self.tokens, Token::Town(town_name)),
                 rest: if cfg!(feature = "format-house-number") && format_house_number(&rest).is_ok()
                 {
                     format_house_number(&rest).unwrap()


### PR DESCRIPTION
### 変更点
- #498 
- `Token::Prefecture`、`Token::City`、`Token::Town`に格納する値の型をStringに変更しました。
- 内部的な変更であり、APIに変更はありません。
