### PR TITLE
`core::domain::geolonia::entity::Address`と`core::domain::geolonia::error::Error`を外部に公開

### DIFF
--- a/core/src/domain.rs
+++ b/core/src/domain.rs
@@ -1,4 +1,4 @@
 #[cfg(feature = "experimental")]
-pub mod chimei_ruiju;
-pub mod common;
+pub(crate) mod chimei_ruiju;
+pub(crate) mod common;
 pub mod geolonia;

--- a/core/src/domain/geolonia/entity.rs
+++ b/core/src/domain/geolonia/entity.rs
@@ -1,20 +1,20 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, PartialEq, Debug)]
-pub struct Prefecture {
+pub(crate) struct Prefecture {
     pub name: String,
     pub cities: Vec<String>,
 }
 
 #[derive(Debug)]
-pub struct City {
+pub(crate) struct City {
     #[allow(dead_code)]
     pub name: String,
     pub towns: Vec<Town>,
 }
 
 #[derive(PartialEq, Deserialize, Debug)]
-pub struct Town {
+pub(crate) struct Town {
     #[serde(alias = "town")]
     pub name: String,
     pub koaza: String,
@@ -32,7 +32,12 @@ pub struct Address {
 }
 
 impl Address {
-    pub fn new(prefecture_name: &str, city_name: &str, town_name: &str, rest_name: &str) -> Self {
+    pub(crate) fn new(
+        prefecture_name: &str,
+        city_name: &str,
+        town_name: &str,
+        rest_name: &str,
+    ) -> Self {
         Address {
             prefecture: prefecture_name.to_string(),
             city: city_name.to_string(),

--- a/core/src/domain/geolonia/error.rs
+++ b/core/src/domain/geolonia/error.rs
@@ -9,13 +9,13 @@ pub struct Error {
 }
 
 impl Error {
-    pub fn new_parse_error(parse_error_kind: ParseErrorKind) -> Self {
+    pub(crate) fn new_parse_error(parse_error_kind: ParseErrorKind) -> Self {
         Error {
             error_type: "ParseError".to_string(),
             error_message: parse_error_kind.to_string(),
         }
     }
-    pub fn new_api_error(api_error_kind: ApiErrorKind) -> Self {
+    pub(crate) fn new_api_error(api_error_kind: ApiErrorKind) -> Self {
         let error_message = match api_error_kind {
             ApiErrorKind::Fetch(url) => format!("{}を取得できませんでした", url),
             ApiErrorKind::Deserialize(url) => format!("{}のデシリアライズに失敗しました", url),
@@ -27,7 +27,7 @@ impl Error {
     }
 }
 
-pub enum ParseErrorKind {
+pub(crate) enum ParseErrorKind {
     Prefecture,
     City,
     Town,
@@ -44,7 +44,7 @@ impl Display for ParseErrorKind {
     }
 }
 
-pub enum ApiErrorKind {
+pub(crate) enum ApiErrorKind {
     Fetch(String),
     Deserialize(String),
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,7 +14,7 @@ compile_error! {
 }
 
 mod adapter;
-pub(crate) mod domain;
+pub mod domain;
 #[cfg(feature = "experimental")]
 #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub mod experimental;


### PR DESCRIPTION
### 変更点
- #473 
- `core::domain::geolonia::entity::Address`と`core::domain::geolonia::error::Error`を外部に公開します。
- 理由は、これらは既に公開している`ParseResult`のフィールドに含まれるからです。


### 備考
- `core::domain::geolonia::entity::Address`は従来`core::entity::Address`として公開されていましたが、こちらは #529 で削除されています。
