### PR TITLE
`console_error_panic_hook::set_once()`の呼び出し箇所を変更

### DIFF
--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -7,6 +7,8 @@ use wasm_bindgen::JsValue;
 
 #[wasm_bindgen(start)]
 fn start() {
+    #[cfg(feature = "debug")]
+    console_error_panic_hook::set_once();
     #[cfg(feature = "nightly")]
     console_log::init_with_level(log::Level::Trace).expect("could not initialize log");
 }
@@ -47,8 +49,6 @@ pub struct Parser {
 impl Parser {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
-        #[cfg(feature = "debug")]
-        console_error_panic_hook::set_once();
         Parser {
             parser: parser::Parser::default(),
         }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -5,6 +5,12 @@ use japanese_address_parser::parser;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::JsValue;
 
+#[wasm_bindgen(start)]
+fn start() {
+    #[cfg(feature = "nightly")]
+    console_log::init_with_level(log::Level::Trace).expect("could not initialize log");
+}
+
 #[wasm_bindgen(typescript_custom_section)]
 const TYPESCRIPT_TYPE: &'static str = r#"
 export interface ParseResult {

--- a/wasm/src/nightly.rs
+++ b/wasm/src/nightly.rs
@@ -30,11 +30,6 @@ export interface ParsedAddress {
     metadata: Metadata;
 }"#;
 
-#[wasm_bindgen(start)]
-fn start() {
-    console_log::init_with_level(log::Level::Trace).expect("could not initialize log");
-}
-
 #[derive(Deserialize)]
 pub struct Options {
     #[serde(alias = "dataSource")]


### PR DESCRIPTION
### 変更点
- #535 
- `console_error_panic_hook::set_once()`の呼び出し箇所を、`Parser::new()`から`#[wasm_bindgen(start)] fn start()`に移動します。
- `#[wasm_bindgen(start)]`は複数個定義することができないため、`nightly.rs`に定義していた`#[wasm_bindgen(start)] fn start()`は`lib.rs`に移動します。