### PR TITLE
interactor層の実装を`ApiService`ベースになるように修正

### DIFF
--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -1,6 +1,7 @@
 use crate::domain::common::latlng::LatLng;
 use crate::domain::common::token::Token;
 use crate::experimental::parser::Parser;
+use crate::http::reqwest_client::ReqwestApiClient;
 use crate::interactor::chimei_ruiju::{ChimeiRuijuInteractor, ChimeiRuijuInteractorImpl};
 use crate::tokenizer::Tokenizer;
 use std::option::Option;
@@ -10,7 +11,7 @@ impl Parser {
         &self,
         address: &str,
     ) -> (Vec<Token>, Option<LatLng>) {
-        let interactor = ChimeiRuijuInteractorImpl::default();
+        let interactor = ChimeiRuijuInteractorImpl::<ReqwestApiClient>::default();
         let tokenizer = Tokenizer::new(address);
         let mut lat_lng: Option<LatLng> = None;
 

--- a/core/src/experimental/parse_with_geolonia.rs
+++ b/core/src/experimental/parse_with_geolonia.rs
@@ -1,12 +1,13 @@
 use crate::domain::common::token::Token;
 use crate::experimental::parser::Parser;
+use crate::http::reqwest_client::ReqwestApiClient;
 use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
 use crate::tokenizer::Tokenizer;
 
 impl Parser {
     #[inline]
     pub(crate) async fn parse_with_geolonia(&self, address: &str) -> Vec<Token> {
-        let interactor = GeoloniaInteractorImpl::default();
+        let interactor = GeoloniaInteractorImpl::<ReqwestApiClient>::default();
         let tokenizer = Tokenizer::new(address);
 
         // 都道府県名の検出

--- a/core/src/http/client.rs
+++ b/core/src/http/client.rs
@@ -5,6 +5,11 @@ use serde::de::DeserializeOwned;
 ///
 /// 住所データマスタを取得するためのHTTPクライアントはこのトレイトを実装する必要があります。
 pub(crate) trait ApiClient {
+    /// Initialize `ApiClient`
+    ///
+    /// `ApiClient`を初期化処理を実装します。
+    fn new() -> Self;
+
     async fn fetch<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError>;
 
     #[cfg(feature = "blocking")]

--- a/core/src/http/reqwest_client.rs
+++ b/core/src/http/reqwest_client.rs
@@ -6,6 +6,10 @@ use serde::de::DeserializeOwned;
 pub(crate) struct ReqwestApiClient {}
 
 impl ApiClient for ReqwestApiClient {
+    fn new() -> Self {
+        ReqwestApiClient {}
+    }
+
     async fn fetch<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
         let response = reqwest::get(url)
             .await

--- a/core/src/interactor/chimei_ruiju.rs
+++ b/core/src/interactor/chimei_ruiju.rs
@@ -1,6 +1,6 @@
 use crate::domain::chimei_ruiju::entity::{CityMaster, PrefectureMaster, TownMaster};
 use crate::domain::chimei_ruiju::error::ApiError;
-use crate::http::reqwest_client::ReqwestApiClient;
+use crate::http::client::ApiClient;
 use crate::repository::chimei_ruiju::city::CityMasterRepository;
 use crate::repository::chimei_ruiju::prefecture::PrefectureMasterRepository;
 use crate::repository::chimei_ruiju::town::TownMasterRepository;
@@ -28,29 +28,29 @@ pub(crate) trait ChimeiRuijuInteractor {
     ) -> Result<TownMaster, ApiError>;
 }
 
-pub(crate) struct ChimeiRuijuInteractorImpl {
-    prefecture_repository: PrefectureMasterRepository<ReqwestApiClient>,
-    city_repository: CityMasterRepository<ReqwestApiClient>,
-    town_repository: TownMasterRepository<ReqwestApiClient>,
+pub(crate) struct ChimeiRuijuInteractorImpl<C: ApiClient> {
+    prefecture_repository: PrefectureMasterRepository<C>,
+    city_repository: CityMasterRepository<C>,
+    town_repository: TownMasterRepository<C>,
 }
 
-impl Default for ChimeiRuijuInteractorImpl {
+impl<C: ApiClient> Default for ChimeiRuijuInteractorImpl<C> {
     fn default() -> Self {
         Self {
             prefecture_repository: PrefectureMasterRepository {
-                api_client: ReqwestApiClient {},
+                api_client: C::new(),
             },
             city_repository: CityMasterRepository {
-                api_client: ReqwestApiClient {},
+                api_client: C::new(),
             },
             town_repository: TownMasterRepository {
-                api_client: ReqwestApiClient {},
+                api_client: C::new(),
             },
         }
     }
 }
 
-impl ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl {
+impl<C: ApiClient> ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl<C> {
     async fn get_prefecture_master(
         &self,
         prefecture: &Prefecture,

--- a/core/src/interactor/chimei_ruiju.rs
+++ b/core/src/interactor/chimei_ruiju.rs
@@ -28,29 +28,29 @@ pub(crate) trait ChimeiRuijuInteractor {
     ) -> Result<TownMaster, ApiError>;
 }
 
-pub(crate) struct ChimeiRuijuInteractorImpl<C: ApiClient> {
-    prefecture_repository: PrefectureMasterRepository<C>,
-    city_repository: CityMasterRepository<C>,
-    town_repository: TownMasterRepository<C>,
+pub(crate) struct ChimeiRuijuInteractorImpl<Client: ApiClient> {
+    prefecture_repository: PrefectureMasterRepository<Client>,
+    city_repository: CityMasterRepository<Client>,
+    town_repository: TownMasterRepository<Client>,
 }
 
-impl<C: ApiClient> Default for ChimeiRuijuInteractorImpl<C> {
+impl<Client: ApiClient> Default for ChimeiRuijuInteractorImpl<Client> {
     fn default() -> Self {
         Self {
             prefecture_repository: PrefectureMasterRepository {
-                api_client: C::new(),
+                api_client: Client::new(),
             },
             city_repository: CityMasterRepository {
-                api_client: C::new(),
+                api_client: Client::new(),
             },
             town_repository: TownMasterRepository {
-                api_client: C::new(),
+                api_client: Client::new(),
             },
         }
     }
 }
 
-impl<C: ApiClient> ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl<C> {
+impl<Client: ApiClient> ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl<Client> {
     async fn get_prefecture_master(
         &self,
         prefecture: &Prefecture,

--- a/core/src/interactor/chimei_ruiju.rs
+++ b/core/src/interactor/chimei_ruiju.rs
@@ -28,18 +28,34 @@ pub(crate) trait ChimeiRuijuInteractor {
     ) -> Result<TownMaster, ApiError>;
 }
 
-#[derive(Default)]
-pub(crate) struct ChimeiRuijuInteractorImpl {}
+pub(crate) struct ChimeiRuijuInteractorImpl {
+    prefecture_repository: PrefectureMasterRepository<ReqwestApiClient>,
+    city_repository: CityMasterRepository<ReqwestApiClient>,
+    town_repository: TownMasterRepository<ReqwestApiClient>,
+}
+
+impl Default for ChimeiRuijuInteractorImpl {
+    fn default() -> Self {
+        Self {
+            prefecture_repository: PrefectureMasterRepository {
+                api_client: ReqwestApiClient {},
+            },
+            city_repository: CityMasterRepository {
+                api_client: ReqwestApiClient {},
+            },
+            town_repository: TownMasterRepository {
+                api_client: ReqwestApiClient {},
+            },
+        }
+    }
+}
 
 impl ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl {
     async fn get_prefecture_master(
         &self,
         prefecture: &Prefecture,
     ) -> Result<PrefectureMaster, ApiError> {
-        let repository = PrefectureMasterRepository {
-            api_client: ReqwestApiClient {},
-        };
-        repository.get(prefecture).await
+        self.prefecture_repository.get(prefecture).await
     }
 
     async fn get_city_master(
@@ -47,10 +63,7 @@ impl ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl {
         prefecture: &Prefecture,
         city_name: &str,
     ) -> Result<CityMaster, ApiError> {
-        let repository = CityMasterRepository {
-            api_client: ReqwestApiClient {},
-        };
-        repository.get(prefecture, city_name).await
+        self.city_repository.get(prefecture, city_name).await
     }
 
     async fn get_town_master(
@@ -59,9 +72,8 @@ impl ChimeiRuijuInteractor for ChimeiRuijuInteractorImpl {
         city_name: &str,
         town_name: &str,
     ) -> Result<TownMaster, ApiError> {
-        let repository = TownMasterRepository {
-            api_client: ReqwestApiClient {},
-        };
-        repository.get(prefecture, city_name, town_name).await
+        self.town_repository
+            .get(prefecture, city_name, town_name)
+            .await
     }
 }

--- a/core/src/interactor/geolonia.rs
+++ b/core/src/interactor/geolonia.rs
@@ -24,30 +24,36 @@ pub(crate) trait GeoloniaInteractor {
     ) -> Result<City, Error>;
 }
 
-#[derive(Default)]
-pub(crate) struct GeoloniaInteractorImpl {}
+pub(crate) struct GeoloniaInteractorImpl {
+    prefecture_repository: PrefectureMasterRepository<ReqwestApiClient>,
+    city_repository: CityMasterRepository<ReqwestApiClient>,
+}
+
+impl Default for GeoloniaInteractorImpl {
+    fn default() -> Self {
+        Self {
+            prefecture_repository: PrefectureMasterRepository {
+                api_client: ReqwestApiClient {},
+            },
+            city_repository: CityMasterRepository {
+                api_client: ReqwestApiClient {},
+            },
+        }
+    }
+}
 
 impl GeoloniaInteractor for GeoloniaInteractorImpl {
     async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
-        let repository = PrefectureMasterRepository {
-            api_client: ReqwestApiClient {},
-        };
-        repository.get(prefecture_name).await
+        self.prefecture_repository.get(prefecture_name).await
     }
 
     #[cfg(feature = "blocking")]
     fn get_blocking_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
-        let repository = PrefectureMasterRepository {
-            api_client: ReqwestApiClient {},
-        };
-        repository.get_blocking(prefecture_name)
+        self.prefecture_repository.get_blocking(prefecture_name)
     }
 
     async fn get_city_master(&self, prefecture_name: &str, city_name: &str) -> Result<City, Error> {
-        let repository = CityMasterRepository {
-            api_client: ReqwestApiClient {},
-        };
-        repository.get(prefecture_name, city_name).await
+        self.city_repository.get(prefecture_name, city_name).await
     }
 
     #[cfg(feature = "blocking")]
@@ -56,9 +62,7 @@ impl GeoloniaInteractor for GeoloniaInteractorImpl {
         prefecture_name: &str,
         city_name: &str,
     ) -> Result<City, Error> {
-        let repository = CityMasterRepository {
-            api_client: ReqwestApiClient {},
-        };
-        repository.get_blocking(prefecture_name, city_name)
+        self.city_repository
+            .get_blocking(prefecture_name, city_name)
     }
 }

--- a/core/src/interactor/geolonia.rs
+++ b/core/src/interactor/geolonia.rs
@@ -1,6 +1,6 @@
 use crate::domain::geolonia::entity::{City, Prefecture};
 use crate::domain::geolonia::error::Error;
-use crate::http::reqwest_client::ReqwestApiClient;
+use crate::http::client::ApiClient;
 use crate::repository::geolonia::city::CityMasterRepository;
 use crate::repository::geolonia::prefecture::PrefectureMasterRepository;
 
@@ -24,25 +24,25 @@ pub(crate) trait GeoloniaInteractor {
     ) -> Result<City, Error>;
 }
 
-pub(crate) struct GeoloniaInteractorImpl {
-    prefecture_repository: PrefectureMasterRepository<ReqwestApiClient>,
-    city_repository: CityMasterRepository<ReqwestApiClient>,
+pub(crate) struct GeoloniaInteractorImpl<C: ApiClient> {
+    prefecture_repository: PrefectureMasterRepository<C>,
+    city_repository: CityMasterRepository<C>,
 }
 
-impl Default for GeoloniaInteractorImpl {
+impl<C: ApiClient> Default for GeoloniaInteractorImpl<C> {
     fn default() -> Self {
         Self {
             prefecture_repository: PrefectureMasterRepository {
-                api_client: ReqwestApiClient {},
+                api_client: C::new(),
             },
             city_repository: CityMasterRepository {
-                api_client: ReqwestApiClient {},
+                api_client: C::new(),
             },
         }
     }
 }
 
-impl GeoloniaInteractor for GeoloniaInteractorImpl {
+impl<C: ApiClient> GeoloniaInteractor for GeoloniaInteractorImpl<C> {
     async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         self.prefecture_repository.get(prefecture_name).await
     }

--- a/core/src/interactor/geolonia.rs
+++ b/core/src/interactor/geolonia.rs
@@ -24,25 +24,25 @@ pub(crate) trait GeoloniaInteractor {
     ) -> Result<City, Error>;
 }
 
-pub(crate) struct GeoloniaInteractorImpl<C: ApiClient> {
-    prefecture_repository: PrefectureMasterRepository<C>,
-    city_repository: CityMasterRepository<C>,
+pub(crate) struct GeoloniaInteractorImpl<Client: ApiClient> {
+    prefecture_repository: PrefectureMasterRepository<Client>,
+    city_repository: CityMasterRepository<Client>,
 }
 
-impl<C: ApiClient> Default for GeoloniaInteractorImpl<C> {
+impl<Client: ApiClient> Default for GeoloniaInteractorImpl<Client> {
     fn default() -> Self {
         Self {
             prefecture_repository: PrefectureMasterRepository {
-                api_client: C::new(),
+                api_client: Client::new(),
             },
             city_repository: CityMasterRepository {
-                api_client: C::new(),
+                api_client: Client::new(),
             },
         }
     }
 }
 
-impl<C: ApiClient> GeoloniaInteractor for GeoloniaInteractorImpl<C> {
+impl<Client: ApiClient> GeoloniaInteractor for GeoloniaInteractorImpl<Client> {
     async fn get_prefecture_master(&self, prefecture_name: &str) -> Result<Prefecture, Error> {
         self.prefecture_repository.get(prefecture_name).await
     }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::domain::common::token::Token;
 use crate::domain::geolonia::entity::Address;
 use crate::domain::geolonia::error::{Error, ParseErrorKind};
+use crate::http::reqwest_client::ReqwestApiClient;
 use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
 use crate::tokenizer::{End, Tokenizer};
 use serde::Serialize;
@@ -35,7 +36,7 @@ impl From<Tokenizer<End>> for Address {
 /// }
 /// ```
 pub struct Parser {
-    interactor: Arc<GeoloniaInteractorImpl>,
+    interactor: Arc<GeoloniaInteractorImpl<ReqwestApiClient>>,
 }
 
 impl Default for Parser {


### PR DESCRIPTION
### 変更点
- interactor層の実装を、`reqwest`に依存している`ReqwestApiService`に依存しない形に書き換えます。
- #607 を見越した実装です。
