### PR TITLE
Rust 2024 Editionへの対応

### DIFF
--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -52,26 +52,13 @@ jobs:
 
   msrv:
     runs-on: ubuntu-latest
-    # ローカル環境では1.75.0でビルドできるがGitHub Actions上ではビルドが通らないため一時的にスキップするよう設定
-    # MSRVを見直す際に以下の設定は除却する
-    if: false
     steps:
       - uses: actions/checkout@v4
       - name: Install minimum supported version
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.75.0
+          toolchain: 1.85.0
       - name: Basic build
-        run: |
-          # `litemap`と`zerofrom`の最新版でMSRVがv1.81.0になってしまっていて、Rust1.75.0でビルドしようとすると失敗するため以下を実行
-          # `litemap`と`zerofrom`においてMSRVが元に戻ったり、`japanese-address-parser`自体のMSRVが1.81.0以上になったら以下の処理は不要になるので除却する
-          cargo update litemap --precise 0.7.4
-          cargo update zerofrom --precise 0.1.5
-          cargo build --verbose
+        run: cargo build --verbose
       - name: Build docs
-        run: |
-          # `litemap`と`zerofrom`の最新版でMSRVがv1.81.0になってしまっていて、Rust1.75.0でビルドしようとすると失敗するため以下を実行
-          # `litemap`と`zerofrom`においてMSRVが元に戻ったり、`japanese-address-parser`自体のMSRVが1.81.0以上になったら以下の処理は不要になるので除却する
-          cargo update litemap --precise 0.7.4
-          cargo update zerofrom --precise 0.1.5
-          cargo doc --verbose
+        run: cargo doc --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.2.12"
-edition = "2021"
+edition = "2024"
 description = "A library for processing addresses of Japan"
 repository = "https://github.com/YuukiToriyama/japanese-address-parser"
 authors = ["Yuuki Toriyama <github@toriyama.dev>"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 readme = "../README.md"
 keywords.workspace = true
 categories.workspace = true
-rust-version = "1.75.0"
+rust-version = "1.85.0"
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/core/src/formatter/informal_town_name_notation.rs
+++ b/core/src/formatter/informal_town_name_notation.rs
@@ -3,24 +3,22 @@ use crate::util::converter::JapaneseNumber;
 /// 住居表示実施済みの住所でN丁目のNが算用数字の場合に漢数字に書き換えます
 pub(crate) fn format_informal_town_name_notation(target: &str) -> Option<String> {
     let (town_name, chome, rest) = if cfg!(target_arch = "wasm32") {
-        let captures = js_sys::RegExp::new(
+        js_sys::RegExp::new(
             r"^(\D+)(\d+)[\u002D\u2010\u2011\u2012\u2013\u2014\u2015\u2212\u30FC\uFF0D\uFF70]*(.*)$",
             "",
-        ).exec(target)?;
-        (
+        ).exec(target).and_then(|captures| Some((
             captures.get(1).as_string()?,
             captures.get(2).as_string()?.parse::<i8>().ok()?,
             captures.get(3).as_string()?,
-        )
+        )))?
     } else {
-        let captures = regex::Regex::new(
+        regex::Regex::new(
             r"^(?<town_name>\D+)(?<chome>\d+)[\u002D\u2010\u2011\u2012\u2013\u2014\u2015\u2212\u30FC\uFF0D\uFF70]*(?<rest>.*)$",
-        ).unwrap().captures(target)?;
-        (
+        ).unwrap().captures(target).and_then(|captures| Some((
             captures.name("town_name")?.as_str().to_string(),
             captures.name("chome")?.as_str().parse::<i8>().ok()?,
             captures.name("rest")?.as_str().to_string(),
-        )
+        )))?
     };
     // 帯広市西十九条四十二丁目の42が最大なので、43以上の値の場合はNoneを返すようにする
     if chome > 42 {

--- a/core/src/http/reqwest_client.rs
+++ b/core/src/http/reqwest_client.rs
@@ -14,15 +14,17 @@ impl ApiClient for ReqwestApiClient {
         let response = if cfg!(target_arch = "wasm32") {
             reqwest::get(url).await
         } else {
-            let client = reqwest::Client::builder()
+            reqwest::Client::builder()
                 .user_agent(format!(
                     "{}/{}",
                     env!("CARGO_PKG_NAME"),
                     env!("CARGO_PKG_VERSION")
                 ))
                 .build()
-                .unwrap();
-            client.get(url).send().await
+                .unwrap()
+                .get(url)
+                .send()
+                .await
         }
         .map_err(|e| ApiClientError::Request {
             url: url.to_string(),

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasm"
 version.workspace = true
-edition.workspace = true
+edition = "2021" # `wasm-bindgen`が2024に未対応なため
 description.workspace = true
 repository.workspace = true
 authors.workspace = true


### PR DESCRIPTION
### 変更点
- Rust言語のeditionを2021から2024に更新します。
- edition変更により警告がでている箇所を修正します。
- MSRVを1.75.0から1.85.0に変更します。

### 備考
- #584 
