### PR TITLE
`jisx0401`のバージョンを`0.1.1`に変更をrelease/v0.2.0にマージ

### DIFF
--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -27,6 +27,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.7.8
           target: x86_64
           args: --release --out dist --zig
           working-directory: python
@@ -50,6 +51,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.7.8
           target: x64
           args: --release --out dist
           working-directory: python
@@ -71,6 +73,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.7.8
           target: aarch64
           args: --release --out dist
           working-directory: python
@@ -89,6 +92,7 @@ jobs:
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
+          maturin-version: 1.7.8
           command: sdist
           args: --out dist
           working-directory: python

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,7 +30,7 @@ serde.workspace = true
 reqwest = { version = "0.12.9", default-features = false, features = ["json", "rustls-tls"] }
 js-sys = "0.3.74"
 thiserror = "2.0.3"
-jisx0401 = "0.1.0-beta.3"
+jisx0401 = "0.1.1"
 
 [dev-dependencies]
 tokio.workspace = true


### PR DESCRIPTION
### 変更点
- 依存クレート`jisx0401`のバージョンを`0.1.0-beta.3`から`0.1.1`に変更します

### その他
- `PyO3/maturin-action`で使用する`maturin`のバージョンを固定するコミットが含まれていますが、これは直接は関係ありません。
- PR作成時に、`maturin`の最新バージョンが上がってしまっていて、CIが通らなかったためです。