### PR TITLE
`experimental::parser::Parser`においてジェネリクスの型指定で`ApiClient`を差し替え可能にする

### DIFF
--- a/core/src/experimental/parse_with_chimeiruiju.rs
+++ b/core/src/experimental/parse_with_chimeiruiju.rs
@@ -1,18 +1,18 @@
 use crate::domain::common::latlng::LatLng;
 use crate::domain::common::token::Token;
 use crate::experimental::parser::{Parser, ParserOptions};
-use crate::http::reqwest_client::ReqwestApiClient;
+use crate::http::client::ApiClient;
 use crate::interactor::chimei_ruiju::{ChimeiRuijuInteractor, ChimeiRuijuInteractorImpl};
 use crate::tokenizer::Tokenizer;
 use std::option::Option;
 
-impl Parser {
+impl<Client: ApiClient> Parser<Client> {
     pub(crate) async fn parse_with_chimeiruiju(
         &self,
         address: &str,
         options: &ParserOptions,
     ) -> (Vec<Token>, Option<LatLng>) {
-        let interactor = ChimeiRuijuInteractorImpl::<ReqwestApiClient>::default();
+        let interactor = ChimeiRuijuInteractorImpl::<Client>::default();
         let tokenizer = Tokenizer::new(address);
         let mut lat_lng: Option<LatLng> = None;
 

--- a/core/src/experimental/parse_with_geolonia.rs
+++ b/core/src/experimental/parse_with_geolonia.rs
@@ -1,17 +1,17 @@
 use crate::domain::common::token::Token;
 use crate::experimental::parser::{Parser, ParserOptions};
-use crate::http::reqwest_client::ReqwestApiClient;
+use crate::http::client::ApiClient;
 use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
 use crate::tokenizer::Tokenizer;
 
-impl Parser {
+impl<Client: ApiClient> Parser<Client> {
     #[inline]
     pub(crate) async fn parse_with_geolonia(
         &self,
         address: &str,
         options: &ParserOptions,
     ) -> Vec<Token> {
-        let interactor = GeoloniaInteractorImpl::<ReqwestApiClient>::default();
+        let interactor = GeoloniaInteractorImpl::<Client>::default();
         let tokenizer = Tokenizer::new(address);
 
         // 都道府県名の検出

--- a/core/src/experimental/parser.rs
+++ b/core/src/experimental/parser.rs
@@ -1,6 +1,9 @@
 use crate::domain::common::latlng::LatLng;
 use crate::domain::common::token::Token;
+use crate::http::client::ApiClient;
+use crate::http::reqwest_client::ReqwestApiClient;
 use serde::Serialize;
+use std::marker::PhantomData;
 
 /// Data source for Parser
 ///
@@ -55,11 +58,33 @@ impl Default for ParserOptions {
     }
 }
 
-/// Yet another address parser
+/// Yet another address parser(experimental)
 ///
-/// 新型の住所パーサーです。オプションを指定しない場合は`Parser::default()`を使用できます。
-#[derive(Debug, Default)]
-pub struct Parser {
+/// 新型の住所パーサーです。試験的な機能のため、予告なしに破壊的変更が入る可能性があります。
+/// ジェネリクスで型を指定することでデータ通信に用いる`ApiClient`を差し替えることができます。
+///
+/// # Example
+/// ```
+/// use japanese_address_parser::experimental::parser::Parser;
+/// use japanese_address_parser::http::reqwest_client::ReqwestApiClient;
+///
+/// // デフォルトの`ApiClient`を使用する場合
+/// let parser = Parser::default();
+///
+/// // `ApiClient`を指定する場合
+/// let parser = Parser::<ReqwestApiClient>::default();
+/// ```
+#[derive(Debug)]
+pub struct Parser<Client: ApiClient = ReqwestApiClient> {
+    _client: PhantomData<Client>,
+}
+
+impl Default for Parser {
+    fn default() -> Self {
+        Parser {
+            _client: Default::default(),
+        }
+    }
 }
 
 impl Parser {


### PR DESCRIPTION
### 変更点
- implements #624 
- `experimental::parser::Parser`において住所マスタのデータ取得に用いる`ApiClient`を差し替えられるようにします。
- この修正により、ユーザーが独自実装した`ApiClient`を使用することが可能になります。