### PR TITLE
APIクライアントにキャッシュを導入する: CachedApiClientを実装

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,6 +28,7 @@ log.workspace = true
 rapidfuzz = "0.5.0"
 regex = { version = "1.11.1", default-features = false, features = ["std", "unicode-perl"] }
 serde.workspace = true
+serde_json = "1.0.150"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
 js-sys = "0.3.74"
 thiserror = "2.0.3"

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -1,3 +1,4 @@
+pub mod cached_client;
 pub mod client;
 pub mod error;
 pub mod reqwest_client;

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -1,0 +1,77 @@
+use crate::http::client::ApiClient;
+use crate::http::error::ApiClientError;
+use crate::util::inmemory_cache::InMemoryCache;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+/// Wrapper of `ApiClient` that enables in-memory cache
+///
+/// ```rust
+/// use japanese_address_parser::http::cached_client::CachedApiClient;
+/// use japanese_address_parser::http::client::ApiClient;
+/// use japanese_address_parser::http::reqwest_client::ReqwestApiClient;
+///
+/// let client = CachedApiClient::<ReqwestApiClient>::new();
+/// ```
+pub struct CachedApiClient<C: ApiClient> {
+    client: C,
+    cache: InMemoryCache,
+}
+
+impl<C: ApiClient + Sync> ApiClient for CachedApiClient<C> {
+    fn new() -> Self {
+        Self {
+            client: C::new(),
+            cache: InMemoryCache::new(),
+        }
+    }
+
+    async fn fetch<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
+        // キャッシュが利用できる場合は、キャッシュからバイト列を取得してデシリアライズして利用する
+        if let Some(entry) = self.cache.get(url) {
+            return serde_json::from_slice::<T>(&entry.body).map_err(|e| {
+                ApiClientError::Deserialize {
+                    url: url.to_string(),
+                    message: e.to_string(),
+                }
+            });
+        }
+
+        // キャッシュが利用できない場合は、APIリクエストを行ないデータを取得、取得したデータをキャッシュに保存する
+        let response = self.client.fetch::<Value>(url).await?;
+        let bytes = serde_json::to_vec(&response).map_err(|e| ApiClientError::Deserialize {
+            url: url.to_string(),
+            message: e.to_string(),
+        })?;
+        self.cache.register(url, bytes.clone());
+        serde_json::from_slice::<T>(&bytes).map_err(|e| ApiClientError::Deserialize {
+            url: url.to_string(),
+            message: e.to_string(),
+        })
+    }
+
+    #[cfg(feature = "blocking")]
+    fn fetch_blocking<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
+        // キャッシュが利用できる場合は、キャッシュからバイト列を取得してデシリアライズして利用する
+        if let Some(entry) = self.cache.get(url) {
+            return serde_json::from_slice::<T>(&entry.body).map_err(|e| {
+                ApiClientError::Deserialize {
+                    url: url.to_string(),
+                    message: e.to_string(),
+                }
+            });
+        }
+
+        // キャッシュが利用できない場合は、APIリクエストを行ないデータを取得、取得したデータをキャッシュに保存する
+        let response = self.client.fetch_blocking::<Value>(url)?;
+        let bytes = serde_json::to_vec(&response).map_err(|e| ApiClientError::Deserialize {
+            url: url.to_string(),
+            message: e.to_string(),
+        })?;
+        self.cache.register(url, bytes.clone());
+        serde_json::from_slice::<T>(&bytes).map_err(|e| ApiClientError::Deserialize {
+            url: url.to_string(),
+            message: e.to_string(),
+        })
+    }
+}

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -3,6 +3,7 @@ use crate::http::error::ApiClientError;
 use crate::util::inmemory_cache::InMemoryCache;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use std::time::Duration;
 
 /// Wrapper of `ApiClient` that enables in-memory cache
 ///
