### PR TITLE
GitHubActionsで使用するNode.jsのバージョンを24に変更

### DIFF
--- a/.github/workflows/free-test.yaml
+++ b/.github/workflows/free-test.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Run free test
         id: run-free-test

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
           scope: '@toriyama'
 


### PR DESCRIPTION
### 変更点
- fix #589 
- GitHubActionsで使用しているNode.jsのバージョンを20系から24系に変更します
- 20系がすでにメンテナンスモードに入っているためです

### 備考
- https://nodejs.org/ja/about/previous-releases
