### PR TITLE
Sans-IOパターンを使ったParserのリファクタ

### DIFF
--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::domain::common::token::Token;
 use crate::domain::geolonia::entity::Address;
-use crate::domain::geolonia::error::{Error, ParseErrorKind};
+use crate::domain::geolonia::error::Error;
 use crate::http::reqwest_client::ReqwestApiClient;
 use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
 use crate::parser::pure::{PureParser, PureParserAction};
@@ -83,61 +83,27 @@ impl Parser {
     #[cfg(feature = "blocking")]
     pub fn parse_blocking(&self, address: &str) -> ParseResult {
         let interactor = self.interactor.clone();
-        let tokenizer = Tokenizer::new(address);
-        let (prefecture, tokenizer) = match tokenizer.read_prefecture() {
-            Ok(found) => found,
-            Err(tokenizer) => {
-                return ParseResult {
-                    address: Address::from(tokenizer),
-                    error: Some(Error::new_parse_error(ParseErrorKind::Prefecture)),
-                }
-            }
-        };
-        let prefecture_master =
-            match interactor.get_blocking_prefecture_master(prefecture.name_ja()) {
-                Err(error) => {
-                    return ParseResult {
-                        address: Address::from(tokenizer.finish()),
-                        error: Some(error),
-                    };
-                }
-                Ok(result) => result,
-            };
-        let (city_name, tokenizer) = match tokenizer.read_city(&prefecture_master.cities) {
-            Ok(found) => found,
-            Err(not_found) => {
-                match not_found.read_city_with_county_name_completion(&prefecture_master.cities) {
-                    Ok(found) if cfg!(feature = "city-name-correction") => found,
-                    _ => {
-                        return ParseResult {
-                            address: Address::from(tokenizer.finish()),
-                            error: Some(Error::new_parse_error(ParseErrorKind::City)),
-                        };
+        let mut pure_parser = PureParser::new(address);
+
+        loop {
+            match pure_parser.advance() {
+                PureParserAction::RequestCityNameList(pref_name) => {
+                    match interactor.get_blocking_prefecture_master(&pref_name) {
+                        Ok(result) => pure_parser.provide_input(result.cities),
+                        Err(error) => return pure_parser.abort(error),
                     }
                 }
+                PureParserAction::RequestTownNameList(pref_name, city_name) => {
+                    match interactor.get_blocking_city_master(&pref_name, &city_name) {
+                        Ok(result) => {
+                            let town_names = result.towns.into_iter().map(|x| x.name).collect();
+                            pure_parser.provide_input(town_names);
+                        }
+                        Err(error) => return pure_parser.abort(error),
+                    }
+                }
+                PureParserAction::Done(result) => return result,
             }
-        };
-        let city = match interactor.get_blocking_city_master(prefecture.name_ja(), &city_name) {
-            Err(error) => {
-                return ParseResult {
-                    address: Address::from(tokenizer.finish()),
-                    error: Some(error),
-                };
-            }
-            Ok(result) => result,
-        };
-        let Ok((_, tokenizer)) =
-            tokenizer.read_town(city.towns.iter().map(|x| x.name.clone()).collect())
-        else {
-            return ParseResult {
-                address: Address::from(tokenizer.finish()),
-                error: Some(Error::new_parse_error(ParseErrorKind::Town)),
-            };
-        };
-
-        ParseResult {
-            address: Address::from(tokenizer.finish()),
-            error: None,
         }
     }
 }

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -1,3 +1,5 @@
+mod pure;
+
 use std::sync::Arc;
 
 use crate::domain::common::token::Token;

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -7,6 +7,7 @@ use crate::domain::geolonia::entity::Address;
 use crate::domain::geolonia::error::{Error, ParseErrorKind};
 use crate::http::reqwest_client::ReqwestApiClient;
 use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
+use crate::parser::pure::{PureParser, PureParserAction};
 use crate::tokenizer::{End, Tokenizer};
 use serde::Serialize;
 
@@ -54,70 +55,27 @@ impl Parser {
     /// Parses the given `address` asynchronously.
     pub async fn parse(&self, address: &str) -> ParseResult {
         let interactor = self.interactor.clone();
-        let tokenizer = Tokenizer::new(address);
-        // 都道府県を特定
-        let (prefecture, tokenizer) = match tokenizer.read_prefecture() {
-            Ok(found) => found,
-            Err(tokenizer) => {
-                return ParseResult {
-                    address: Address::from(tokenizer),
-                    error: Some(Error::new_parse_error(ParseErrorKind::Prefecture)),
-                }
-            }
-        };
-        // その都道府県の市町村名リストを取得
-        let prefecture_master = match interactor.get_prefecture_master(prefecture.name_ja()).await {
-            Err(error) => {
-                return ParseResult {
-                    address: Address::from(tokenizer.finish()),
-                    error: Some(error),
-                };
-            }
-            Ok(result) => result,
-        };
-        // 市町村名を特定
-        let (city_name, tokenizer) = match tokenizer.read_city(&prefecture_master.cities) {
-            Ok(found) => found,
-            Err(not_found) => {
-                // 市区町村が特定できない場合かつフィーチャフラグが有効な場合、郡名が抜けている可能性を検討
-                match not_found.read_city_with_county_name_completion(&prefecture_master.cities) {
-                    Ok(found) if cfg!(feature = "city-name-correction") => found,
-                    _ => {
-                        // それでも見つからない場合は終了
-                        return ParseResult {
-                            address: Address::from(tokenizer.finish()),
-                            error: Some(Error::new_parse_error(ParseErrorKind::City)),
-                        };
+        let mut pure_parser = PureParser::new(address);
+
+        loop {
+            match pure_parser.advance() {
+                PureParserAction::RequestCityNameList(pref_name) => {
+                    match interactor.get_prefecture_master(&pref_name).await {
+                        Ok(result) => pure_parser.provide_input(result.cities),
+                        Err(error) => return pure_parser.abort(error),
                     }
                 }
+                PureParserAction::RequestTownNameList(pref_name, city_name) => {
+                    match interactor.get_city_master(&pref_name, &city_name).await {
+                        Ok(result) => {
+                            let town_names = result.towns.into_iter().map(|x| x.name).collect();
+                            pure_parser.provide_input(town_names);
+                        }
+                        Err(error) => return pure_parser.abort(error),
+                    }
+                }
+                PureParserAction::Done(result) => return result,
             }
-        };
-        // その市町村の町名リストを取得
-        let city = match interactor
-            .get_city_master(prefecture.name_ja(), &city_name)
-            .await
-        {
-            Err(error) => {
-                return ParseResult {
-                    address: Address::from(tokenizer.finish()),
-                    error: Some(error),
-                };
-            }
-            Ok(result) => result,
-        };
-        // 町名を特定
-        let Ok((_, tokenizer)) =
-            tokenizer.read_town(city.towns.iter().map(|x| x.name.clone()).collect())
-        else {
-            return ParseResult {
-                address: Address::from(tokenizer.finish()),
-                error: Some(Error::new_parse_error(ParseErrorKind::Town)),
-            };
-        };
-
-        ParseResult {
-            address: Address::from(tokenizer.finish()),
-            error: None,
         }
     }
 

--- a/core/src/parser/pure.rs
+++ b/core/src/parser/pure.rs
@@ -6,7 +6,7 @@ use crate::tokenizer::{CityNameFound, Init, PrefectureNameFound, Tokenizer};
 type PrefectureName = String;
 type CityName = String;
 
-enum State {
+pub(crate) enum State {
     Init(Tokenizer<Init>),
     WaitPrefectureMasterData(Tokenizer<PrefectureNameFound>, PrefectureName),
     WaitCityMasterData(Tokenizer<CityNameFound>),
@@ -109,5 +109,74 @@ impl PureParser {
             address: Address::from(tokenizer),
             error: Some(error),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::geolonia::error::{ApiErrorKind, Error};
+    use crate::parser::pure::{PureParser, PureParserAction, State};
+
+    #[test]
+    fn new() {
+        let pure_parser = PureParser::new("東京都杉並区阿佐谷南1丁目15番1号");
+        assert!(matches!(pure_parser.state, State::Init(_)));
+    }
+
+    #[test]
+    fn provide_input() {
+        let mut pure_parser = PureParser::new("東京都杉並区阿佐谷南1丁目15番1号");
+        assert!(pure_parser.input.is_none());
+
+        pure_parser.provide_input(vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+        assert!(pure_parser.input.is_some());
+        assert_eq!(
+            pure_parser.input.unwrap(),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn advance() {
+        let mut pure_parser = PureParser::new("東京都杉並区阿佐谷南1丁目15番1号");
+        assert!(matches!(pure_parser.state, State::Init(_)));
+
+        let action = pure_parser.advance();
+        assert!(matches!(action, PureParserAction::RequestCityNameList(_)));
+        assert!(matches!(
+            pure_parser.state,
+            State::WaitPrefectureMasterData(_, _)
+        ));
+
+        pure_parser.provide_input(vec![
+            "杉並区".to_string(),
+            "板橋区".to_string(),
+            "中野区".to_string(),
+        ]);
+        let action = pure_parser.advance();
+        assert!(matches!(
+            action,
+            PureParserAction::RequestTownNameList(_, _)
+        ));
+        assert!(matches!(pure_parser.state, State::WaitCityMasterData(_)));
+
+        pure_parser.provide_input(vec![
+            "阿佐谷南一丁目".to_string(),
+            "阿佐谷南二丁目".to_string(),
+            "阿佐谷南三丁目".to_string(),
+        ]);
+        let action = pure_parser.advance();
+        assert!(matches!(action, PureParserAction::Done(_)));
+    }
+
+    #[test]
+    fn abort() {
+        let pure_parser = PureParser::new("東京都杉並区阿佐谷南1丁目15番1号");
+        let result = pure_parser.abort(Error::new_api_error(ApiErrorKind::Fetch(
+            "hoge".to_string(),
+        )));
+
+        assert_eq!(result.address.rest, "東京都杉並区阿佐谷南1丁目15番1号");
+        assert!(result.error.is_some());
     }
 }

--- a/core/src/parser/pure.rs
+++ b/core/src/parser/pure.rs
@@ -1,0 +1,113 @@
+use crate::domain::geolonia::entity::Address;
+use crate::domain::geolonia::error::{Error, ParseErrorKind};
+use crate::parser::ParseResult;
+use crate::tokenizer::{CityNameFound, Init, PrefectureNameFound, Tokenizer};
+
+type PrefectureName = String;
+type CityName = String;
+
+enum State {
+    Init(Tokenizer<Init>),
+    WaitPrefectureMasterData(Tokenizer<PrefectureNameFound>, PrefectureName),
+    WaitCityMasterData(Tokenizer<CityNameFound>),
+    Temporary,
+}
+
+pub(crate) enum PureParserAction {
+    RequestCityNameList(PrefectureName),
+    RequestTownNameList(PrefectureName, CityName),
+    Done(ParseResult),
+}
+
+pub(crate) struct PureParser {
+    state: State,
+    input: Option<Vec<String>>,
+}
+
+impl PureParser {
+    pub fn new(address: &str) -> Self {
+        Self {
+            state: State::Init(Tokenizer::new(address)),
+            input: None,
+        }
+    }
+
+    pub fn provide_input(&mut self, data: Vec<String>) {
+        self.input = Some(data);
+    }
+
+    pub fn advance(&mut self) -> PureParserAction {
+        let current_state = std::mem::replace(&mut self.state, State::Temporary);
+        let input = self.input.take();
+
+        match current_state {
+            State::Init(tokenizer) => match tokenizer.read_prefecture() {
+                Ok((pref, next_tokenizer)) => {
+                    let pref_name = pref.name_ja().to_string();
+                    self.state = State::WaitPrefectureMasterData(next_tokenizer, pref_name.clone());
+                    PureParserAction::RequestCityNameList(pref_name)
+                }
+                Err(tokenizer) => PureParserAction::Done(ParseResult {
+                    address: Address::from(tokenizer),
+                    error: Some(Error::new_parse_error(ParseErrorKind::Prefecture)),
+                }),
+            },
+
+            State::WaitPrefectureMasterData(tokenizer, pref_name) => {
+                let city_names = input.expect("city name list is required");
+                match tokenizer.read_city(&city_names) {
+                    Ok((city_name, next_tokenizer)) => {
+                        self.state = State::WaitCityMasterData(next_tokenizer);
+                        PureParserAction::RequestTownNameList(pref_name.clone(), city_name)
+                    }
+                    Err(tokenizer) => {
+                        match tokenizer.read_city_with_county_name_completion(&city_names) {
+                            Ok((city_name, next_tokenizer))
+                                if cfg!(feature = "city-name-correction") =>
+                            {
+                                self.state = State::WaitCityMasterData(next_tokenizer);
+                                PureParserAction::RequestTownNameList(pref_name.clone(), city_name)
+                            }
+                            _ => PureParserAction::Done(ParseResult {
+                                address: Address::from(tokenizer.finish()),
+                                error: Some(Error::new_parse_error(ParseErrorKind::City)),
+                            }),
+                        }
+                    }
+                }
+            }
+
+            State::WaitCityMasterData(tokenizer) => {
+                let town_names = input.expect("town name list is required");
+                match tokenizer.read_town(town_names) {
+                    Ok((_, next_tokenizer)) => PureParserAction::Done(ParseResult {
+                        address: Address::from(next_tokenizer.finish()),
+                        error: None,
+                    }),
+                    Err(tokenizer) => PureParserAction::Done(ParseResult {
+                        address: Address::from(tokenizer),
+                        error: Some(Error::new_parse_error(ParseErrorKind::Town)),
+                    }),
+                }
+            }
+
+            State::Temporary => unreachable!(),
+        }
+    }
+
+    /// IOエラーなど、途中で解析を中断してエラーを返す場合に使用する
+    pub fn abort(self, error: Error) -> ParseResult {
+        let current_state = self.state;
+        let tokenizer = match current_state {
+            State::Init(t) => t.finish(),
+            State::WaitPrefectureMasterData(t, _) => t.finish(),
+            State::WaitCityMasterData(t) => t.finish(),
+            State::Temporary => unreachable!(),
+        };
+
+        ParseResult {
+            address: Address::from(tokenizer),
+            error: Some(error),
+        }
+    }
+}


### PR DESCRIPTION
### 概要
- `Parser#parse`及び`Parser#parse_blocking`に関して、異なるのはIO部分だけであり、同じコードがコピペされて書かれている状態だった。
- IO部分とそれ以外のロジックの部分を分離させることで見通しがよくなりそうだったので対応した。

### 備考
- IO部分と非IO部分を完全に分離するアプローチを「Sans-IO」と呼ぶそうである。
  - https://qiita.com/yonaka15/items/6bac3a0d8ad973092dff
  - https://www.firezone.dev/blog/sans-io
