### PR TITLE
npmjsのTrusted Publishingに対応する

### DIFF
--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -50,4 +50,4 @@ jobs:
       - name: Upload wasm to npmjs.com
         run: |
           cd pkg
-          npm publish --provenance --access public
+          npm publish --access public

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -51,5 +51,3 @@ jobs:
         run: |
           cd pkg
           npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_REGISTRY_TOKEN }}


### PR DESCRIPTION
### 変更点
- implements #665 
- crates.ioに続き、npmjs.comでもTrusted Publishingができるようになったので対応します

### 備考
- https://docs.npmjs.com/trusted-publishers