### PR TITLE
crates.ioのTrusted Publishingに対応する

### DIFF
--- a/.github/workflows/upload-cratesio.yaml
+++ b/.github/workflows/upload-cratesio.yaml
@@ -9,11 +9,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: crates-io
+    permissions:
+      id-token: write # Required for OIDC token exchange
     defaults:
       run:
         working-directory: core
     steps:
       - uses: actions/checkout@v4
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
 
       - name: Build check
         run: cargo build --verbose
@@ -29,4 +33,4 @@ jobs:
       - name: Upload artifact to crates.io
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
### 変更点
- implements #645 
- crates.ioでTrusted Publishing機能が使えるようになったので対応します。

### 備考
- https://crates.io/docs/trusted-publishing
