### PR TITLE
APIクライアントにキャッシュを導入する: 簡易的なインメモリキャッシュを実装

### DIFF
--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -1,4 +1,5 @@
 pub mod converter;
 pub(crate) mod extension;
+pub(crate) mod inmemory_cache;
 pub mod sequence_matcher;
 mod trimmer;

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -59,7 +59,7 @@ impl InMemoryCache {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         // キャッシュの最大容量を超える場合は、キャッシュに登録した時刻が最も古いものが削除される
-        if store.len() == self.max_entries {
+        if store.len() == self.max_entries && !store.contains_key(key) {
             if let Some(oldest_key) = store
                 .iter()
                 .min_by_key(|(_, value)| value.registered_at)

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+#[derive(Clone)]
+pub(crate) struct CacheEntry {
+    /// データ
+    pub body: Vec<u8>,
+    /// キャッシュに登録した時刻
+    pub registered_at: Instant,
+}
+
+pub(crate) struct InMemoryCache {
+    /// キャッシュストア
+    store: Arc<RwLock<HashMap<String, CacheEntry>>>,
+    /// キャッシュの保持期間
+    ttl: Duration,
+}
+
+impl InMemoryCache {
+    /// キャッシュの初期化
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(RwLock::new(HashMap::new())),
+            ttl: Duration::from_secs(3600),
+        }
+    }
+
+    /// キャッシュデータの取得
+    pub fn get(&self, key: &str) -> Option<CacheEntry> {
+        let store = self.store.read().ok()?;
+        let entry = store.get(key).cloned()?;
+        if entry.registered_at.elapsed() < self.ttl {
+            Some(entry)
+        } else {
+            None
+        }
+    }
+
+    /// キャッシュデータの登録
+    pub fn register(&self, key: &str, value: Vec<u8>) {
+        let mut store = self
+            .store
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = CacheEntry {
+            body: value,
+            registered_at: Instant::now(),
+        };
+        store.insert(key.to_string(), entry);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::inmemory_cache::InMemoryCache;
+    use std::ops::Add;
+    use std::time::Duration;
+
+    #[test]
+    fn キャッシュヒット時はキャッシュされたデータを返すこと() {
+        let cache = InMemoryCache::new();
+        cache.register("key1", vec![1, 2, 3, 4, 5]);
+
+        let result = cache.get("key1");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().body, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn キャッシュミス時は_noneを返すこと() {
+        let cache = InMemoryCache::new();
+        cache.register("key1", vec![4, 5, 6]);
+
+        let result = cache.get("invalid key");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
+        let cache = InMemoryCache::new();
+        cache.register("key1", vec![1, 3, 5, 7, 9]);
+
+        let wait_time = cache.ttl.add(Duration::from_secs(1));
+        tokio::time::sleep(wait_time).await;
+
+        let result = cache.get("key1");
+        assert!(result.is_none());
+    }
+}

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -102,13 +102,13 @@ mod tests {
         assert!(result.is_none());
     }
 
-    #[tokio::test]
-    async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
+    #[test]
+    fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
         let cache = InMemoryCache::with_config(Duration::from_nanos(1), 10);
         cache.register("key1", vec![1, 3, 5, 7, 9]);
 
         let wait_time = cache.ttl.add(Duration::from_nanos(1));
-        tokio::time::sleep(wait_time).await;
+        std::thread::sleep(wait_time);
 
         let result = cache.get("key1");
         assert!(result.is_none());

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -26,6 +26,14 @@ impl InMemoryCache {
         }
     }
 
+    /// キャッシュの初期化(カスタム)
+    pub fn with_config(ttl: Duration) -> Self {
+        Self {
+            store: Arc::new(RwLock::new(HashMap::new())),
+            ttl,
+        }
+    }
+
     /// キャッシュデータの取得
     pub fn get(&self, key: &str) -> Option<CacheEntry> {
         let store = self.store.read().ok()?;
@@ -78,10 +86,10 @@ mod tests {
 
     #[tokio::test]
     async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
-        let cache = InMemoryCache::new();
+        let cache = InMemoryCache::with_config(Duration::from_nanos(1));
         cache.register("key1", vec![1, 3, 5, 7, 9]);
 
-        let wait_time = cache.ttl.add(Duration::from_secs(1));
+        let wait_time = cache.ttl.add(Duration::from_nanos(1));
         tokio::time::sleep(wait_time).await;
 
         let result = cache.get("key1");

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -42,7 +42,11 @@ impl InMemoryCache {
 
     /// キャッシュデータの取得
     pub fn get(&self, key: &str) -> Option<CacheEntry> {
-        let store = self.store.read().ok()?;
+        let store = self
+            .store
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
         let entry = store.get(key).cloned()?;
         if entry.registered_at.elapsed() < self.ttl {
             Some(entry)

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -33,6 +33,7 @@ impl InMemoryCache {
 
     /// キャッシュの初期化(カスタム)
     pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
+        assert!(max_entries > 0, "max_entries must be greater than 0");
         Self {
             store: Arc::new(RwLock::new(HashMap::new())),
             ttl,
@@ -63,7 +64,7 @@ impl InMemoryCache {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         // キャッシュの最大容量を超える場合は、キャッシュに登録した時刻が最も古いものが削除される
-        if store.len() == self.max_entries && !store.contains_key(key) {
+        if store.len() >= self.max_entries && !store.contains_key(key) {
             if let Some(oldest_key) = store
                 .iter()
                 .min_by_key(|(_, value)| value.registered_at)

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -15,6 +15,8 @@ pub(crate) struct InMemoryCache {
     store: Arc<RwLock<HashMap<String, CacheEntry>>>,
     /// キャッシュの保持期間
     ttl: Duration,
+    /// キャッシュの最大容量
+    max_entries: usize,
 }
 
 impl InMemoryCache {
@@ -23,14 +25,16 @@ impl InMemoryCache {
         Self {
             store: Arc::new(RwLock::new(HashMap::new())),
             ttl: Duration::from_secs(3600),
+            max_entries: 100,
         }
     }
 
     /// キャッシュの初期化(カスタム)
-    pub fn with_config(ttl: Duration) -> Self {
+    pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
         Self {
             store: Arc::new(RwLock::new(HashMap::new())),
             ttl,
+            max_entries,
         }
     }
 
@@ -51,6 +55,18 @@ impl InMemoryCache {
             .store
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        // キャッシュの最大容量を超える場合は、キャッシュに登録した時刻が最も古いものが削除される
+        if store.len() == self.max_entries {
+            if let Some(oldest_key) = store
+                .iter()
+                .min_by_key(|(_, value)| value.registered_at)
+                .map(|(key, _)| key.to_string())
+            {
+                store.remove(&oldest_key);
+            }
+        }
+
         let entry = CacheEntry {
             body: value,
             registered_at: Instant::now(),
@@ -86,7 +102,7 @@ mod tests {
 
     #[tokio::test]
     async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
-        let cache = InMemoryCache::with_config(Duration::from_nanos(1));
+        let cache = InMemoryCache::with_config(Duration::from_nanos(1), 10);
         cache.register("key1", vec![1, 3, 5, 7, 9]);
 
         let wait_time = cache.ttl.add(Duration::from_nanos(1));
@@ -94,5 +110,19 @@ mod tests {
 
         let result = cache.get("key1");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn キャッシュ最大容量を超えた場合は最古のエントリが削除されること() {
+        let cache = InMemoryCache::with_config(Duration::from_secs(3600), 3);
+        cache.register("key1", vec![1, 2, 3]);
+        cache.register("key2", vec![4, 5, 6]);
+        cache.register("key3", vec![7, 8, 9]);
+
+        assert!(cache.get("key1").is_some());
+
+        cache.register("key4", vec![0, 0, 0]);
+        assert!(cache.get("key1").is_none());
+        assert!(cache.get("key4").is_some());
     }
 }


### PR DESCRIPTION
## 変更点
- implements part of #71 
- APIクライアントに組み込んで使用するためのインメモリキャッシュを実装します。
- JSONバイト列を保持する目的のため、データ型は`Vec<u8>`としています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-memory caching functionality with configurable expiration times and capacity limits. The cache automatically manages storage by removing expired entries and evicting oldest entries when capacity is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->