### PR TITLE
PyPIのTrusted Publishingに対応する

### DIFF
--- a/.github/workflows/upload-pypi-org.yaml
+++ b/.github/workflows/upload-pypi-org.yaml
@@ -128,13 +128,14 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     environment: pypi
+    permissions:
+      id-token: write
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
           MATURIN_REPOSITORY: "pypi" # test.pypi.orgにアップロードする際は"testpypi"を設定する
         with:
           maturin-version: 1.8.1


### PR DESCRIPTION
### 変更点
- implements #667 
- PyPIのTrusted Publishingに対応します

### 備考
- アップロードにはmaturinを使っているので、maturinのドキュメントを参考に作業しました
  - https://github.com/PyO3/maturin/blob/main/guide/src/distribution.md
