### PR TITLE
`reqwest`をv0.13系に変更

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,7 +28,7 @@ log.workspace = true
 rapidfuzz = "0.5.0"
 regex = { version = "1.11.1", default-features = false, features = ["std", "unicode-perl"] }
 serde.workspace = true
-reqwest = { version = "0.12.9", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
 js-sys = "0.3.74"
 thiserror = "2.0.3"
 jisx0401 = "0.1.1"


### PR DESCRIPTION
### 変更点
- `reqwest`をv0.12系からv0.13系に変更します

### 備考
- https://github.com/seanmonstar/reqwest/releases/tag/v0.13.0
