### PR TITLE
apiモジュールを非推奨化をrelease/v0.1.23にマージ

### DIFF
--- a/core/src/api.rs
+++ b/core/src/api.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 pub use crate::repository::geolonia::city_master_api;
 pub use crate::repository::geolonia::prefecture_master_api;
 

--- a/core/src/experimental/parse_with_geolonia.rs
+++ b/core/src/experimental/parse_with_geolonia.rs
@@ -1,12 +1,12 @@
-use crate::api::AsyncApi;
 use crate::domain::common::token::Token;
 use crate::experimental::parser::Parser;
+use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
 use crate::tokenizer::Tokenizer;
 
 impl Parser {
     #[inline]
     pub(crate) async fn parse_with_geolonia(&self, address: &str) -> Vec<Token> {
-        let geolonia_api = AsyncApi::default();
+        let interactor = GeoloniaInteractorImpl::default();
         let tokenizer = Tokenizer::new(address);
 
         // 都道府県名の検出
@@ -21,10 +21,7 @@ impl Parser {
         };
 
         // 市区町村名の検出
-        let prefecture_master = match geolonia_api
-            .get_prefecture_master(prefecture.name_ja())
-            .await
-        {
+        let prefecture_master = match interactor.get_prefecture_master(prefecture.name_ja()).await {
             Ok(result) => result,
             Err(error) => {
                 if self.options.verbose {
@@ -57,7 +54,7 @@ impl Parser {
         };
 
         // 町名の検出
-        let city_master = match geolonia_api
+        let city_master = match interactor
             .get_city_master(prefecture.name_ja(), &city_name)
             .await
         {

--- a/core/src/interactor.rs
+++ b/core/src/interactor.rs
@@ -1,2 +1,3 @@
 #[cfg(feature = "experimental")]
 pub mod chimei_ruiju;
+pub mod geolonia;

--- a/core/src/interactor/geolonia.rs
+++ b/core/src/interactor/geolonia.rs
@@ -1,0 +1,56 @@
+use crate::api::city_master_api::CityMasterApi;
+use crate::api::prefecture_master_api::PrefectureMasterApi;
+use crate::domain::geolonia::entity::{City, Prefecture};
+use crate::domain::geolonia::error::Error;
+
+#[allow(dead_code)]
+pub(crate) trait GeoloniaInteractor {
+    /// 都道府県マスタを取得(非同期)
+    async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error>;
+
+    /// 都道府県マスタを取得(同期)
+    #[cfg(feature = "blocking")]
+    fn get_blocking_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error>;
+
+    /// 市区町村マスタを取得(非同期)
+    async fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error>;
+
+    /// 市区町村マスタを取得(同期)
+    #[cfg(feature = "blocking")]
+    fn get_blocking_city_master(
+        &self,
+        prefecture_name: &str,
+        city_name: &str,
+    ) -> Result<City, Error>;
+}
+
+#[allow(dead_code)]
+pub(crate) struct GeoloniaInteractorImpl;
+
+impl GeoloniaInteractor for GeoloniaInteractorImpl {
+    async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
+        let prefecture_master_api = PrefectureMasterApi::default();
+        prefecture_master_api.get(prefecture_name).await
+    }
+
+    #[cfg(feature = "blocking")]
+    fn get_blocking_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
+        let prefecture_master_api = PrefectureMasterApi::default();
+        prefecture_master_api.get_blocking(prefecture_name)
+    }
+
+    async fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
+        let city_master_api = CityMasterApi::default();
+        city_master_api.get(prefecture_name, city_name).await
+    }
+
+    #[cfg(feature = "blocking")]
+    fn get_blocking_city_master(
+        &self,
+        prefecture_name: &str,
+        city_name: &str,
+    ) -> Result<City, Error> {
+        let city_master_api = CityMasterApi::default();
+        city_master_api.get_blocking(prefecture_name, city_name)
+    }
+}

--- a/core/src/interactor/geolonia.rs
+++ b/core/src/interactor/geolonia.rs
@@ -30,6 +30,14 @@ pub(crate) struct GeoloniaInteractorImpl {
     api_service: GeoloniaApiService,
 }
 
+impl Default for GeoloniaInteractorImpl {
+    fn default() -> Self {
+        Self {
+            api_service: GeoloniaApiService {},
+        }
+    }
+}
+
 impl GeoloniaInteractor for GeoloniaInteractorImpl {
     async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         PrefectureMasterRepository::get(&self.api_service, prefecture_name).await

--- a/core/src/interactor/geolonia.rs
+++ b/core/src/interactor/geolonia.rs
@@ -1,7 +1,8 @@
-use crate::api::city_master_api::CityMasterApi;
-use crate::api::prefecture_master_api::PrefectureMasterApi;
 use crate::domain::geolonia::entity::{City, Prefecture};
 use crate::domain::geolonia::error::Error;
+use crate::repository::geolonia::city::CityMasterRepository;
+use crate::repository::geolonia::prefecture::PrefectureMasterRepository;
+use crate::service::geolonia::GeoloniaApiService;
 
 #[allow(dead_code)]
 pub(crate) trait GeoloniaInteractor {
@@ -25,23 +26,22 @@ pub(crate) trait GeoloniaInteractor {
 }
 
 #[allow(dead_code)]
-pub(crate) struct GeoloniaInteractorImpl;
+pub(crate) struct GeoloniaInteractorImpl {
+    api_service: GeoloniaApiService,
+}
 
 impl GeoloniaInteractor for GeoloniaInteractorImpl {
     async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
-        let prefecture_master_api = PrefectureMasterApi::default();
-        prefecture_master_api.get(prefecture_name).await
+        PrefectureMasterRepository::get(&self.api_service, prefecture_name).await
     }
 
     #[cfg(feature = "blocking")]
     fn get_blocking_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
-        let prefecture_master_api = PrefectureMasterApi::default();
-        prefecture_master_api.get_blocking(prefecture_name)
+        PrefectureMasterRepository::get_blocking(&self.api_service, prefecture_name)
     }
 
     async fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
-        let city_master_api = CityMasterApi::default();
-        city_master_api.get(prefecture_name, city_name).await
+        CityMasterRepository::get(&self.api_service, prefecture_name, city_name).await
     }
 
     #[cfg(feature = "blocking")]
@@ -50,7 +50,6 @@ impl GeoloniaInteractor for GeoloniaInteractorImpl {
         prefecture_name: &str,
         city_name: &str,
     ) -> Result<City, Error> {
-        let city_master_api = CityMasterApi::default();
-        city_master_api.get_blocking(prefecture_name, city_name)
+        CityMasterRepository::get_blocking(&self.api_service, prefecture_name, city_name)
     }
 }

--- a/core/src/interactor/geolonia.rs
+++ b/core/src/interactor/geolonia.rs
@@ -4,7 +4,6 @@ use crate::repository::geolonia::city::CityMasterRepository;
 use crate::repository::geolonia::prefecture::PrefectureMasterRepository;
 use crate::service::geolonia::GeoloniaApiService;
 
-#[allow(dead_code)]
 pub(crate) trait GeoloniaInteractor {
     /// 都道府県マスタを取得(非同期)
     async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error>;
@@ -25,7 +24,6 @@ pub(crate) trait GeoloniaInteractor {
     ) -> Result<City, Error>;
 }
 
-#[allow(dead_code)]
 pub(crate) struct GeoloniaInteractorImpl {
     api_service: GeoloniaApiService,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -13,6 +13,7 @@ compile_error! {
     "The `blocking` feature is not supported with wasm target."
 }
 
+#[deprecated(since = "0.1.23", note = "This module will be deleted in v0.2")]
 pub mod api;
 pub(crate) mod domain;
 #[deprecated(since = "0.1.6", note = "This module will be deleted in v0.2")]

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -6,6 +6,7 @@ use crate::api::BlockingApi;
 use crate::domain::common::token::Token;
 use crate::domain::geolonia::entity::Address;
 use crate::domain::geolonia::error::{Error, ParseErrorKind};
+use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
 use crate::tokenizer::{End, Tokenizer};
 use serde::Serialize;
 
@@ -39,25 +40,14 @@ impl From<Tokenizer<End>> for Address {
 /// }
 /// ```
 pub struct Parser {
-    async_api: Arc<AsyncApi>,
-    #[cfg(feature = "blocking")]
-    blocking_api: Arc<BlockingApi>,
+    interactor: Arc<GeoloniaInteractorImpl>,
 }
 
 impl Default for Parser {
     /// Constructs a new `Parser`.
-    #[cfg(feature = "blocking")]
     fn default() -> Self {
         Self {
-            async_api: Arc::new(Default::default()),
-            blocking_api: Arc::new(Default::default()),
-        }
-    }
-    /// Constructs a new `Parser`.
-    #[cfg(not(feature = "blocking"))]
-    fn default() -> Self {
-        Self {
-            async_api: Arc::new(Default::default()),
+            interactor: Arc::new(Default::default()),
         }
     }
 }
@@ -65,19 +55,144 @@ impl Default for Parser {
 impl Parser {
     /// Parses the given `address` asynchronously.
     pub async fn parse(&self, address: &str) -> ParseResult {
-        parse(self.async_api.clone(), address).await
+        let interasctor = self.interactor.clone();
+        let tokenizer = Tokenizer::new(address);
+        // 都道府県を特定
+        let (prefecture, tokenizer) = match tokenizer.read_prefecture() {
+            Ok(found) => found,
+            Err(tokenizer) => {
+                return ParseResult {
+                    address: Address::from(tokenizer),
+                    error: Some(Error::new_parse_error(ParseErrorKind::Prefecture)),
+                }
+            }
+        };
+        // その都道府県の市町村名リストを取得
+        let prefecture_master = match interasctor
+            .get_prefecture_master(prefecture.name_ja())
+            .await
+        {
+            Err(error) => {
+                return ParseResult {
+                    address: Address::from(tokenizer.finish()),
+                    error: Some(error),
+                };
+            }
+            Ok(result) => result,
+        };
+        // 市町村名を特定
+        let (city_name, tokenizer) = match tokenizer.read_city(&prefecture_master.cities) {
+            Ok(found) => found,
+            Err(not_found) => {
+                // 市区町村が特定できない場合かつフィーチャフラグが有効な場合、郡名が抜けている可能性を検討
+                match not_found.read_city_with_county_name_completion(&prefecture_master.cities) {
+                    Ok(found) if cfg!(feature = "city-name-correction") => found,
+                    _ => {
+                        // それでも見つからない場合は終了
+                        return ParseResult {
+                            address: Address::from(tokenizer.finish()),
+                            error: Some(Error::new_parse_error(ParseErrorKind::City)),
+                        };
+                    }
+                }
+            }
+        };
+        // その市町村の町名リストを取得
+        let city = match interasctor
+            .get_city_master(prefecture.name_ja(), &city_name)
+            .await
+        {
+            Err(error) => {
+                return ParseResult {
+                    address: Address::from(tokenizer.finish()),
+                    error: Some(error),
+                };
+            }
+            Ok(result) => result,
+        };
+        // 町名を特定
+        let Ok((_, tokenizer)) =
+            tokenizer.read_town(city.towns.iter().map(|x| x.name.clone()).collect())
+        else {
+            return ParseResult {
+                address: Address::from(tokenizer.finish()),
+                error: Some(Error::new_parse_error(ParseErrorKind::Town)),
+            };
+        };
+
+        ParseResult {
+            address: Address::from(tokenizer.finish()),
+            error: None,
+        }
     }
 
     /// Parses the given `address` synchronously.
     #[cfg(feature = "blocking")]
     pub fn parse_blocking(&self, address: &str) -> ParseResult {
-        parse_blocking(self.blocking_api.clone(), address)
+        let interactor = self.interactor.clone();
+        let tokenizer = Tokenizer::new(address);
+        let (prefecture, tokenizer) = match tokenizer.read_prefecture() {
+            Ok(found) => found,
+            Err(tokenizer) => {
+                return ParseResult {
+                    address: Address::from(tokenizer),
+                    error: Some(Error::new_parse_error(ParseErrorKind::Prefecture)),
+                }
+            }
+        };
+        let prefecture_master =
+            match interactor.get_blocking_prefecture_master(prefecture.name_ja()) {
+                Err(error) => {
+                    return ParseResult {
+                        address: Address::from(tokenizer.finish()),
+                        error: Some(error),
+                    };
+                }
+                Ok(result) => result,
+            };
+        let (city_name, tokenizer) = match tokenizer.read_city(&prefecture_master.cities) {
+            Ok(found) => found,
+            Err(not_found) => {
+                match not_found.read_city_with_county_name_completion(&prefecture_master.cities) {
+                    Ok(found) if cfg!(feature = "city-name-correction") => found,
+                    _ => {
+                        return ParseResult {
+                            address: Address::from(tokenizer.finish()),
+                            error: Some(Error::new_parse_error(ParseErrorKind::City)),
+                        };
+                    }
+                }
+            }
+        };
+        let city = match interactor.get_blocking_city_master(prefecture.name_ja(), &city_name) {
+            Err(error) => {
+                return ParseResult {
+                    address: Address::from(tokenizer.finish()),
+                    error: Some(error),
+                };
+            }
+            Ok(result) => result,
+        };
+        let Ok((_, tokenizer)) =
+            tokenizer.read_town(city.towns.iter().map(|x| x.name.clone()).collect())
+        else {
+            return ParseResult {
+                address: Address::from(tokenizer.finish()),
+                error: Some(Error::new_parse_error(ParseErrorKind::Town)),
+            };
+        };
+
+        ParseResult {
+            address: Address::from(tokenizer.finish()),
+            error: None,
+        }
     }
 }
 
 /// A function to parse the given address asynchronously.
 ///
 /// publicにしていますが、直接の使用は推奨されません。[Parser]の利用を検討してください。
+#[deprecated(since = "0.1.23", note = "This module will be deleted in v0.2")]
 pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
     let tokenizer = Tokenizer::new(input);
     // 都道府県を特定
@@ -145,17 +260,14 @@ pub async fn parse(api: Arc<AsyncApi>, input: &str) -> ParseResult {
 
 #[cfg(all(test, not(feature = "blocking")))]
 mod tests {
-    use crate::api::AsyncApi;
     use crate::domain::geolonia::error::ParseErrorKind;
-    use crate::parser::parse;
-    use crate::repository::geolonia::city_master_api::CityMasterApi;
-    use crate::repository::geolonia::prefecture_master_api::PrefectureMasterApi;
+    use crate::parser::Parser;
     use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
     #[tokio::test]
     async fn 都道府県名が誤っている場合() {
-        let api: AsyncApi = Default::default();
-        let result = parse(api.into(), "青盛県青森市長島１丁目１−１").await;
+        let parser = Parser::default();
+        let result = parser.parse("青盛県青森市長島１丁目１−１").await;
         assert_eq!(result.address.prefecture, "");
         assert_eq!(result.address.city, "");
         assert_eq!(result.address.town, "");
@@ -168,24 +280,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn 都道府県マスタが取得できない場合() {
-        let mut api: AsyncApi = Default::default();
-        api.prefecture_master_api = PrefectureMasterApi {
-            server_url: "https://example.com/invalid_url/api/",
-        };
-
-        let result = parse(api.into(), "青森県青森市長島１丁目１−１").await;
-        assert_eq!(result.error.is_some(), true);
-        assert_eq!(result.address.prefecture, "青森県");
-        assert_eq!(result.address.city, "");
-        assert_eq!(result.address.town, "");
-        assert_eq!(result.address.rest, "青森市長島１丁目１−１");
-    }
-
-    #[tokio::test]
     async fn 市区町村名が誤っている場合() {
-        let api: AsyncApi = Default::default();
-        let result = parse(api.into(), "青森県青盛市長島１丁目１−１").await;
+        let parser = Parser::default();
+        let result = parser.parse("青森県青盛市長島１丁目１−１").await;
         assert_eq!(result.address.prefecture, "青森県");
         assert_eq!(result.address.city, "");
         assert_eq!(result.address.town, "");
@@ -198,24 +295,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn 市区町村マスタが取得できない場合() {
-        let mut api: AsyncApi = Default::default();
-        api.city_master_api = CityMasterApi {
-            server_url: "https://example.com/invalid_url/api/",
-        };
-
-        let result = parse(api.into(), "青森県青森市長島１丁目１−１").await;
-        assert_eq!(result.error.is_some(), true);
-        assert_eq!(result.address.prefecture, "青森県");
-        assert_eq!(result.address.city, "青森市");
-        assert_eq!(result.address.town, "");
-        assert_eq!(result.address.rest, "長島１丁目１−１");
-    }
-
-    #[tokio::test]
     async fn 町名が誤っている場合() {
-        let api: AsyncApi = Default::default();
-        let result = parse(api.into(), "青森県青森市永嶋１丁目１−１").await;
+        let parser = Parser::default();
+        let result = parser.parse("青森県青森市永嶋１丁目１−１").await;
         assert_eq!(result.address.prefecture, "青森県");
         assert_eq!(result.address.city, "青森市");
         assert_eq!(result.address.town, "");
@@ -231,8 +313,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn parse_wasm_success() {
-        let api: AsyncApi = Default::default();
-        let result = parse(api.into(), "兵庫県淡路市生穂新島8番地").await;
+        let parser = Parser::default();
+        let result = parser.parse("兵庫県淡路市生穂新島8番地").await;
         assert_eq!(result.address.prefecture, "兵庫県".to_string());
         assert_eq!(result.address.city, "淡路市".to_string());
         assert_eq!(result.address.town, "生穂".to_string());
@@ -245,6 +327,7 @@ mod tests {
 ///
 /// publicにしていますが、直接の使用は推奨されません。[Parser]の利用を検討してください。
 #[cfg(feature = "blocking")]
+#[deprecated(since = "0.1.23", note = "This module will be deleted in v0.2")]
 pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
     let tokenizer = Tokenizer::new(input);
     let (prefecture, tokenizer) = match tokenizer.read_prefecture() {
@@ -305,14 +388,13 @@ pub fn parse_blocking(api: Arc<BlockingApi>, input: &str) -> ParseResult {
 
 #[cfg(all(test, feature = "blocking"))]
 mod blocking_tests {
-    use crate::api::BlockingApi;
     use crate::domain::geolonia::error::ParseErrorKind;
-    use crate::parser::parse_blocking;
+    use crate::parser::Parser;
 
     #[test]
     fn parse_blocking_success_埼玉県秩父市熊木町8番15号() {
-        let client: BlockingApi = Default::default();
-        let result = parse_blocking(client.into(), "埼玉県秩父市熊木町8番15号");
+        let parser = Parser::default();
+        let result = parser.parse_blocking("埼玉県秩父市熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "秩父市");
         assert_eq!(result.address.town, "熊木町");
@@ -322,8 +404,8 @@ mod blocking_tests {
 
     #[test]
     fn parse_blocking_fail_市町村名が間違っている場合() {
-        let client: BlockingApi = Default::default();
-        let result = parse_blocking(client.into(), "埼玉県秩父柿熊木町8番15号");
+        let parser = Parser::default();
+        let result = parser.parse_blocking("埼玉県秩父柿熊木町8番15号");
         assert_eq!(result.address.prefecture, "埼玉県");
         assert_eq!(result.address.city, "");
         assert_eq!(result.address.town, "");

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -56,7 +56,7 @@ impl Default for Parser {
 impl Parser {
     /// Parses the given `address` asynchronously.
     pub async fn parse(&self, address: &str) -> ParseResult {
-        let interasctor = self.interactor.clone();
+        let interactor = self.interactor.clone();
         let tokenizer = Tokenizer::new(address);
         // 都道府県を特定
         let (prefecture, tokenizer) = match tokenizer.read_prefecture() {
@@ -69,10 +69,7 @@ impl Parser {
             }
         };
         // その都道府県の市町村名リストを取得
-        let prefecture_master = match interasctor
-            .get_prefecture_master(prefecture.name_ja())
-            .await
-        {
+        let prefecture_master = match interactor.get_prefecture_master(prefecture.name_ja()).await {
             Err(error) => {
                 return ParseResult {
                     address: Address::from(tokenizer.finish()),
@@ -99,7 +96,7 @@ impl Parser {
             }
         };
         // その市町村の町名リストを取得
-        let city = match interasctor
+        let city = match interactor
             .get_city_master(prefecture.name_ja(), &city_name)
             .await
         {

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use std::sync::Arc;
 
 use crate::api::AsyncApi;

--- a/core/src/repository/geolonia.rs
+++ b/core/src/repository/geolonia.rs
@@ -1,4 +1,6 @@
 pub(crate) mod city;
+#[deprecated(since = "0.1.23", note = "This module will be deleted in v0.2")]
 pub mod city_master_api;
 pub(crate) mod prefecture;
+#[deprecated(since = "0.1.23", note = "This module will be deleted in v0.2")]
 pub mod prefecture_master_api;

--- a/core/src/repository/geolonia.rs
+++ b/core/src/repository/geolonia.rs
@@ -1,2 +1,4 @@
+pub(crate) mod city;
 pub mod city_master_api;
+pub(crate) mod prefecture;
 pub mod prefecture_master_api;

--- a/core/src/repository/geolonia/city.rs
+++ b/core/src/repository/geolonia/city.rs
@@ -1,0 +1,102 @@
+use crate::domain::geolonia::entity::{City, Town};
+use crate::domain::geolonia::error::Error;
+use crate::service::geolonia::GeoloniaApiService;
+
+pub struct CityMasterRepository {}
+
+impl CityMasterRepository {
+    pub async fn get(
+        api_service: &GeoloniaApiService,
+        prefecture_name: &str,
+        city_name: &str,
+    ) -> Result<City, Error> {
+        let server_url = "https://geolonia.github.io/japanese-addresses/api/ja";
+        let endpoint = format!("{}/{}/{}.json", server_url, prefecture_name, city_name);
+        let towns = api_service.get::<Vec<Town>>(&endpoint).await?;
+        Ok(City {
+            name: city_name.to_string(),
+            towns,
+        })
+    }
+
+    #[cfg(feature = "blocking")]
+    pub fn get_blocking(
+        api_service: &GeoloniaApiService,
+        prefecture_name: &str,
+        city_name: &str,
+    ) -> Result<City, Error> {
+        let server_url = "https://geolonia.github.io/japanese-addresses/api/ja";
+        let endpoint = format!("{}/{}/{}.json", server_url, prefecture_name, city_name);
+        let towns = api_service.get_blocking::<Vec<Town>>(&endpoint)?;
+        Ok(City {
+            name: city_name.to_string(),
+            towns,
+        })
+    }
+}
+
+#[cfg(all(test, not(feature = "blocking")))]
+mod async_tests {
+    use crate::domain::geolonia::entity::Town;
+    use crate::repository::geolonia::city::CityMasterRepository;
+    use crate::service::geolonia::GeoloniaApiService;
+
+    #[tokio::test]
+    async fn 非同期_石川県羽咋郡志賀町_成功() {
+        let api_service = GeoloniaApiService {};
+        let result = CityMasterRepository::get(&api_service, "石川県", "羽咋郡志賀町").await;
+        let city = result.unwrap();
+        assert_eq!(city.name, "羽咋郡志賀町");
+        let town = Town {
+            name: "末吉".to_string(),
+            koaza: "千古".to_string(),
+            lat: Some(37.006235),
+            lng: Some(136.779155),
+        };
+        assert!(city.towns.contains(&town));
+    }
+
+    #[tokio::test]
+    async fn 非同期_誤った市区町村名_失敗() {
+        let api_service = GeoloniaApiService {};
+        let result = CityMasterRepository::get(&api_service, "石川県", "敦賀市").await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().error_message,
+            "https://geolonia.github.io/japanese-addresses/api/ja/石川県/敦賀市.jsonを取得できませんでした"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "blocking"))]
+mod blocking_tests {
+    use crate::domain::geolonia::entity::Town;
+    use crate::repository::geolonia::city::CityMasterRepository;
+    use crate::service::geolonia::GeoloniaApiService;
+
+    #[test]
+    fn 同期_石川県羽咋郡志賀町_成功() {
+        let api_service = GeoloniaApiService {};
+        let result = CityMasterRepository::get_blocking(&api_service, "石川県", "羽咋郡志賀町");
+        let city = result.unwrap();
+        assert_eq!(city.name, "羽咋郡志賀町");
+        let town = Town {
+            name: "末吉".to_string(),
+            koaza: "千古".to_string(),
+            lat: Some(37.006235),
+            lng: Some(136.779155),
+        };
+        assert!(city.towns.contains(&town));
+    }
+
+    #[test]
+    fn 同期_誤った市区町村名_失敗() {
+        let api_service = GeoloniaApiService {};
+        let result = CityMasterRepository::get_blocking(&api_service, "石川県", "敦賀市");
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().error_message,
+            "https://geolonia.github.io/japanese-addresses/api/ja/石川県/敦賀市.jsonを取得できませんでした",
+        );
+    }
+}

--- a/core/src/repository/geolonia/prefecture.rs
+++ b/core/src/repository/geolonia/prefecture.rs
@@ -1,0 +1,120 @@
+use crate::domain::geolonia::entity::Prefecture;
+use crate::domain::geolonia::error::Error;
+use crate::service::geolonia::GeoloniaApiService;
+
+pub struct PrefectureMasterRepository {}
+
+impl PrefectureMasterRepository {
+    pub async fn get(
+        api_service: &GeoloniaApiService,
+        prefecture_name: &str,
+    ) -> Result<Prefecture, Error> {
+        let server_url = "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist";
+        let endpoint = format!("{}/{}/master.json", server_url, prefecture_name);
+        api_service.get::<Prefecture>(&endpoint).await
+    }
+
+    #[cfg(feature = "blocking")]
+    pub fn get_blocking(
+        api_service: &GeoloniaApiService,
+        prefecture_name: &str,
+    ) -> Result<Prefecture, Error> {
+        let server_url = "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist";
+        let endpoint = format!("{}/{}/master.json", server_url, prefecture_name);
+        api_service.get_blocking::<Prefecture>(&endpoint)
+    }
+}
+
+#[cfg(all(test, not(feature = "blocking")))]
+mod tests {
+    use crate::repository::geolonia::prefecture::PrefectureMasterRepository;
+    use crate::repository::geolonia::prefecture_master_api::PrefectureMasterApi;
+    use crate::service::geolonia::GeoloniaApiService;
+
+    #[tokio::test]
+    async fn 非同期_富山県_成功() {
+        let api_service = GeoloniaApiService {};
+        let result = PrefectureMasterRepository::get(&api_service, "富山県").await;
+        let prefecture = result.unwrap();
+        assert_eq!(prefecture.name, "富山県");
+        let cities = vec![
+            "富山市",
+            "高岡市",
+            "魚津市",
+            "氷見市",
+            "滑川市",
+            "黒部市",
+            "砺波市",
+            "小矢部市",
+            "南砺市",
+            "射水市",
+            "中新川郡舟橋村",
+            "中新川郡上市町",
+            "中新川郡立山町",
+            "下新川郡入善町",
+            "下新川郡朝日町",
+        ];
+        for city in cities {
+            assert!(prefecture.cities.contains(&city.to_string()));
+        }
+    }
+
+    #[tokio::test]
+    async fn 非同期_誤った都道府県名_失敗() {
+        let prefecture_master_api: PrefectureMasterApi = Default::default();
+        let result = prefecture_master_api.get("大阪都").await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().error_message,
+            format!(
+                "{}/大阪都/master.jsonを取得できませんでした",
+                prefecture_master_api.server_url
+            )
+        );
+    }
+}
+
+#[cfg(all(test, feature = "blocking"))]
+mod blocking_tests {
+    use crate::repository::geolonia::prefecture::PrefectureMasterRepository;
+    use crate::service::geolonia::GeoloniaApiService;
+
+    #[test]
+    fn 同期_富山県_成功() {
+        let api_service = GeoloniaApiService {};
+        let result = PrefectureMasterRepository::get_blocking(&api_service, "富山県");
+        let prefecture = result.unwrap();
+        assert_eq!(prefecture.name, "富山県");
+        let cities = vec![
+            "富山市",
+            "高岡市",
+            "魚津市",
+            "氷見市",
+            "滑川市",
+            "黒部市",
+            "砺波市",
+            "小矢部市",
+            "南砺市",
+            "射水市",
+            "中新川郡舟橋村",
+            "中新川郡上市町",
+            "中新川郡立山町",
+            "下新川郡入善町",
+            "下新川郡朝日町",
+        ];
+        for city in cities {
+            assert!(prefecture.cities.contains(&city.to_string()));
+        }
+    }
+
+    #[test]
+    fn 同期_誤った都道府県名_失敗() {
+        let api_service = GeoloniaApiService {};
+        let result = PrefectureMasterRepository::get_blocking(&api_service, "大阪都");
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().error_message,
+            "https://yuukitoriyama.github.io/geolonia-japanese-addresses-accompanist/大阪都/master.jsonを取得できませんでした",
+        );
+    }
+}

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -1,9 +1,7 @@
 #[cfg(feature = "nightly")]
 mod nightly;
 
-use japanese_address_parser::api::AsyncApi;
 use japanese_address_parser::parser;
-use std::sync::Arc;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
@@ -35,7 +33,7 @@ export class Parser {
 
 #[wasm_bindgen(skip_typescript)]
 pub struct Parser {
-    async_api: Arc<AsyncApi>,
+    parser: parser::Parser,
 }
 
 #[warn(clippy::new_without_default)]
@@ -46,12 +44,12 @@ impl Parser {
         #[cfg(feature = "debug")]
         console_error_panic_hook::set_once();
         Parser {
-            async_api: Arc::new(Default::default()),
+            parser: parser::Parser::default(),
         }
     }
 
     pub async fn parse(&self, address: &str) -> JsValue {
-        let result = parser::parse(self.async_api.clone(), address).await;
+        let result = self.parser.parse(address).await;
         serde_wasm_bindgen::to_value(&result).unwrap()
     }
 }


### PR DESCRIPTION
### 変更点
- #499 
- `GeoloniaInteractor`を作成しそちらを使うようにしました。
- `api`モジュールおよび、`repository::geolonia::city_master_api`、`repository::geolonia::prefecture_master_api`はv0.2で削除したく、非推奨化しました。
- 内部的には構造を大きく変えていますが、公開APIには破壊的な変更はありません。
