### PR TITLE
PyO3のアップデート: 0.24.1から0.28.3へ

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -17,4 +17,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 japanese-address-parser = { path = "../core", features = ["blocking"] }
-pyo3 = { version = "0.24.1", features = ["abi3-py37"] }
+pyo3 = { version = "0.28.3", features = ["abi3-py37"] }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -45,14 +45,13 @@ impl PyParser {
 
     fn parse(&self, py: Python<'_>, address: &str) -> PyParseResult {
         // parse_blocking はPythonオブジェクトに触れないためGILを解放する
-        py.allow_threads(|| self.parser.parse_blocking(address))
-            .into()
+        py.detach(|| self.parser.parse_blocking(address)).into()
     }
 }
 
 #[pyfunction]
 fn parse(py: Python<'_>, address: &str) -> PyParseResult {
-    py.allow_threads(|| {
+    py.detach(|| {
         let parser: Parser = Default::default();
         parser.parse_blocking(address)
     })

--- a/python/tests/test_bench_threading.py
+++ b/python/tests/test_bench_threading.py
@@ -1,6 +1,6 @@
 """Benchmarks for verifying the GIL-release effect on ``Parser.parse``.
 
-``Parser.parse`` releases the GIL via ``py.allow_threads`` so that concurrent
+``Parser.parse`` releases the GIL via ``py.detach`` so that concurrent
 Python threads can overlap HTTP I/O while fetching Geolonia masters. These
 benchmarks keep that behavior under regression watch.
 


### PR DESCRIPTION
### 変更点
- PyO3のバージョンを0.24.1から0.28.3へアップデートします
- `pyo3::marker::Python::allow_threads`はv0.26.0で非推奨になり`pyo3::marker::Python::detach`への移行が推奨されているため修正します

### 備考
- #676 