@@ -16,6 +17,16 @@ use serde_json::Value;
 pub struct CachedApiClient<C: ApiClient> {
     client: C,
     cache: InMemoryCache,
+}
+
+impl<C: ApiClient> CachedApiClient<C> {
+    #[allow(dead_code)]
+    fn with_config(ttl: Duration, max_entries: usize) -> Self {
+        Self {
+            client: C::new(),
+            cache: InMemoryCache::with_config(ttl, max_entries),
+        }
+    }
 }
 
 impl<C: ApiClient + Sync> ApiClient for CachedApiClient<C> {

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -86,3 +86,109 @@ impl<C: ApiClient + Sync> ApiClient for CachedApiClient<C> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::http::cached_client::CachedApiClient;
+    use crate::http::client::ApiClient;
+    use crate::http::error::ApiClientError;
+    use serde::de::DeserializeOwned;
+    use serde_json::Value;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    struct MockApiClient {
+        called_count: AtomicUsize,
+    }
+
+    impl MockApiClient {
+        fn generate_dummy_response<T: DeserializeOwned>(
+            &self,
+            _url: &str,
+        ) -> Result<T, ApiClientError> {
+            Ok(serde_json::from_str(&format!(
+                "{{\"called_count\": {}}}",
+                self.called_count.load(Ordering::SeqCst),
+            ))
+            .unwrap())
+        }
+
+        fn increment(&self) {
+            self.called_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl ApiClient for MockApiClient {
+        fn new() -> Self {
+            Self {
+                called_count: 0.into(),
+            }
+        }
+
+        async fn fetch<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
+            self.increment();
+            self.generate_dummy_response(url)
+        }
+
+        #[cfg(feature = "blocking")]
+        fn fetch_blocking<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
+            self.increment();
+            self.generate_dummy_response(url)
+        }
+    }
+
+    #[tokio::test]
+    async fn キャッシュヒット時はキャッシュされたデータを返すこと() {
+        let client = CachedApiClient::<MockApiClient>::new();
+        let response = client.fetch::<Value>("/endpoint").await.unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+
+        let response = client.fetch::<Value>("/endpoint").await.unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+        assert_ne!(response.get("called_count").unwrap().as_u64(), Some(2));
+    }
+
+    #[tokio::test]
+    async fn キャッシュミス時はfetchによるデータを返すこと() {
+        let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
+        let response = client.fetch::<Value>("/endpoint").await.unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+
+        // 1秒待機
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let response = client.fetch::<Value>("/endpoint").await.unwrap();
+        // TTL=1秒なのでキャッシュミスになるはず
+        assert_ne!(response.get("called_count").unwrap().as_u64(), Some(1));
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(2));
+    }
+
+    #[test]
+    #[cfg(feature = "blocking")]
+    fn キャッシュヒット時はキャッシュされたデータを返すこと_blocking() {
+        let client = CachedApiClient::<MockApiClient>::new();
+        let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+
+        let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+        assert_ne!(response.get("called_count").unwrap().as_u64(), Some(2));
+    }
+
+    #[test]
+    #[cfg(feature = "blocking")]
+    fn キャッシュミス時はfetchによるデータを返すこと_blocking() {
+        let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
+        let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+
+        // 1秒待機
+        sleep(Duration::from_secs(1));
+
+        let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
+        // TTL=1秒なのでキャッシュミスになるはず
+        assert_ne!(response.get("called_count").unwrap().as_u64(), Some(1));
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(2));
+    }
+}

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -94,7 +94,6 @@ mod tests {
     use serde::de::DeserializeOwned;
     use serde_json::Value;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::thread::sleep;
     use std::time::Duration;
 
     struct MockApiClient {
@@ -148,6 +147,7 @@ mod tests {
         assert_ne!(response.get("called_count").unwrap().as_u64(), Some(2));
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn キャッシュミス時はfetchによるデータを返すこと() {
         let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
 
         // 1秒待機
-        sleep(Duration::from_secs(1));
+        std::thread::sleep(Duration::from_secs(1));
 
         let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
         // TTL=1秒なのでキャッシュミスになるはず

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -20,8 +20,7 @@ pub struct CachedApiClient<C: ApiClient> {
 }
 
 impl<C: ApiClient> CachedApiClient<C> {
-    #[allow(dead_code)]
-    fn with_config(ttl: Duration, max_entries: usize) -> Self {
+    pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
         Self {
             client: C::new(),
             cache: InMemoryCache::with_config(ttl, max_entries),

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -30,7 +30,6 @@ impl InMemoryCache {
     }
 
     /// キャッシュの初期化(カスタム)
-    #[allow(dead_code)]
     pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
         assert!(max_entries > 0, "max_entries must be greater than 0");
         Self {

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -32,6 +30,7 @@ impl InMemoryCache {
     }
 
     /// キャッシュの初期化(カスタム)
+    #[allow(dead_code)]
     pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
         assert!(max_entries > 0, "max_entries must be greater than 0");
         Self {


### PR DESCRIPTION
## 変更点
- implements part of #71 
- キャッシュを利用できるApiClientを実装します。
- `InMemoryCache`を利用しurlをキーとしてAPIレスポンスをキャッシュに保持する仕組みを実装。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced API response caching with configurable expiration and capacity limits for improved performance and reduced latency.

* **Tests**
  * Added unit tests verifying cache behavior and expiration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->