### PR TITLE
`experimental::parser::Parser`からフィールド`options: ParserOptions`を削除

### DIFF
--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -1,6 +1,6 @@
 use crate::domain::common::latlng::LatLng;
 use crate::domain::common::token::Token;
-use crate::experimental::parser::Parser;
+use crate::experimental::parser::{Parser, ParserOptions};
 use crate::http::reqwest_client::ReqwestApiClient;
 use crate::interactor::chimei_ruiju::{ChimeiRuijuInteractor, ChimeiRuijuInteractorImpl};
 use crate::tokenizer::Tokenizer;
@@ -10,6 +10,7 @@ impl Parser {
     pub(crate) async fn parse_with_chimeiruiju(
         &self,
         address: &str,
+        options: &ParserOptions,
     ) -> (Vec<Token>, Option<LatLng>) {
         let interactor = ChimeiRuijuInteractorImpl::<ReqwestApiClient>::default();
         let tokenizer = Tokenizer::new(address);
@@ -19,7 +20,7 @@ impl Parser {
         let (prefecture, tokenizer) = match tokenizer.read_prefecture() {
             Ok(found) => found,
             Err(not_found) => {
-                if self.options.verbose {
+                if options.verbose {
                     log::error!("都道府県名の検出に失敗しました")
                 }
                 return (not_found.tokens, lat_lng);
@@ -33,7 +34,7 @@ impl Parser {
                 result
             }
             Err(error) => {
-                if self.options.verbose {
+                if options.verbose {
                     log::error!("{}", error)
                 }
                 return (tokenizer.finish().tokens, lat_lng);
@@ -43,19 +44,19 @@ impl Parser {
         let (city_name, tokenizer) = match tokenizer.read_city(&prefecture_master.cities) {
             Ok(found) => found,
             Err(not_found) => {
-                if self.options.correct_incomplete_city_names {
+                if options.correct_incomplete_city_names {
                     match not_found.read_city_with_county_name_completion(&prefecture_master.cities)
                     {
                         Ok(result) => result,
                         Err(not_found) => {
-                            if self.options.verbose {
+                            if options.verbose {
                                 log::error!("市区町村名の検出に失敗しました")
                             }
                             return (not_found.tokens, lat_lng);
                         }
                     }
                 } else {
-                    if self.options.verbose {
+                    if options.verbose {
                         log::error!("市区町村名の検出に失敗しました")
                     }
                     return (not_found.finish().tokens, lat_lng);
@@ -70,7 +71,7 @@ impl Parser {
                 result
             }
             Err(error) => {
-                if self.options.verbose {
+                if options.verbose {
                     log::error!("{}", error)
                 }
                 return (tokenizer.finish().tokens, lat_lng);
@@ -80,7 +81,7 @@ impl Parser {
         let (town_name, tokenizer) = match tokenizer.read_town(city_master.towns) {
             Ok(found) => found,
             Err(not_found) => {
-                if self.options.verbose {
+                if options.verbose {
                     log::error!("町名の検出に失敗しました")
                 }
                 return (not_found.tokens, lat_lng);
@@ -106,15 +107,14 @@ mod tests {
 
     #[tokio::test]
     async fn 都道府県名が誤っている場合() {
-        let parser = Parser {
-            options: ParserOptions {
-                data_source: DataSource::ChimeiRuiju,
-                correct_incomplete_city_names: false,
-                verbose: false,
-            },
+        let parser = Parser::default();
+        let parser_options = ParserOptions {
+            data_source: DataSource::ChimeiRuiju,
+            correct_incomplete_city_names: false,
+            verbose: false,
         };
         let (tokens, _) = parser
-            .parse_with_chimeiruiju("奈川県横浜市磯子区洋光台3-10-3")
+            .parse_with_chimeiruiju("奈川県横浜市磯子区洋光台3-10-3", &parser_options)
             .await;
         assert_eq!(
             tokens,
@@ -124,15 +124,14 @@ mod tests {
 
     #[tokio::test]
     async fn 市区町村名が誤っている場合() {
-        let parser = Parser {
-            options: ParserOptions {
-                data_source: DataSource::ChimeiRuiju,
-                correct_incomplete_city_names: false,
-                verbose: false,
-            },
+        let parser = Parser::default();
+        let parser_options = ParserOptions {
+            data_source: DataSource::ChimeiRuiju,
+            correct_incomplete_city_names: false,
+            verbose: false,
         };
         let (tokens, _) = parser
-            .parse_with_chimeiruiju("神奈川県横浜県磯子市洋光台3-10-3")
+            .parse_with_chimeiruiju("神奈川県横浜県磯子市洋光台3-10-3", &parser_options)
             .await;
         assert_eq!(
             tokens,
@@ -145,15 +144,14 @@ mod tests {
 
     #[tokio::test]
     async fn 町名が誤っている場合() {
-        let parser = Parser {
-            options: ParserOptions {
-                data_source: DataSource::ChimeiRuiju,
-                correct_incomplete_city_names: false,
-                verbose: false,
-            },
+        let parser = Parser::default();
+        let parser_options = ParserOptions {
+            data_source: DataSource::ChimeiRuiju,
+            correct_incomplete_city_names: false,
+            verbose: false,
         };
         let (tokens, _) = parser
-            .parse_with_chimeiruiju("神奈川県横浜市磯子区陽光台3-10-3")
+            .parse_with_chimeiruiju("神奈川県横浜市磯子区陽光台3-10-3", &parser_options)
             .await;
         assert_eq!(
             tokens,
@@ -167,15 +165,14 @@ mod tests {
 
     #[tokio::test]
     async fn パースに成功した場合() {
-        let parser = Parser {
-            options: ParserOptions {
-                data_source: DataSource::ChimeiRuiju,
-                correct_incomplete_city_names: false,
-                verbose: false,
-            },
+        let parser = Parser::default();
+        let parser_options = ParserOptions {
+            data_source: DataSource::ChimeiRuiju,
+            correct_incomplete_city_names: false,
+            verbose: false,
         };
         let (tokens, _) = parser
-            .parse_with_chimeiruiju("神奈川県横浜市磯子区洋光台3-10-3")
+            .parse_with_chimeiruiju("神奈川県横浜市磯子区洋光台3-10-3", &parser_options)
             .await;
         assert_eq!(
             tokens,

--- a/core/src/experimental/parse_with_geolonia.rs
+++ b/core/src/experimental/parse_with_geolonia.rs
@@ -1,12 +1,16 @@
 use crate::domain::common::token::Token;
-use crate::experimental::parser::Parser;
+use crate::experimental::parser::{Parser, ParserOptions};
 use crate::http::reqwest_client::ReqwestApiClient;
 use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
 use crate::tokenizer::Tokenizer;
 
 impl Parser {
     #[inline]
-    pub(crate) async fn parse_with_geolonia(&self, address: &str) -> Vec<Token> {
+    pub(crate) async fn parse_with_geolonia(
+        &self,
+        address: &str,
+        options: &ParserOptions,
+    ) -> Vec<Token> {
         let interactor = GeoloniaInteractorImpl::<ReqwestApiClient>::default();
         let tokenizer = Tokenizer::new(address);
 
@@ -14,7 +18,7 @@ impl Parser {
         let (prefecture, tokenizer) = match tokenizer.read_prefecture() {
             Ok(found) => found,
             Err(not_found) => {
-                if self.options.verbose {
+                if options.verbose {
                     log::error!("都道府県名の検出に失敗しました")
                 }
                 return not_found.tokens;
@@ -25,7 +29,7 @@ impl Parser {
         let prefecture_master = match interactor.get_prefecture_master(prefecture.name_ja()).await {
             Ok(result) => result,
             Err(error) => {
-                if self.options.verbose {
+                if options.verbose {
                     log::error!("{}", error.error_message)
                 }
                 return tokenizer.finish().tokens;
@@ -34,19 +38,19 @@ impl Parser {
         let (city_name, tokenizer) = match tokenizer.read_city(&prefecture_master.cities) {
             Ok(found) => found,
             Err(not_found) => {
-                if self.options.correct_incomplete_city_names {
+                if options.correct_incomplete_city_names {
                     match not_found.read_city_with_county_name_completion(&prefecture_master.cities)
                     {
                         Ok(result) => result,
                         Err(not_found) => {
-                            if self.options.verbose {
+                            if options.verbose {
                                 log::error!("市区町村名の検出に失敗しました")
                             }
                             return not_found.tokens;
                         }
                     }
                 } else {
-                    if self.options.verbose {
+                    if options.verbose {
                         log::error!("市区町村名の検出に失敗しました")
                     }
                     return not_found.finish().tokens;
@@ -61,7 +65,7 @@ impl Parser {
         {
             Ok(result) => result,
             Err(error) => {
-                if self.options.verbose {
+                if options.verbose {
                     log::error!("{}", error.error_message)
                 }
                 return tokenizer.finish().tokens;
@@ -71,7 +75,7 @@ impl Parser {
             match tokenizer.read_town(city_master.towns.iter().map(|x| x.name.clone()).collect()) {
                 Ok(found) => found,
                 Err(not_found) => {
-                    if self.options.verbose {
+                    if options.verbose {
                         log::error!("町名の検出に失敗しました")
                     }
                     return not_found.tokens;
@@ -89,15 +93,14 @@ mod tests {
 
     #[tokio::test]
     async fn 都道府県名が誤っている場合() {
-        let parser = Parser {
-            options: ParserOptions {
-                data_source: DataSource::Geolonia,
-                correct_incomplete_city_names: false,
-                verbose: false,
-            },
+        let parser = Parser::default();
+        let parser_options = ParserOptions {
+            data_source: DataSource::Geolonia,
+            correct_incomplete_city_names: false,
+            verbose: false,
         };
         let result = parser
-            .parse_with_geolonia("奈川県横浜市磯子区洋光台3-10-3")
+            .parse_with_geolonia("奈川県横浜市磯子区洋光台3-10-3", &parser_options)
             .await;
         assert_eq!(
             result,
@@ -107,15 +110,14 @@ mod tests {
 
     #[tokio::test]
     async fn 市区町村名が誤っている場合() {
-        let parser = Parser {
-            options: ParserOptions {
-                data_source: DataSource::Geolonia,
-                correct_incomplete_city_names: false,
-                verbose: false,
-            },
+        let parser = Parser::default();
+        let parser_options = ParserOptions {
+            data_source: DataSource::Geolonia,
+            correct_incomplete_city_names: false,
+            verbose: false,
         };
         let result = parser
-            .parse_with_geolonia("神奈川県横浜県磯子市洋光台3-10-3")
+            .parse_with_geolonia("神奈川県横浜県磯子市洋光台3-10-3", &parser_options)
             .await;
         assert_eq!(
             result,
@@ -128,15 +130,14 @@ mod tests {
 
     #[tokio::test]
     async fn 町名が誤っている場合() {
-        let parser = Parser {
-            options: ParserOptions {
-                data_source: DataSource::Geolonia,
-                correct_incomplete_city_names: false,
-                verbose: false,
-            },
+        let parser = Parser::default();
+        let parser_options = ParserOptions {
+            data_source: DataSource::Geolonia,
+            correct_incomplete_city_names: false,
+            verbose: false,
         };
         let result = parser
-            .parse_with_geolonia("神奈川県横浜市磯子区陽光台3-10-3")
+            .parse_with_geolonia("神奈川県横浜市磯子区陽光台3-10-3", &parser_options)
             .await;
         assert_eq!(
             result,
@@ -150,15 +151,14 @@ mod tests {
 
     #[tokio::test]
     async fn パースに成功した場合() {
-        let parser = Parser {
-            options: ParserOptions {
-                data_source: DataSource::Geolonia,
-                correct_incomplete_city_names: false,
-                verbose: false,
-            },
+        let parser = Parser::default();
+        let parser_options = ParserOptions {
+            data_source: DataSource::Geolonia,
+            correct_incomplete_city_names: false,
+            verbose: false,
         };
         let result = parser
-            .parse_with_geolonia("神奈川県横浜市磯子区洋光台3-10-3")
+            .parse_with_geolonia("神奈川県横浜市磯子区洋光台3-10-3", &parser_options)
             .await;
         assert_eq!(
             result,

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -124,7 +124,7 @@ impl Parser {
     ) -> ParsedAddress {
         match options.data_source {
             DataSource::ChimeiRuiju => {
-                ParsedAddress::from(self.parse_with_chimeiruiju(address).await)
+                ParsedAddress::from(self.parse_with_chimeiruiju(address, options).await)
             }
             DataSource::Geolonia => ParsedAddress::from(self.parse_with_geolonia(address).await),
         }

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -88,7 +88,41 @@ impl Parser {
     /// }
     /// ```
     pub async fn parse(&self, address: &str) -> ParsedAddress {
-        match self.options.data_source {
+        ParsedAddress::from(
+            self.parse_with_options(address, &ParserOptions::default())
+                .await,
+        )
+    }
+
+    /// Parse address into [ParsedAddress] with options.
+    ///
+    /// オプションを指定して住所をパースします。[ParsedAddress]を返します。
+    ///
+    /// # Example
+    /// ```
+    /// use japanese_address_parser::experimental::parser::{DataSource, Parser, ParserOptions};
+    ///
+    ///  async fn example() {
+    ///     let parser = Parser::default();
+    ///     let parser_options = &ParserOptions {
+    ///             data_source: DataSource::ChimeiRuiju,
+    ///             correct_incomplete_city_names: true,
+    ///             verbose: true,
+    ///     };
+    ///     let result = parser.parse_with_options("東京都中央区銀座1丁目1-1", parser_options).await;
+    ///     assert_eq!(result.prefecture, "東京都");
+    ///     assert_eq!(result.city, "中央区");
+    ///     assert_eq!(result.town, "銀座一丁目");
+    ///     assert_eq!(result.rest, "1-1");
+    ///     assert_eq!(result.metadata.depth, 3);
+    /// }
+    /// ```
+    pub async fn parse_with_options(
+        &self,
+        address: &str,
+        options: &ParserOptions,
+    ) -> ParsedAddress {
+        match options.data_source {
             DataSource::ChimeiRuiju => {
                 ParsedAddress::from(self.parse_with_chimeiruiju(address).await)
             }

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -126,7 +126,9 @@ impl Parser {
             DataSource::ChimeiRuiju => {
                 ParsedAddress::from(self.parse_with_chimeiruiju(address, options).await)
             }
-            DataSource::Geolonia => ParsedAddress::from(self.parse_with_geolonia(address).await),
+            DataSource::Geolonia => {
+                ParsedAddress::from(self.parse_with_geolonia(address, options).await)
+            }
         }
     }
 }

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -26,18 +26,14 @@ pub enum DataSource {
 /// use japanese_address_parser::experimental::parser::{DataSource, Parser, ParserOptions};
 ///
 /// // Customize parser
-/// let parser = Parser {
-///     options: ParserOptions {
-///         data_source: DataSource::Geolonia,
-///         correct_incomplete_city_names: false,
-///         verbose: false,
-///     }
+/// let options = ParserOptions {
+///     data_source: DataSource::Geolonia,
+///     correct_incomplete_city_names: false,
+///     verbose: false,
 /// };
 ///
 /// // Use default options
-/// let parser = Parser {
-///     options: ParserOptions::default()
-/// };
+/// let options = ParserOptions::default();
 /// ```
 #[derive(Debug)]
 pub struct ParserOptions {
@@ -64,8 +60,6 @@ impl Default for ParserOptions {
 /// 新型の住所パーサーです。オプションを指定しない場合は`Parser::default()`を使用できます。
 #[derive(Debug, Default)]
 pub struct Parser {
-    /// パーサーのオプションを指定します
-    pub options: ParserOptions,
 }
 
 impl Parser {

--- a/wasm/src/nightly.rs
+++ b/wasm/src/nightly.rs
@@ -66,9 +66,7 @@ pub async fn parse_experimental(address: &str, options: JsValue) -> JsValue {
             },
         },
     };
-    let parser = Parser {
-        options: parser_options,
-    };
-    let result = parser.parse(address).await;
+    let parser = Parser::default();
+    let result = parser.parse_with_options(address, options).await;
     serde_wasm_bindgen::to_value(&result).expect("could not serialize struct into json")
 }


### PR DESCRIPTION
### 変更点
- `experimental::parser::Parser`からフィールド`options: ParserOptions`を削除します
- `options: ParserOptions`はパース関数を呼び出す際に引数で与えるようにします
