### PR TITLE
Python向け実装にasyncioに対応した非同期版関数・メソッドを追加

### DIFF
--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -61,9 +61,10 @@ jobs:
         with:
           enable-cache: true
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --dev
       - name: Run tests
-        run: uv run pytest tests/test_parser.py
+        run: |
+          uv run pytest tests/test_parser.py tests/test_async.py
 
   msrv:
     runs-on: ubuntu-latest

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -18,3 +18,4 @@ crate-type = ["cdylib"]
 [dependencies]
 japanese-address-parser = { path = "../core", features = ["blocking"] }
 pyo3 = { version = "0.28.3", features = ["abi3-py37"] }
+pyo3-async-runtimes = { version = "0.28.0", features = ["tokio-runtime"] }

--- a/python/README.md
+++ b/python/README.md
@@ -72,6 +72,31 @@ for result in results:
 {'city': '高知市', 'town': '丸ノ内一丁目', 'rest': '2-20', 'prefecture': '高知県'}
 ```
 
+### Async usage
+
+```python
+import asyncio
+from japanese_address_parser_py import parse_async
+
+ADDRESSES = [
+    "神奈川県相模原市緑区西橋本五丁目3番21",
+    "神奈川県相模原市中央区中央二丁目11番15号",
+    "神奈川県相模原市南区相模大野五丁目31番1号",
+]
+
+
+async def main():
+    tasks = [parse_async(addr) for addr in ADDRESSES]
+    results = await asyncio.gather(*tasks)
+
+    for result in results:
+        print(result.address)
+        print(result.error)
+
+
+asyncio.run(main())
+```
+
 ## Development
 
 This library is written in Rust. You need to set up a Rust development environment to build this library.

--- a/python/japanese_address_parser_py.pyi
+++ b/python/japanese_address_parser_py.pyi
@@ -61,3 +61,13 @@ class Parser:
         :param address: 住所
         :return: ParseResult
         """
+
+    async def parse_async(self, address: str) -> ParseResult:
+        """
+        Format informal address into formal style (async)
+
+        入力された住所を正式な表記に整形します（非同期版）。
+
+        :param address: 住所
+        :return: ParseResult
+        """

--- a/python/japanese_address_parser_py.pyi
+++ b/python/japanese_address_parser_py.pyi
@@ -31,6 +31,17 @@ def parse(address: str) -> ParseResult:
     """
 
 
+async def parse_async(address: str) -> ParseResult:
+    """
+    Format informal address into formal style (async)
+
+    入力された住所を正式な表記に整形します（非同期版）。
+
+    :param address: 住所
+    :return: ParseResult
+    """
+
+
 class Parser:
     def __new__(cls) -> Parser:
         """

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,6 +21,7 @@ features = ["pyo3/extension-module"]
 dev = [
     "pytest>=8,<9",
     "pytest-benchmark>=5,<6",
+    "pytest-asyncio>=0.24,<1",
 ]
 
 [tool.pytest.ini_options]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-
 use pyo3::prelude::*;
+use std::collections::HashMap;
+use std::sync::OnceLock;
 
 use japanese_address_parser::parser::ParseResult;
 use japanese_address_parser::parser::Parser;
@@ -51,13 +51,15 @@ impl PyParser {
     }
 }
 
+static GLOBAL_PARSER: OnceLock<Parser> = OnceLock::new();
+
+fn get_parser() -> &'static Parser {
+    GLOBAL_PARSER.get_or_init(Default::default)
+}
+
 #[pyfunction]
 fn parse(py: Python<'_>, address: &str) -> PyParseResult {
-    py.detach(|| {
-        let parser: Parser = Default::default();
-        parser.parse_blocking(address)
-    })
-    .into()
+    py.detach(|| get_parser().parse_blocking(address)).into()
 }
 
 #[pymodule]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -62,11 +62,21 @@ fn parse(py: Python<'_>, address: &str) -> PyParseResult {
     py.detach(|| get_parser().parse_blocking(address)).into()
 }
 
+#[pyfunction]
+fn parse_async<'py>(py: Python<'py>, address: String) -> PyResult<Bound<'py, PyAny>> {
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let result: ParseResult = get_parser().parse(&address).await;
+        let py_result: PyParseResult = result.into();
+        Ok(py_result)
+    })
+}
+
 #[pymodule]
 #[pyo3(name = "japanese_address_parser_py")]
 fn python_module(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyParseResult>()?;
     m.add_class::<PyParser>()?;
     m.add_function(wrap_pyfunction!(parse, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_async, m)?)?;
     Ok(())
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,6 +1,6 @@
 use pyo3::prelude::*;
 use std::collections::HashMap;
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 
 use japanese_address_parser::parser::ParseResult;
 use japanese_address_parser::parser::Parser;
@@ -33,7 +33,7 @@ impl From<ParseResult> for PyParseResult {
 
 #[pyclass(name = "Parser")]
 struct PyParser {
-    parser: Parser,
+    parser: Arc<Parser>,
 }
 
 #[pymethods]
@@ -41,13 +41,22 @@ impl PyParser {
     #[new]
     fn default() -> Self {
         PyParser {
-            parser: Default::default(),
+            parser: Arc::new(Default::default()),
         }
     }
 
     fn parse(&self, py: Python<'_>, address: &str) -> PyParseResult {
         // parse_blocking はPythonオブジェクトに触れないためGILを解放する
         py.detach(|| self.parser.parse_blocking(address)).into()
+    }
+
+    fn parse_async<'py>(&self, py: Python<'py>, address: String) -> PyResult<Bound<'py, PyAny>> {
+        let parser = Arc::clone(&self.parser);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let result: ParseResult = parser.parse(&address).await;
+            let py_result: PyParseResult = result.into();
+            Ok(py_result)
+        })
     }
 }
 

--- a/python/tests/test_async.py
+++ b/python/tests/test_async.py
@@ -1,0 +1,36 @@
+import asyncio
+import pytest
+
+from japanese_address_parser_py import parse_async
+
+
+@pytest.mark.asyncio
+async def test_parse_async_function():
+    """Standalone parse_async function test."""
+    result = await parse_async("東京都目黒区上目黒2-19-15")
+
+    assert result.address["prefecture"] == "東京都"
+    assert result.address["city"] == "目黒区"
+    assert result.address["town"] == "上目黒二丁目"
+    assert result.address["rest"] == "19-15"
+    assert result.error == {}
+
+
+@pytest.mark.asyncio
+async def test_parse_async_concurrency():
+    """Test if multiple async calls can run concurrently."""
+    addresses = [
+        "神奈川県横浜市港南区港南四丁目2番10号",
+        "神奈川県横浜市南区浦舟町2丁目33番地",
+        "神奈川県横浜市緑区寺山町118番地",
+    ]
+    tasks = [parse_async(addr) for addr in addresses]
+    results = await asyncio.gather(*tasks)
+
+    assert len(results) == 3
+    assert results[0].address["prefecture"] == "神奈川県"
+    assert results[0].address["city"] == "横浜市港南区"
+    assert results[1].address["prefecture"] == "神奈川県"
+    assert results[1].address["city"] == "横浜市南区"
+    assert results[2].address["prefecture"] == "神奈川県"
+    assert results[2].address["city"] == "横浜市緑区"

--- a/python/tests/test_async.py
+++ b/python/tests/test_async.py
@@ -1,7 +1,7 @@
 import asyncio
 import pytest
 
-from japanese_address_parser_py import parse_async
+from japanese_address_parser_py import Parser, parse_async
 
 
 @pytest.mark.asyncio
@@ -34,3 +34,37 @@ async def test_parse_async_concurrency():
     assert results[1].address["city"] == "横浜市南区"
     assert results[2].address["prefecture"] == "神奈川県"
     assert results[2].address["city"] == "横浜市緑区"
+
+
+@pytest.mark.asyncio
+async def test_parser_parse_async_method():
+    """Parser::parse_async method test."""
+    parser = Parser()
+    result = await parser.parse_async("東京都江戸川区中央一丁目4番1号")
+
+    assert result.address["prefecture"] == "東京都"
+    assert result.address["city"] == "江戸川区"
+    assert result.address["town"] == "中央一丁目"
+    assert result.address["rest"] == "4番1号"
+    assert result.error == {}
+
+
+@pytest.mark.asyncio
+async def test_parser_parse_async_concurrency():
+    """Parser::parse_async concurrency test."""
+    parser = Parser()
+    addresses = [
+        "神奈川県横浜市都筑区茅ケ崎中央32番1号",
+        "神奈川県横浜市神奈川区広台太田町3番地8",
+        "神奈川県横浜市鶴見区鶴見中央三丁目20番1号",
+    ]
+    tasks = [parser.parse_async(addr) for addr in addresses]
+    results = await asyncio.gather(*tasks)
+
+    assert len(results) == 3
+    assert results[0].address["prefecture"] == "神奈川県"
+    assert results[0].address["city"] == "横浜市都筑区"
+    assert results[1].address["prefecture"] == "神奈川県"
+    assert results[1].address["city"] == "横浜市神奈川区"
+    assert results[2].address["prefecture"] == "神奈川県"
+    assert results[2].address["city"] == "横浜市鶴見区"


### PR DESCRIPTION
### 変更点
- implements #655 
- `parse`関数の非同期版として、`parse_async`関数を追加します。
- `Parser.parse()`メソッドの非同期版として、`Parser.parse_async()`メソッドを追加します。

### 備考
- Rustコード上は破壊的変更が加わっていますが、Pythonから見たときにはインターフェースに破壊的変更は入っていないのでパッチバージョンでのリリースとしています。
