### PR TITLE
表記揺れアダプタのリファクタ: リファクタ

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,6 @@ name = "core_benchmark"
 harness = false
 
 [dependencies]
-itertools = "0.13.0"
 log.workspace = true
 rapidfuzz = "0.5.0"
 regex = { version = "1.10.6", default-features = false, features = ["std", "unicode-perl"] }

--- a/core/benches/orthographical_variant_adapter.rs
+++ b/core/benches/orthographical_variant_adapter.rs
@@ -1,7 +1,7 @@
 use criterion::measurement::WallTime;
 use criterion::{BatchSize, BenchmarkGroup, BenchmarkId, Criterion};
 use japanese_address_parser::parser::adapter::orthographical_variant_adapter::{
-    OrthographicalVariantAdapter, OrthographicalVariants, Variant,
+    OrthographicalVariant, OrthographicalVariantAdapter,
 };
 
 pub fn bench_orthographical_variant_adapter(c: &mut Criterion) {
@@ -17,7 +17,11 @@ pub fn bench_orthographical_variant_adapter(c: &mut Criterion) {
                 "松ケ﨑東池の内町",
                 "松ガ﨑東池の内町",
             ],
-            variants_to_be_used: vec![Variant::ケ, Variant::崎, Variant::の],
+            variants_to_be_used: vec![
+                OrthographicalVariant::ケ,
+                OrthographicalVariant::崎,
+                OrthographicalVariant::の,
+            ],
         },
     );
     group.finish();
