### PR TITLE
maturinのバージョン変更をrelease/v0.2.3にマージ

### DIFF
--- a/.github/workflows/python-build-check.yaml
+++ b/.github/workflows/python-build-check.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.7.8
+          maturin-version: 1.8.1
           target: x86_64
           args: --release --out dist --zig
           working-directory: python
@@ -51,7 +51,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.7.8
+          maturin-version: 1.8.1
           target: x64
           args: --release --out dist
           working-directory: python
@@ -73,7 +73,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.7.8
+          maturin-version: 1.8.1
           target: aarch64
           args: --release --out dist
           working-directory: python
@@ -92,7 +92,7 @@ jobs:
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.7.8
+          maturin-version: 1.8.1
           command: sdist
           args: --out dist
           working-directory: python

--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.7.8
+          maturin-version: 1.8.1
           target: ${{ matrix.platform.target }}
           args: --release --out dist --zig
           working-directory: python
@@ -68,7 +68,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.7.8
+          maturin-version: 1.8.1
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           working-directory: python
@@ -96,7 +96,7 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.7.8
+          maturin-version: 1.8.1
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           working-directory: python
@@ -114,7 +114,7 @@ jobs:
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:
-          maturin-version: 1.7.8
+          maturin-version: 1.8.1
           command: sdist
           args: --out dist
           working-directory: python
@@ -137,6 +137,6 @@ jobs:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
           MATURIN_REPOSITORY: "pypi" # test.pypi.orgにアップロードする際は"testpypi"を設定する
         with:
-          maturin-version: 1.7.8
+          maturin-version: 1.8.1
           command: upload
           args: --non-interactive --skip-existing wheels-*/*


### PR DESCRIPTION
### 変更点
- maturinを1.8.0に上げるとビルドが失敗するため1.7.8に固定していたが、1.8.1がリリースされ問題ないことが判明したためバージョンを変更する。