### PR TITLE
APIクライアントにキャッシュを導入する: `CachedApiClient`を有効にするためのフィーチャフラグ`enable-api-client-cache`を追加

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ blocking = ["reqwest/blocking"]
 city-name-correction = []
 format-house-number = []
 eliminate-whitespaces = []
+enable-api-client-cache = []
 fix-halfwidth-katakana = []
 experimental = ["fix-halfwidth-katakana"]
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@
 //! - `city-name-correction`*(enabled by default)*: Enable autocorrection if ambiguous city name was typed
 //! - `format-house-number`: Enable normalization of addresses after town name
 //! - `eliminate-whitespaces`*(experimental)*: Enable elimination of whitespaces from given text
+//! - `enable-api-client-cache`: Enable In-Memory cache for api client
 //! - `fix-halfwidth-katakana`*(experimental)*: Enable fixing halfwidth katakana with fullwidth ones
 //! - `experimental`: Enable experimental module
 

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use crate::domain::common::token::Token;
 use crate::domain::geolonia::entity::Address;
 use crate::domain::geolonia::error::{Error, ParseErrorKind};
+#[cfg(feature = "enable-api-client-cache")]
+use crate::http::cached_client::CachedApiClient;
 use crate::http::reqwest_client::ReqwestApiClient;
 use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
 use crate::tokenizer::{End, Tokenizer};
@@ -36,7 +38,10 @@ impl From<Tokenizer<End>> for Address {
 /// }
 /// ```
 pub struct Parser {
+    #[cfg(not(feature = "enable-api-client-cache"))]
     interactor: Arc<GeoloniaInteractorImpl<ReqwestApiClient>>,
+    #[cfg(feature = "enable-api-client-cache")]
+    interactor: Arc<GeoloniaInteractorImpl<CachedApiClient<ReqwestApiClient>>>,
 }
 
 impl Default for Parser {

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.102"
 futures = "0.3.32"
-japanese-address-parser = { version = "0.3.4", path = "../core", features = ["experimental"] }
+japanese-address-parser = { version = "0.3.4", path = "../core", features = ["experimental", "enable-api-client-cache"] }
 rmcp = { version = "1.6.0", features = ["server", "transport-io"] }
 schemars = "1.2.1"
 serde.workspace = true

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,6 +16,6 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-japanese-address-parser = { path = "../core", features = ["blocking"] }
+japanese-address-parser = { path = "../core", features = ["blocking", "enable-api-client-cache"] }
 pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -27,7 +27,7 @@ nightly = [
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-japanese-address-parser = { path = "../core" }
+japanese-address-parser = { path = "../core", features = ["enable-api-client-cache"] }
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }


### PR DESCRIPTION
## 変更点
- implements #71 
- `CachedApiClient`を有効にするためのフィーチャフラグを追加します。
- デフォルトでは無効にしていますが、wasm版、python版、mcp版では有効になるように設定します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-memory caching capability for API client to improve performance and reduce redundant requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->