### PR TITLE
MCPサーバーの改善

### DIFF
--- a/.github/workflows/upload-cratesio.yaml
+++ b/.github/workflows/upload-cratesio.yaml
@@ -51,6 +51,8 @@ jobs:
         id: auth
       - name: Build check
         run: cargo build --verbose
+      - name: Copy project root LICENSE file to mcp directory
+        run: cp ../LICENSE LICENSE
       - name: Try packaging
         run: cargo publish --dry-run
       - name: Show files will be included

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.102"
+futures = "0.3.32"
 japanese-address-parser = { version = "0.3.2", path = "../core", features = ["experimental"] }
 rmcp = { version = "1.6.0", features = ["server", "transport-io"] }
 schemars = "1.2.1"

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -7,7 +7,6 @@ readme = "README.md"
 repository.workspace = true
 authors.workspace = true
 license.workspace = true
-license-file.workspace = true
 keywords = ["parser", "geo", "mcp"]
 categories.workspace = true
 

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -6,6 +6,7 @@ description = "MCP server for japanese-address-parser — parsing addresses with
 readme = "README.md"
 repository.workspace = true
 authors.workspace = true
+license.workspace = true
 license-file.workspace = true
 keywords = ["parser", "geo", "mcp"]
 categories.workspace = true

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -40,12 +40,13 @@ impl ParseAddressServer {
 #[tool_handler]
 impl ServerHandler for ParseAddressServer {
     fn get_info(&self) -> ServerInfo {
+        let instructions = "日本の住所を都道府県・市区町村・町名・それ以降に分割できるMCPサーバーです。 \
+            process_an_address: 1件の住所を解析 \
+            process_address_list: 複数の住所を一括で解析 \
+            環境変数 JAPANESE_ADDRESS_PARSER_MCP_MAX_CONCURRENCY で並列度を制御できます（デフォルト:8）";
+
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::from_build_env())
-            .with_instructions(
-                "日本の住所を都道府県・市区町村・町名・それ以降に分割できるMCPサーバーです。 \
-                process_an_address: 1件の住所を解析 \
-                process_address_list: 複数の住所を一括で解析",
-            )
+            .with_instructions(instructions)
     }
 }

--- a/mcp/src/server.rs
+++ b/mcp/src/server.rs
@@ -45,8 +45,13 @@ impl ServerHandler for ParseAddressServer {
             process_address_list: 複数の住所を一括で解析 \
             環境変数 JAPANESE_ADDRESS_PARSER_MCP_MAX_CONCURRENCY で並列度を制御できます（デフォルト:8）";
 
+        let server_info = Implementation::from_build_env()
+            .with_title("japanese-address-parser MCP")
+            .with_description("An MCP server for parsing addresses of Japan into components.")
+            .with_website_url("https://crates.io/crates/japanese-address-parser-mcp");
+
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_server_info(Implementation::from_build_env())
+            .with_server_info(server_info)
             .with_instructions(instructions)
     }
 }

--- a/mcp/src/server/process_address_list.rs
+++ b/mcp/src/server/process_address_list.rs
@@ -3,6 +3,10 @@ use rmcp::ErrorData;
 use rmcp::model::{CallToolResult, Content};
 use schemars::JsonSchema;
 use serde::Deserialize;
+use serde_json::Value;
+
+use futures::StreamExt;
+use std::sync::Arc;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct RequestParameters {
@@ -26,17 +30,34 @@ pub(crate) async fn process_address_list(
         ));
     }
 
-    let mut results = Vec::with_capacity(params.address_list.len());
-    let parser = Parser::default();
-    for address in &params.address_list {
-        let result = parser.parse(address).await;
-        results.push(serde_json::json!({
-            "input": address,
-            "result": result,
-        }));
-    }
+    let max_concurrency: usize = std::env::var("JAPANESE_ADDRESS_PARSER_MCP_MAX_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8);
+
+    let parser = Arc::new(Parser::default());
+
+    let stream = futures::stream::iter(params.address_list.into_iter().enumerate())
+        .map(|(index, address)| {
+            let parser = Arc::clone(&parser);
+            async move { parse_entry(parser, index, address).await }
+        })
+        .buffer_unordered(max_concurrency);
+
+    let mut entries = stream.collect::<Vec<(usize, Value)>>().await;
+    entries.sort_by_key(|(index, _)| *index);
+    let results: Vec<Value> = entries.into_iter().map(|(_, v)| v).collect();
 
     let json = serde_json::to_string_pretty(&results)
         .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
     Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+async fn parse_entry(parser: Arc<Parser>, index: usize, address: String) -> (usize, Value) {
+    let result = parser.parse(&address).await;
+    let entry = serde_json::json!({
+        "input": address,
+        "result": result,
+    });
+    (index, entry)
 }

--- a/mcp/src/server/process_address_list.rs
+++ b/mcp/src/server/process_address_list.rs
@@ -33,6 +33,7 @@ pub(crate) async fn process_address_list(
     let max_concurrency: usize = std::env::var("JAPANESE_ADDRESS_PARSER_MCP_MAX_CONCURRENCY")
         .ok()
         .and_then(|v| v.parse().ok())
+        .filter(|&v| v > 0)
         .unwrap_or(8);
 
     let parser = Arc::new(Parser::default());


### PR DESCRIPTION
### 変更点
- v0.3.2で公開したMCPサーバーについて、いくつかの点を修正します。
  - crates.ioにてLICENSEが適切に表示されていなかった問題を修正
  - ツール`process_address_list`に関して直列処理になっていたものを並行処理に書き換える
  - MCPサーバーの詳細情報にMCPサーバーの説明や外部リンクを追加
