### PR TITLE
ライブラリバージョンアップをrelease/v0.2.0-rc.3にマージ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ categories = ["parser-implementations", "wasm"]
 
 [workspace.dependencies]
 log = "0.4.22"
-serde = { version = "1.0.192", features = ["derive"] }
-tokio = { version = "1.38.0", features = ["rt", "macros"] }
-wasm-bindgen = "0.2.92"
-wasm-bindgen-futures = "0.4.42"
-wasm-bindgen-test = "0.3.42"
+serde = { version = "1.0.215", features = ["derive"] }
+tokio = { version = "1.41.1", features = ["rt", "macros"] }
+wasm-bindgen = "0.2.97"
+wasm-bindgen-futures = "0.4.47"
+wasm-bindgen-test = "0.3.47"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,11 +25,11 @@ experimental = []
 [dependencies]
 log.workspace = true
 rapidfuzz = "0.5.0"
-regex = { version = "1.10.6", default-features = false, features = ["std", "unicode-perl"] }
+regex = { version = "1.11.1", default-features = false, features = ["std", "unicode-perl"] }
 serde.workspace = true
-reqwest = { version = "0.12.5", default-features = false, features = ["json", "rustls-tls"] }
-js-sys = "0.3.67"
-thiserror = "1.0.63"
+reqwest = { version = "0.12.9", default-features = false, features = ["json", "rustls-tls"] }
+js-sys = "0.3.74"
+thiserror = "2.0.3"
 jisx0401 = "0.1.0-beta.3"
 
 [dev-dependencies]
@@ -37,7 +37,7 @@ tokio.workspace = true
 wasm-bindgen-test = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-mockito = "1.4.0" # mockitoがwasm32に対応していないため
+mockito = "1.6.1" # mockitoがwasm32に対応していないため
 
 [package.metadata.docs.rs]
 all-features = true

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -17,4 +17,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 japanese-address-parser = { path = "../core", features = ["blocking"] }
-pyo3 = { version = "0.22.0", features = ["abi3-py37"] }
+pyo3 = { version = "0.23.2", features = ["abi3-py37"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,7 +10,7 @@ name = "integration_tests"
 path = "integration_tests.rs"
 
 [dev-dependencies]
-csv = "1.3.0"
+csv = "1.3.1"
 japanese-address-parser = { path = "../core" }
-serde = { version = "1.0.197", features = ["derive"] }
+serde.workspace = true
 tokio.workspace = true

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -27,7 +27,7 @@ nightly = [
 [dependencies]
 console_error_panic_hook = "0.1.7"
 japanese-address-parser = { path = "../core" }
-serde-wasm-bindgen = "0.6.1"
+serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 # 以下は`nightly`が有効な場合のみ使用される


### PR DESCRIPTION
### 変更点
- 依存クレートのバージョンを最新に更新しました。
