### PR TITLE
`ReqwestApiClient`に対してテストコードを追加

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,6 +32,7 @@ reqwest = { version = "0.12.9", default-features = false, features = ["json", "r
 js-sys = "0.3.74"
 thiserror = "2.0.3"
 jisx0401 = "0.1.1"
+strum = { version = "0.27.1", features = ["derive"] }
 
 [dev-dependencies]
 tokio.workspace = true

--- a/core/src/http/error.rs
+++ b/core/src/http/error.rs
@@ -1,6 +1,7 @@
+use strum::EnumIs;
 use thiserror::Error;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, EnumIs)]
 pub enum ApiClientError {
     #[error("Network error: {url} {message}")]
     Request { url: String, message: String },

--- a/core/src/http/reqwest_client.rs
+++ b/core/src/http/reqwest_client.rs
@@ -132,3 +132,80 @@ mod async_tests {
         mock.assert_async().await;
     }
 }
+
+#[cfg(all(
+    test,
+    feature = "blocking",
+    feature = "experimental",
+    not(target_arch = "wasm32")
+))]
+mod blocking_tests {
+    use crate::domain::chimei_ruiju::entity::PrefectureMaster;
+    use crate::http::client::ApiClient;
+    use crate::http::reqwest_client::ReqwestApiClient;
+
+    #[test]
+    fn 不正なurlを渡した場合_requestエラーになる() {
+        let invalid_url = "htttp://chimei-ruiju.org";
+        let api_client = ReqwestApiClient {};
+        let result = api_client.fetch_blocking::<PrefectureMaster>(invalid_url);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_request());
+    }
+
+    #[test]
+    fn レスポンスが404の場合_requestエラーになる() {
+        let mut server = mockito::Server::new();
+        let url = format!("{}/master.json", &server.url());
+        let mock = server.mock("GET", "/master.json").with_status(404).create();
+
+        let api_client = ReqwestApiClient {};
+        let result = api_client.fetch_blocking::<PrefectureMaster>(&url);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_request());
+
+        mock.assert();
+    }
+
+    #[test]
+    fn デシリアライズに失敗した場合_deserializeエラーになる() {
+        let mut server = mockito::Server::new();
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"hoge": true, "piyo": 100}"#)
+            .create();
+
+        let api_client = ReqwestApiClient {};
+        let result = api_client.fetch_blocking::<PrefectureMaster>(&url);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_deserialize());
+
+        mock.assert();
+    }
+
+    #[test]
+    fn 通信にもデシリアライズにも成功した場合_データを返す() {
+        let mut server = mockito::Server::new();
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"name": "新浜県", "cities": ["新浜市"], "coordinate": {"latitude": 34.6570413, "longitude": 135.2741341}}"#)
+            .create();
+
+        let api_client = ReqwestApiClient {};
+        let result = api_client.fetch_blocking::<PrefectureMaster>(&url);
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.name, "新浜県");
+        assert_eq!(data.cities, vec!["新浜市"]);
+        assert_eq!(data.coordinate.latitude, 34.6570413);
+        assert_eq!(data.coordinate.longitude, 135.2741341);
+
+        mock.assert();
+    }
+}

--- a/core/src/http/reqwest_client.rs
+++ b/core/src/http/reqwest_client.rs
@@ -53,3 +53,82 @@ impl ApiClient for ReqwestApiClient {
             })
     }
 }
+
+#[cfg(all(test, feature = "experimental", not(target_arch = "wasm32")))]
+mod async_tests {
+    use crate::domain::chimei_ruiju::entity::PrefectureMaster;
+    use crate::http::client::ApiClient;
+    use crate::http::reqwest_client::ReqwestApiClient;
+
+    #[tokio::test]
+    async fn 不正なurlを渡した場合_requestエラーになる() {
+        let invalid_url = "htttp://chimei-ruiju.org";
+        let api_client = ReqwestApiClient {};
+
+        let result = api_client.fetch::<PrefectureMaster>(invalid_url).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_request());
+    }
+
+    #[tokio::test]
+    async fn レスポンスが404の場合_requestエラーになる() {
+        let mut server = mockito::Server::new_async().await;
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let api_client = ReqwestApiClient {};
+        let result = api_client.fetch::<PrefectureMaster>(&url).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_request());
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn デシリアライズに失敗した場合_deserializeエラーになる() {
+        let mut server = mockito::Server::new_async().await;
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"hoge": true, "piyo": 100}"#)
+            .create_async()
+            .await;
+
+        let api_client = ReqwestApiClient {};
+        let result = api_client.fetch::<PrefectureMaster>(&url).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_deserialize());
+
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn 通信にもデシリアライズにも成功した場合_データを返す() {
+        let mut server = mockito::Server::new_async().await;
+        let url = format!("{}/master.json", &server.url());
+        let mock = server
+            .mock("GET", "/master.json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"name": "新浜県", "cities": ["新浜市"], "coordinate": {"latitude": 34.6570413, "longitude": 135.2741341}}"#)
+            .create_async()
+            .await;
+
+        let api_client = ReqwestApiClient {};
+        let result = api_client.fetch::<PrefectureMaster>(&url).await;
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.name, "新浜県");
+        assert_eq!(data.cities, vec!["新浜市"]);
+        assert_eq!(data.coordinate.latitude, 34.6570413);
+        assert_eq!(data.coordinate.longitude, 135.2741341);
+
+        mock.assert_async().await;
+    }
+}


### PR DESCRIPTION
### 変更点
- implements #606 
- `ReqwestApiClient#fetch`および``ReqwestApiClient#fetch_blocking`に対してテストコードを追加します
- `service::chimei_ruiju::ChimeiRuijuApiService`や`service::geolonia::GeoloniaApiService`に対して書いていたテストコードと同等のものになります
