### PR TITLE
MCPサーバーの実装: REAMDEの記述修正&crates.ioへのアップロードジョブの整備

### DIFF
--- a/.github/workflows/upload-cratesio.yaml
+++ b/.github/workflows/upload-cratesio.yaml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  build:
+  release-core:
     runs-on: ubuntu-latest
     environment: crates-io
     permissions:
@@ -26,6 +26,31 @@ jobs:
           cargo test
           cargo test --features blocking
 
+      - name: Try packaging
+        run: cargo publish --dry-run
+      - name: Show files will be included
+        run: cargo package --list
+      - name: Upload artifact to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+  release-mcp:
+    needs: release-core
+    runs-on: ubuntu-latest
+    environment: crates-io
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC token exchange
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - name: Build check
+        run: cargo build --verbose
       - name: Try packaging
         run: cargo publish --dry-run
       - name: Show files will be included

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ description = "A library for processing addresses of Japan"
 repository = "https://github.com/YuukiToriyama/japanese-address-parser"
 authors = ["Yuuki Toriyama <github@toriyama.dev>"]
 license = "MIT"
+license-file = "LICENSE"
 keywords = ["parser", "geo", "wasm"]
 categories = ["parser-implementations", "wasm"]
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ This library can be called from the Python world. For more details, see [python 
 
 ## MCP server(experimental)
 
+[![Crates.io (latest)](https://img.shields.io/crates/v/japanese-address-parser-mcp)](https://crates.io/crates/japanese-address-parser-mcp)
+
 This library provides an MCP (Model Context Protocol) server implementation that allows AI models and tools to integrate Japanese address parsing capabilities.  
 The MCP server is available as a separate package: [`japanese-address-parser-mcp`](https://crates.io/crates/japanese-address-parser-mcp)  
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ You can run this crate on your browser. For more details, see [wasm module's REA
 
 This library can be called from the Python world. For more details, see [python module's README](python/README.md).
 
+## MCP server(experimental)
+
+This library provides an MCP (Model Context Protocol) server implementation that allows AI models and tools to integrate Japanese address parsing capabilities.  
+The MCP server is available as a separate package: [`japanese-address-parser-mcp`](https://crates.io/crates/japanese-address-parser-mcp)  
+
 ## Road to v1
 
 The goals of this library are as follows.

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -6,7 +6,7 @@ description = "MCP server for japanese-address-parser — parsing addresses with
 readme = "README.md"
 repository.workspace = true
 authors.workspace = true
-license.workspace = true
+license-file.workspace = true
 keywords = ["parser", "geo", "mcp"]
 categories.workspace = true
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,5 +1,7 @@
 # japanese-address-parser-mcp
 
+[![Crates.io (latest)](https://img.shields.io/crates/v/japanese-address-parser-mcp)](https://crates.io/crates/japanese-address-parser-mcp)
+
 [japanese-address-parser](https://github.com/YuukiToriyama/japanese-address-parser)をModel Context Protocol(MCP)サーバーとして提供するためのクレートです。
 
 このクレートを利用することで、Claude DesktopなどのMCP対応クライアントを介して、日本の住所の正規化機能をAIアシスタントから直接呼び出すことが可能になります。  
@@ -22,10 +24,17 @@ RustやJavaScriptのコードを実装することなく、自然言語による
 
 ## 導入手順
 
-### 1. ビルド方法
+### 1. MCPサーバーのインストール
 
-本MCPサーバーのビルドには Rust の開発環境（Cargo）が必要です。  
-リポジトリをクローンし、ビルドを行なってください。  
+#### crates.ioからインストールする
+
+```bash
+cargo install japanese-address-parser-mcp
+```
+
+インストールが完了すると、`$HOME/.cargo/bin/japanese-address-parser-mcp`に実行バイナリが配置されます。
+
+#### ソースコードからビルドする
 
 ```bash
 git clone git@github.com:YuukiToriyama/japanese-address-parser.git

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,28 +2,30 @@
 
 [japanese-address-parser](https://github.com/YuukiToriyama/japanese-address-parser)をModel Context Protocol(MCP)サーバーとして提供するためのクレートです。
 
-本プロジェクトを利用することで、Claude DesktopなどのMCP対応クライアントを介して、日本の住所の正規化機能をAIアシスタントから直接呼び出すことが可能になります。RustやJavaScriptのコードを実装することなく、自然言語による指示のみで高度な住所解析機能を利用できます。
+このクレートを利用することで、Claude DesktopなどのMCP対応クライアントを介して、日本の住所の正規化機能をAIアシスタントから直接呼び出すことが可能になります。  
+RustやJavaScriptのコードを実装することなく、自然言語による指示のみで高度な住所解析機能を利用できます。  
 
 ## 主な特徴
 
-- **正確な住所分割**: 複雑な日本の住所体系を「都道府県」「市区町村」「町名」「番地以降」に適切に分割します。
+- **正確な住所分割**: 複雑な日本の住所体系を「都道府県」「市区町村」「町名」「番地以降」に分割します。
 - **バッチ処理対応**: 最大100件までの住所を一度の操作で一括処理可能です。
-- **シームレスな AI 統合**: Claude Desktop やその他の MCP 対応ツールと即座に連携できます。
+- **シームレスなAI統合**: Claude Desktop やその他の MCP 対応ツールと即座に連携できます。
 
 ## 公開ツール
 
-本サーバーは以下のツールを AI アシスタントに提供します。
+本サーバーは以下のツールをAIアシスタントに提供します。
 
-| ツール名 | 機能概要 |
-| :--- | :--- |
-| `process_an_address` | 単一の住所文字列を解析し、構成要素（都道府県・市区町村・町名等）に分割します。 |
-| `process_address_list` | 複数の住所を一括で解析します（一回の呼び出しで最大100件まで）。 |
+| ツール名 | 機能概要                                    |
+| :--- |:----------------------------------------|
+| `process_an_address` | 単一の住所文字列を解析し、構成要素(都道府県・市区町村・町名等)に分割します。 |
+| `process_address_list` | 複数の住所を一括で解析します(一回の呼び出しで最大100件まで)。       |
 
 ## 導入手順
 
 ### 1. ビルド方法
 
-本サーバーのビルドには Rust の開発環境（Cargo）が必要です。リポジトリをクローンし、リリースビルドを行ってください。
+本MCPサーバーのビルドには Rust の開発環境（Cargo）が必要です。  
+リポジトリをクローンし、ビルドを行なってください。  
 
 ```bash
 git clone git@github.com:YuukiToriyama/japanese-address-parser.git
@@ -33,10 +35,9 @@ cargo build --release -p japanese-address-parser-mcp
 
 ビルドが完了すると、`./target/release/japanese-address-parser-mcp` に実行バイナリが生成されます。
 
-### 2. 設定（Claude Desktop の例）
+### 2. 設定(Claude Desktop)
 
-以下の設定ファイルに本サーバーの情報を追記してください。
-設定ファイルのパス: `~/Library/Application Support/Claude/claude_desktop_config.json`
+ClaudeDesktopの設定ファイル(`~/Library/Application Support/Claude/claude_desktop_config.json`)に本サーバーの情報を追記してください。
 
 ```json
 {


### PR DESCRIPTION
### 変更点
- Implementation for #684 
- `japanese-address-parser`と`japanese-address-parser-mcp`それぞれのREADMEの記述を修正します