@@ -44,5 +48,5 @@ fn add_tests(group: &mut BenchmarkGroup<WallTime>, test_suite: TestSuite) {
 struct TestSuite {
     expected: &'static str,
     inputs: Vec<&'static str>,
-    variants_to_be_used: Vec<Variant>,
+    variants_to_be_used: Vec<OrthographicalVariant>,
 }

--- a/core/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/core/src/parser/adapter/orthographical_variant_adapter.rs
@@ -1,80 +1,83 @@
 use itertools::Itertools;
 
-pub type Variant = &'static [&'static str];
-
-pub trait OrthographicalVariants {
-    const の: Variant;
-    const ツ: Variant;
-    const ケ: Variant;
-    const 薮: Variant;
-    const 崎: Variant;
-    const 檜: Variant;
-    const 龍: Variant;
-    const 竈: Variant;
-    const 嶋: Variant;
-    const 舘: Variant;
-    const 脊: Variant;
-    const 渕: Variant;
-    const 己: Variant;
-    const 槇: Variant;
-    const 治: Variant;
-    const 佛: Variant;
-    const 澤: Variant;
-    const 塚: Variant;
-    const 恵: Variant;
-    const 穂: Variant;
-    const 梼: Variant;
-    const 蛍: Variant;
-    const 與: Variant;
-    const 瀧: Variant;
-    const 籠: Variant;
-    const 濱: Variant;
-    const 祗: Variant;
-    const 曾: Variant;
+#[derive(Clone)]
+pub enum OrthographicalVariant {
+    の,
+    ツ,
+    ケ,
+    薮,
+    崎,
+    檜,
+    龍,
+    竈,
+    嶋,
+    舘,
+    脊,
+    渕,
+    己,
+    槇,
+    治,
+    佛,
+    澤,
+    塚,
+    恵,
+    穂,
+    梼,
+    蛍,
+    與,
+    瀧,
+    籠,
+    濱,
+    祗,
+    曾,
 }
 
-impl OrthographicalVariants for Variant {
-    const の: Variant = &["の", "ノ", "之"];
-    const ツ: Variant = &["ツ", "ッ"];
-    const ケ: Variant = &["ケ", "ヶ", "が", "ガ"];
-    const 薮: Variant = &["薮", "藪", "籔"];
-    const 崎: Variant = &["崎", "﨑"];
-    const 檜: Variant = &["桧", "檜"];
-    const 龍: Variant = &["龍", "竜"];
-    const 竈: Variant = &["竈", "竃", "釜"];
-    const 嶋: Variant = &["嶋", "島"];
-    const 舘: Variant = &["舘", "館"];
-    const 脊: Variant = &["脊", "背"];
-    const 渕: Variant = &["渕", "淵"];
-    const 己: Variant = &["己", "巳"];
-    const 槇: Variant = &["槇", "槙"];
-    const 治: Variant = &["治", "冶"];
-    const 佛: Variant = &["佛", "仏"];
-    const 澤: Variant = &["澤", "沢"];
-    const 塚: Variant = &["塚", "塚"];
-    const 恵: Variant = &["恵", "惠"];
-    const 穂: Variant = &["穂", "穗"];
-    const 梼: Variant = &["梼", "檮"];
-    const 蛍: Variant = &["蛍", "螢"];
-    const 與: Variant = &["與", "与"];
-    const 瀧: Variant = &["瀧", "滝"];
-    const 籠: Variant = &["籠", "篭"];
-    const 濱: Variant = &["濱", "浜"];
-    const 祗: Variant = &["祗", "祇"];
-    const 曾: Variant = &["曾", "曽"];
+impl OrthographicalVariant {
+    fn value(&self) -> &'static [&'static str] {
+        match self {
+            OrthographicalVariant::の => &["の", "ノ", "之"],
+            OrthographicalVariant::ツ => &["ツ", "ッ"],
+            OrthographicalVariant::ケ => &["ケ", "ヶ", "が", "ガ"],
+            OrthographicalVariant::薮 => &["薮", "藪", "籔"],
+            OrthographicalVariant::崎 => &["崎", "﨑"],
+            OrthographicalVariant::檜 => &["桧", "檜"],
+            OrthographicalVariant::龍 => &["龍", "竜"],
+            OrthographicalVariant::竈 => &["竈", "竃", "釜"],
+            OrthographicalVariant::嶋 => &["嶋", "島"],
+            OrthographicalVariant::舘 => &["舘", "館"],
+            OrthographicalVariant::脊 => &["脊", "背"],
+            OrthographicalVariant::渕 => &["渕", "淵"],
+            OrthographicalVariant::己 => &["己", "巳"],
+            OrthographicalVariant::槇 => &["槇", "槙"],
+            OrthographicalVariant::治 => &["治", "冶"],
+            OrthographicalVariant::佛 => &["佛", "仏"],
+            OrthographicalVariant::澤 => &["澤", "沢"],
+            OrthographicalVariant::塚 => &["塚", "塚"],
+            OrthographicalVariant::恵 => &["恵", "惠"],
+            OrthographicalVariant::穂 => &["穂", "穗"],
+            OrthographicalVariant::梼 => &["梼", "檮"],
+            OrthographicalVariant::蛍 => &["蛍", "螢"],
+            OrthographicalVariant::與 => &["與", "与"],
+            OrthographicalVariant::瀧 => &["瀧", "滝"],
+            OrthographicalVariant::籠 => &["籠", "篭"],
+            OrthographicalVariant::濱 => &["濱", "浜"],
+            OrthographicalVariant::祗 => &["祗", "祇"],
+            OrthographicalVariant::曾 => &["曾", "曽"],
+        }
+    }
 }
 
 pub struct OrthographicalVariantAdapter {
-    pub variant_list: Vec<Variant>,
+    pub variant_list: Vec<OrthographicalVariant>,
 }
 
 impl OrthographicalVariantAdapter {
     pub fn apply(self, input: &str, region_name: &str) -> Option<(String, String)> {
         // 必要なパターンのみを選別する
-        let variant_list: Vec<&Variant> = self
+        let variant_list: Vec<&OrthographicalVariant> = self
             .variant_list
             .iter()
-            .filter(|v| v.iter().any(|c| input.contains(c)))
+            .filter(|v| v.value().iter().any(|c| input.contains(c)))
             .collect();
         if variant_list.is_empty() {
             return None;
@@ -87,7 +90,7 @@ impl OrthographicalVariantAdapter {
             let mut semi_candidates: Vec<String> = vec![];
             // variantから順列を作成
             // ["ケ", "ヶ", "が"] -> (ケ, ヶ), (ケ, が), (ヶ, ケ), (ヶ, が), (が, ケ), (が, ヶ)
-            for permutation in variant.iter().permutations(2) {
+            for permutation in variant.value().iter().permutations(2) {
                 for candidate in candidates.iter().filter(|c| c.contains(permutation[0])) {
                     // マッチ候補の中でパターンに引っかかるものがあれば文字を置き換えてマッチを試す
                     let edited_region_name = candidate.replace(permutation[0], permutation[1]);

--- a/core/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/core/src/parser/adapter/orthographical_variant_adapter.rs
@@ -1,5 +1,3 @@
-use itertools::Itertools;
-
 #[derive(Clone)]
 pub enum OrthographicalVariant {
     の,
@@ -103,24 +101,22 @@ impl OrthographicalVariantAdapter {
             let mut semi_candidates: Vec<String> = vec![];
             // variantから順列を作成
             // ["ケ", "ヶ", "が"] -> (ケ, ヶ), (ケ, が), (ヶ, ケ), (ヶ, が), (が, ケ), (が, ヶ)
-            for permutation in variant.value().iter().permutations(2) {
-                let (&a, &b) = (permutation[0], permutation[1]);
-                for candidate in candidates.iter().filter(|c| c.contains(a)) {
-                    // マッチ候補の中でパターンに引っかかるものがあれば文字を置き換えてマッチを試す
-                    let edited_region_name = modify_specific_character(candidate, a, b);
-                    if input.starts_with(&edited_region_name) {
+            for (a, b) in variant.permutations() {
+                for candidate in candidates.iter().filter(|x| x.contains(a)) {
+                    let modified_candidate = modify_specific_character(candidate, a, b);
+                    if input.starts_with(&modified_candidate) {
                         // マッチすれば早期リターン
                         return Some((
                             region_name.to_string(),
                             input
                                 .chars()
-                                .skip(edited_region_name.chars().count())
+                                .skip(modified_candidate.chars().count())
                                 .collect(),
                         ));
                     } else {
                         // マッチしなければsemi_candidatesに置き換え後の文字列をpush
-                        semi_candidates.push(edited_region_name);
-                    };
+                        semi_candidates.push(modified_candidate);
+                    }
                 }
             }
             candidates = semi_candidates;

--- a/core/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/core/src/parser/adapter/orthographical_variant_adapter.rs
@@ -65,6 +65,19 @@ impl OrthographicalVariant {
             OrthographicalVariant::曾 => &['曾', '曽'],
         }
     }
+
+    fn permutations(&self) -> Vec<(char, char)> {
+        let characters = self.value();
+        let mut permutations: Vec<(char, char)> = vec![];
+        for n in 0..characters.len() {
+            for m in 0..characters.len() {
+                if n != m {
+                    permutations.push((characters[n], characters[m]));
+                }
+            }
+        }
+        permutations
+    }
 }
 
 pub struct OrthographicalVariantAdapter {
@@ -121,4 +134,31 @@ fn modify_specific_character(text: &str, from: char, to: char) -> String {
     text.chars()
         .map(|x| if x == from { to } else { x })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::adapter::orthographical_variant_adapter::OrthographicalVariant;
+
+    #[test]
+    fn permutations() {
+        let variant = OrthographicalVariant::ケ;
+        assert_eq!(
+            variant.permutations(),
+            vec![
+                ('ケ', 'ヶ'),
+                ('ケ', 'が'),
+                ('ケ', 'ガ'),
+                ('ヶ', 'ケ'),
+                ('ヶ', 'が'),
+                ('ヶ', 'ガ'),
+                ('が', 'ケ'),
+                ('が', 'ヶ'),
+                ('が', 'ガ'),
+                ('ガ', 'ケ'),
+                ('ガ', 'ヶ'),
+                ('ガ', 'が'),
+            ]
+        );
+    }
 }

--- a/core/src/parser/adapter/orthographical_variant_adapter.rs
+++ b/core/src/parser/adapter/orthographical_variant_adapter.rs
@@ -33,36 +33,36 @@ pub enum OrthographicalVariant {
 }
 
 impl OrthographicalVariant {
-    fn value(&self) -> &'static [&'static str] {
+    fn value(&self) -> &[char] {
         match self {
-            OrthographicalVariant::の => &["の", "ノ", "之"],
-            OrthographicalVariant::ツ => &["ツ", "ッ"],
-            OrthographicalVariant::ケ => &["ケ", "ヶ", "が", "ガ"],
-            OrthographicalVariant::薮 => &["薮", "藪", "籔"],
-            OrthographicalVariant::崎 => &["崎", "﨑"],
-            OrthographicalVariant::檜 => &["桧", "檜"],
-            OrthographicalVariant::龍 => &["龍", "竜"],
-            OrthographicalVariant::竈 => &["竈", "竃", "釜"],
-            OrthographicalVariant::嶋 => &["嶋", "島"],
-            OrthographicalVariant::舘 => &["舘", "館"],
-            OrthographicalVariant::脊 => &["脊", "背"],
-            OrthographicalVariant::渕 => &["渕", "淵"],
-            OrthographicalVariant::己 => &["己", "巳"],
-            OrthographicalVariant::槇 => &["槇", "槙"],
-            OrthographicalVariant::治 => &["治", "冶"],
-            OrthographicalVariant::佛 => &["佛", "仏"],
-            OrthographicalVariant::澤 => &["澤", "沢"],
-            OrthographicalVariant::塚 => &["塚", "塚"],
-            OrthographicalVariant::恵 => &["恵", "惠"],
-            OrthographicalVariant::穂 => &["穂", "穗"],
-            OrthographicalVariant::梼 => &["梼", "檮"],
-            OrthographicalVariant::蛍 => &["蛍", "螢"],
-            OrthographicalVariant::與 => &["與", "与"],
-            OrthographicalVariant::瀧 => &["瀧", "滝"],
-            OrthographicalVariant::籠 => &["籠", "篭"],
-            OrthographicalVariant::濱 => &["濱", "浜"],
-            OrthographicalVariant::祗 => &["祗", "祇"],
-            OrthographicalVariant::曾 => &["曾", "曽"],
+            OrthographicalVariant::の => &['の', 'ノ', '之'],
+            OrthographicalVariant::ツ => &['ツ', 'ッ'],
+            OrthographicalVariant::ケ => &['ケ', 'ヶ', 'が', 'ガ'],
+            OrthographicalVariant::薮 => &['薮', '藪', '籔'],
+            OrthographicalVariant::崎 => &['崎', '﨑'],
+            OrthographicalVariant::檜 => &['桧', '檜'],
+            OrthographicalVariant::龍 => &['龍', '竜'],
+            OrthographicalVariant::竈 => &['竈', '竃', '釜'],
+            OrthographicalVariant::嶋 => &['嶋', '島'],
+            OrthographicalVariant::舘 => &['舘', '館'],
+            OrthographicalVariant::脊 => &['脊', '背'],
+            OrthographicalVariant::渕 => &['渕', '淵'],
+            OrthographicalVariant::己 => &['己', '巳'],
+            OrthographicalVariant::槇 => &['槇', '槙'],
+            OrthographicalVariant::治 => &['治', '冶'],
+            OrthographicalVariant::佛 => &['佛', '仏'],
+            OrthographicalVariant::澤 => &['澤', '沢'],
+            OrthographicalVariant::塚 => &['塚', '塚'],
+            OrthographicalVariant::恵 => &['恵', '惠'],
+            OrthographicalVariant::穂 => &['穂', '穗'],
+            OrthographicalVariant::梼 => &['梼', '檮'],
+            OrthographicalVariant::蛍 => &['蛍', '螢'],
+            OrthographicalVariant::與 => &['與', '与'],
+            OrthographicalVariant::瀧 => &['瀧', '滝'],
+            OrthographicalVariant::籠 => &['籠', '篭'],
+            OrthographicalVariant::濱 => &['濱', '浜'],
+            OrthographicalVariant::祗 => &['祗', '祇'],
+            OrthographicalVariant::曾 => &['曾', '曽'],
         }
     }
 }
@@ -77,7 +77,7 @@ impl OrthographicalVariantAdapter {
         let variant_list: Vec<&OrthographicalVariant> = self
             .variant_list
             .iter()
-            .filter(|v| v.value().iter().any(|c| input.contains(c)))
+            .filter(|v| v.value().iter().any(|&c| input.contains(c)))
             .collect();
         if variant_list.is_empty() {
             return None;
@@ -91,9 +91,10 @@ impl OrthographicalVariantAdapter {
             // variantから順列を作成
             // ["ケ", "ヶ", "が"] -> (ケ, ヶ), (ケ, が), (ヶ, ケ), (ヶ, が), (が, ケ), (が, ヶ)
             for permutation in variant.value().iter().permutations(2) {
-                for candidate in candidates.iter().filter(|c| c.contains(permutation[0])) {
+                let (&a, &b) = (permutation[0], permutation[1]);
+                for candidate in candidates.iter().filter(|c| c.contains(a)) {
                     // マッチ候補の中でパターンに引っかかるものがあれば文字を置き換えてマッチを試す
-                    let edited_region_name = candidate.replace(permutation[0], permutation[1]);
+                    let edited_region_name = modify_specific_character(candidate, a, b);
                     if input.starts_with(&edited_region_name) {
                         // マッチすれば早期リターン
                         return Some((
@@ -114,4 +115,10 @@ impl OrthographicalVariantAdapter {
         }
         None
     }
+}
+
+fn modify_specific_character(text: &str, from: char, to: char) -> String {
+    text.chars()
+        .map(|x| if x == from { to } else { x })
+        .collect()
 }

--- a/core/src/tokenizer/read_city.rs
+++ b/core/src/tokenizer/read_city.rs
@@ -1,6 +1,6 @@
 use crate::domain::common::token::{append_token, Token};
 use crate::parser::adapter::orthographical_variant_adapter::{
-    OrthographicalVariantAdapter, OrthographicalVariants, Variant,
+    OrthographicalVariant, OrthographicalVariantAdapter,
 };
 use crate::tokenizer::{CityNameFound, CityNameNotFound, PrefectureNameFound, Tokenizer};
 use std::marker::PhantomData;
@@ -29,29 +29,29 @@ impl Tokenizer<PrefectureNameFound> {
         }
 
         // ここまでで市区町村名が読み取れない場合は、表記ゆれを含む可能性を検討する
-        let mut variant_list = vec![Variant::ケ];
+        let mut variant_list = vec![OrthographicalVariant::ケ];
         match self.get_prefecture_name() {
             Some("青森県") => {
-                variant_list.push(Variant::舘);
+                variant_list.push(OrthographicalVariant::舘);
             }
             Some("宮城県") => {
-                variant_list.push(Variant::竈);
+                variant_list.push(OrthographicalVariant::竈);
             }
             Some("茨城県") => {
-                variant_list.push(Variant::龍);
-                variant_list.push(Variant::嶋);
+                variant_list.push(OrthographicalVariant::龍);
+                variant_list.push(OrthographicalVariant::嶋);
             }
             Some("東京都") => {
-                variant_list.push(Variant::檜);
+                variant_list.push(OrthographicalVariant::檜);
             }
             Some("兵庫県") => {
-                variant_list.push(Variant::塚);
+                variant_list.push(OrthographicalVariant::塚);
             }
             Some("高知県") => {
-                variant_list.push(Variant::梼);
+                variant_list.push(OrthographicalVariant::梼);
             }
             Some("福岡県") => {
-                variant_list.push(Variant::恵);
+                variant_list.push(OrthographicalVariant::恵);
             }
             _ => {}
         }

--- a/core/src/tokenizer/read_town.rs
+++ b/core/src/tokenizer/read_town.rs
@@ -4,7 +4,7 @@ use crate::formatter::fullwidth_character::format_fullwidth_number;
 use crate::formatter::house_number::format_house_number;
 use crate::formatter::informal_town_name_notation::format_informal_town_name_notation;
 use crate::parser::adapter::orthographical_variant_adapter::{
-    OrthographicalVariantAdapter, OrthographicalVariants, Variant,
+    OrthographicalVariant, OrthographicalVariantAdapter,
 };
 use crate::tokenizer::{CityNameFound, End, Tokenizer, TownNameFound};
 use std::marker::PhantomData;
@@ -65,31 +65,31 @@ fn find_town(input: &str, candidates: &Vec<String>) -> Option<(String, String)> 
         }
         let adapter = OrthographicalVariantAdapter {
             variant_list: vec![
-                Variant::の,
-                Variant::ツ,
-                Variant::ケ,
-                Variant::薮,
-                Variant::崎,
-                Variant::檜,
-                Variant::竈,
-                Variant::舘,
-                Variant::脊,
-                Variant::渕,
-                Variant::己,
-                Variant::槇,
-                Variant::治,
-                Variant::佛,
-                Variant::澤,
-                Variant::恵,
-                Variant::穂,
-                Variant::梼,
-                Variant::蛍,
-                Variant::與,
-                Variant::瀧,
-                Variant::籠,
-                Variant::濱,
-                Variant::祗,
-                Variant::曾,
+                OrthographicalVariant::の,
+                OrthographicalVariant::ツ,
+                OrthographicalVariant::ケ,
+                OrthographicalVariant::薮,
+                OrthographicalVariant::崎,
+                OrthographicalVariant::檜,
+                OrthographicalVariant::竈,
+                OrthographicalVariant::舘,
+                OrthographicalVariant::脊,
+                OrthographicalVariant::渕,
+                OrthographicalVariant::己,
+                OrthographicalVariant::槇,
+                OrthographicalVariant::治,
+                OrthographicalVariant::佛,
+                OrthographicalVariant::澤,
+                OrthographicalVariant::恵,
+                OrthographicalVariant::穂,
+                OrthographicalVariant::梼,
+                OrthographicalVariant::蛍,
+                OrthographicalVariant::與,
+                OrthographicalVariant::瀧,
+                OrthographicalVariant::籠,
+                OrthographicalVariant::濱,
+                OrthographicalVariant::祗,
+                OrthographicalVariant::曾,
             ],
         };
         if let Some(result) = adapter.apply(input, candidate) {


### PR DESCRIPTION
### 変更点
- #517 
- これまでは表記揺れのパターンをトレイトとその実装という形で管理していたが、列挙体で管理するように変更します
- また、各パターンの文字を`&str`で保管していたのを`char`で保管するように変更します
- また、itertoolsをつかって順列を生成していたのを自前の実装に置き換えます
