### PR TITLE
APIクライアントにキャッシュを導入する: wasmモジュール関連の追加修正

### DIFF
--- a/public/debug.html
+++ b/public/debug.html
@@ -59,10 +59,10 @@
     const inputTextArea = document.getElementById("input")
 
     init().then(() => {
+        const parser = new Parser();
         document.getElementById("exec").addEventListener("click", () => {
             const input = inputTextArea.value
             alert("input: " + input)
-            const parser = new Parser()
             parser.parse(input).then(result => {
                 document.getElementById("result").appendChild(
                     createRow(input, result)

--- a/public/index.html
+++ b/public/index.html
@@ -56,10 +56,10 @@
     const inputTextArea = document.getElementById("input")
 
     init().then(() => {
+        const parser = new Parser();
         document.getElementById("exec").addEventListener("click", () => {
             const input = inputTextArea.value
             alert("input: " + input)
-            const parser = new Parser()
             parser.parse(input).then(result => {
                 document.getElementById("result").appendChild(
                     createRow(input, result)

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -62,6 +62,12 @@ init().then(() => {
 }
 ```
 
+## Tips
+
+Initialize the `Parser` instance once and reuse it across your application.
+Re-initializing the `Parser` frequently can lead to performance degradation, especially if API client caching is
+enabled, as the cache will be reset for each new instance.
+
 ## How it works
 
 The input string is basically read in order from the beginning to the end.


### PR DESCRIPTION
## 変更点
- implements part of #71
- wasmモジュールのデモページに関して、インメモリキャッシュが効かない書き方になっていたのを修正します。
- `Parser`の初期化を繰り返し行なうことは避け、なるべく使い回すべきことをwasmモジュールのREADMEに追記します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added tips section to Parser documentation with best practices for initialization and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->