### PR TITLE
MSRVを1.75.0に変更をrelease/v0.1.24にマージ

### DIFF
--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -49,3 +49,16 @@ jobs:
       - name: Build check for wasm crate
         working-directory: wasm
         run: wasm-pack build --target web --scope toriyama
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install minimum supported version
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.75.0
+      - name: Basic build
+        run: cargo build --verbose
+      - name: Build docs
+        run: cargo doc --verbose

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docs](https://docs.rs/japanese-address-parser/badge.svg)](https://docs.rs/japanese-address-parser)
 [![Crates.io (latest)](https://img.shields.io/crates/v/japanese-address-parser)](https://crates.io/crates/japanese-address-parser)
-![Rust Version](https://img.shields.io/badge/rust%20version-%3E%3D1.73.0-orange)
+![Rust Version](https://img.shields.io/badge/rust%20version-%3E%3D1.75.0-orange)
 [![Unit test & Integration test](https://github.com/YuukiToriyama/japanese-address-parser/actions/workflows/run-test.yaml/badge.svg?branch=main)](https://github.com/YuukiToriyama/japanese-address-parser/actions/workflows/run-test.yaml)
 
 A Rust library for parsing Japanese addresses.

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 readme = "../README.md"
 keywords.workspace = true
 categories.workspace = true
-rust-version = "1.73.0"
+rust-version = "1.75.0"
 
 [lib]
 crate-type = ["rlib", "cdylib"]


### PR DESCRIPTION
### 変更点
- #513 
- #516 

### 備考
- v0.1.23での変更にRust1.75.0以降でしか使用できない文法が入っていたためです。