### PR TITLE
APIクライアントにキャッシュを導入する: `InMemoryCache`と`CachedApiClient`をwasm32ターゲットでビルドできるようにする

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,10 +35,14 @@ thiserror = "2.0.3"
 jisx0401 = "0.1.1"
 strum = { version = "0.27.1", features = ["derive"] }
 trait-variant = "0.1.2"
+web-time = "1.1.0"
 
 [dev-dependencies]
 tokio.workspace = true
 wasm-bindgen-test = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+gloo-timers = { version = "0.4.0", features = ["futures"] } # wasm_bindgen_test用
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 mockito = "1.6.1" # mockitoがwasm32に対応していないため

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -136,7 +136,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn キャッシュヒット時はキャッシュされたデータを返すこと() {
         let client = CachedApiClient::<MockApiClient>::new();
         let response = client.fetch::<Value>("/endpoint").await.unwrap();
@@ -147,15 +148,18 @@ mod tests {
         assert_ne!(response.get("called_count").unwrap().as_u64(), Some(2));
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn キャッシュミス時はfetchによるデータを返すこと() {
         let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
         let response = client.fetch::<Value>("/endpoint").await.unwrap();
         assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
 
         // 1秒待機
+        #[cfg(not(target_arch = "wasm32"))]
         tokio::time::sleep(Duration::from_secs(1)).await;
+        #[cfg(target_arch = "wasm32")]
+        gloo_timers::future::TimeoutFuture::new(1_000).await;
 
         let response = client.fetch::<Value>("/endpoint").await.unwrap();
         // TTL=1秒なのでキャッシュミスになるはず

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use web_time::Instant;
 
 #[derive(Clone)]
 pub(crate) struct CacheEntry {
@@ -87,6 +88,7 @@ mod tests {
     use std::time::Duration;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn キャッシュヒット時はキャッシュされたデータを返すこと() {
         let cache = InMemoryCache::new();
         cache.register("key1", vec![1, 2, 3, 4, 5]);
@@ -97,6 +99,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn キャッシュミス時は_noneを返すこと() {
         let cache = InMemoryCache::new();
         cache.register("key1", vec![4, 5, 6]);
@@ -105,19 +108,24 @@ mod tests {
         assert!(result.is_none());
     }
 
-    #[test]
-    fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
         let cache = InMemoryCache::with_config(Duration::from_nanos(1), 10);
         cache.register("key1", vec![1, 3, 5, 7, 9]);
 
-        let wait_time = cache.ttl.add(Duration::from_nanos(1));
-        std::thread::sleep(wait_time);
+        let wait_time = cache.ttl.add(Duration::from_secs(1));
+        #[cfg(not(target_arch = "wasm32"))]
+        tokio::time::sleep(wait_time).await;
+        #[cfg(target_arch = "wasm32")]
+        gloo_timers::future::TimeoutFuture::new(wait_time.as_millis() as u32).await;
 
         let result = cache.get("key1");
         assert!(result.is_none());
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn キャッシュ最大容量を超えた場合は最古のエントリが削除されること() {
         let cache = InMemoryCache::with_config(Duration::from_secs(3600), 3);
         cache.register("key1", vec![1, 2, 3]);


### PR DESCRIPTION
## 変更点
- implements part of #71
- `InMemoryCache`に関して、`wasm-pack`でビルドやテストを実行するとwasm32に対応していない箇所がコンパイルエラーになっていたので、その箇所を修正しました。
- 併せて、`CachedApiClient`に対するテストコードを`wasm_bindgen_test`として検証できるように整備し、`wasm-pack test`を実行することで`CachedApiClient`がwasm対応できていることを保証できるようにした。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled WebAssembly support, allowing the application to run in browser environments
  * Updated timing operations to work reliably across native and WebAssembly platforms
  * Expanded test coverage to validate functionality on all supported targets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->