### PR TITLE
npm provenance対応をrelease/v0.1.24にマージ

### DIFF
--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -9,6 +9,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: npmjs
+    permissions:
+      id-token: write
     defaults:
       run:
         working-directory: wasm
@@ -48,6 +50,6 @@ jobs:
       - name: Upload wasm to npmjs.com
         run: |
           cd pkg
-          npm publish --access public
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPMJS_REGISTRY_TOKEN }}


### PR DESCRIPTION
### 変更点
- #523 
- `wasm-pack`を使ってビルドしたコードをnpmjsにアップロードしているが、アップロード時にプロべナンスが付与されるように設定を追加しました。

### 備考
- https://docs.npmjs.com/generating-provenance-statements
