### PR TITLE
`dev-dependencies`から`criterion`を削除

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,7 +33,6 @@ thiserror = "1.0.63"
 jisx0401 = "0.1.0-beta.3"
 
 [dev-dependencies]
-criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
 tokio.workspace = true
 wasm-bindgen-test = { workspace = true }
 


### PR DESCRIPTION
### 変更点
- #473 
- coreクレートの`dev-dependencies`から`criterion`を削除します。
- 現在使用されていないためです。

### 備考
- #519 での除却漏れです。
- このマイルストーンとは直接は関係がないですが、ついでに対応します。
