### PR TITLE
住所データ取得時のHTTPリクエストでライブラリ固有のUser-Agentを指定する

### DIFF
--- a/core/src/http/reqwest_client.rs
+++ b/core/src/http/reqwest_client.rs
@@ -11,7 +11,17 @@ impl ApiClient for ReqwestApiClient {
     }
 
     async fn fetch<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
-        let response = reqwest::get(url)
+        let client = reqwest::Client::builder()
+            .user_agent(format!(
+                "{}/{}",
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION")
+            ))
+            .build()
+            .unwrap();
+        let response = client
+            .get(url)
+            .send()
             .await
             .map_err(|e| ApiClientError::Request {
                 url: url.to_string(),
@@ -36,10 +46,21 @@ impl ApiClient for ReqwestApiClient {
 
     #[cfg(feature = "blocking")]
     fn fetch_blocking<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
-        let response = reqwest::blocking::get(url).map_err(|e| ApiClientError::Request {
-            url: url.to_string(),
-            message: e.to_string(),
-        })?;
+        let client = reqwest::blocking::Client::builder()
+            .user_agent(format!(
+                "{}/{}",
+                env!("CARGO_PKG_NAME"),
+                env!("CARGO_PKG_VERSION")
+            ))
+            .build()
+            .unwrap();
+        let response = client
+            .get(url)
+            .send()
+            .map_err(|e| ApiClientError::Request {
+                url: url.to_string(),
+                message: e.to_string(),
+            })?;
 
         let status = response.status();
         if !status.is_success() {


### PR DESCRIPTION
### 変更点
- implements #652 
- 住所データ取得時のHTTPリクエストでライブラリ固有のUser-Agentを指定するように修正します
- `japanese-address-parser/0.2.11`のような値が設定されるようになります