### PR TITLE
`ApiClient`をパブリックに変更

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,6 +33,7 @@ js-sys = "0.3.74"
 thiserror = "2.0.3"
 jisx0401 = "0.1.1"
 strum = { version = "0.27.1", features = ["derive"] }
+trait-variant = "0.1.2"
 
 [dev-dependencies]
 tokio.workspace = true

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -1,3 +1,3 @@
 pub(crate) mod client;
-pub(crate) mod error;
+pub mod error;
 pub mod reqwest_client;

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -1,3 +1,3 @@
 pub(crate) mod client;
 pub(crate) mod error;
-pub(crate) mod reqwest_client;
+pub mod reqwest_client;

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -1,3 +1,3 @@
-pub(crate) mod client;
+pub mod client;
 pub mod error;
 pub mod reqwest_client;

--- a/core/src/http/client.rs
+++ b/core/src/http/client.rs
@@ -4,7 +4,7 @@ use serde::de::DeserializeOwned;
 /// HTTP client to fetch remote resources
 ///
 /// 住所データマスタを取得するためのHTTPクライアントはこのトレイトを実装する必要があります。
-#[trait_variant::make(Send)]
+#[cfg_attr(not(target_arch = "wasm32"), trait_variant::make(Send))]
 pub trait ApiClient {
     /// Initialize `ApiClient`
     ///

--- a/core/src/http/client.rs
+++ b/core/src/http/client.rs
@@ -4,14 +4,21 @@ use serde::de::DeserializeOwned;
 /// HTTP client to fetch remote resources
 ///
 /// 住所データマスタを取得するためのHTTPクライアントはこのトレイトを実装する必要があります。
-pub(crate) trait ApiClient {
+#[trait_variant::make(Send)]
+pub trait ApiClient {
     /// Initialize `ApiClient`
     ///
     /// `ApiClient`を初期化処理を実装します。
     fn new() -> Self;
 
+    /// Fetches and deserializes data from a remote URL asynchronously
+    ///
+    /// 引数で指定したURLから非同期的にデータを取得し、デシリアライズする処理を実装します。
     async fn fetch<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError>;
 
+    /// Fetches and deserializes data from a remote URL synchronously
+    ///
+    /// 引数で指定したURLから同期的にデータを取得し、デシリアライズする処理を実装します。
     #[cfg(feature = "blocking")]
     fn fetch_blocking<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError>;
 }

--- a/core/src/http/reqwest_client.rs
+++ b/core/src/http/reqwest_client.rs
@@ -3,7 +3,7 @@ use crate::http::error::ApiClientError;
 use serde::de::DeserializeOwned;
 
 /// An implementation of `ApiClient` with `reqwest`
-pub(crate) struct ReqwestApiClient {}
+pub struct ReqwestApiClient {}
 
 impl ApiClient for ReqwestApiClient {
     fn new() -> Self {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,7 +20,7 @@ pub mod domain;
 #[cfg_attr(docsrs, doc(cfg(feature = "experimental")))]
 pub mod experimental;
 mod formatter;
-mod http;
+pub mod http;
 mod interactor;
 pub mod parser;
 mod repository;


### PR DESCRIPTION
### 変更点
- implements #624 
- 以下のトレイト、構造体の可視性をパブリックに変更します
  - `http::client::ApiClient`
  - `http::reqwest_client::ReqwestApiClient`
  - `http::error::ApiClientError`
- ユーザーが独自の`ApiClient`の実装を組んだり、`experimental::parser::Parser`で好みの`ApiClient`実装に差し替えられるようにするための準備です。