### PR TITLE
APIクライアントにキャッシュを導入する

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,6 +28,7 @@ log.workspace = true
 rapidfuzz = "0.5.0"
 regex = { version = "1.11.1", default-features = false, features = ["std", "unicode-perl"] }
 serde.workspace = true
+serde_json = "1.0.150"
 reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls"] }
 js-sys = "0.3.74"
 thiserror = "2.0.3"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -35,10 +35,14 @@ thiserror = "2.0.3"
 jisx0401 = "0.1.1"
 strum = { version = "0.27.1", features = ["derive"] }
 trait-variant = "0.1.2"
+web-time = "1.1.0"
 
 [dev-dependencies]
 tokio.workspace = true
 wasm-bindgen-test = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+gloo-timers = { version = "0.4.0", features = ["futures"] } # wasm_bindgen_test用
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 mockito = "1.6.1" # mockitoがwasm32に対応していないため

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ blocking = ["reqwest/blocking"]
 city-name-correction = []
 format-house-number = []
 eliminate-whitespaces = []
+enable-api-client-cache = []
 fix-halfwidth-katakana = []
 experimental = ["fix-halfwidth-katakana"]
 

--- a/core/src/http.rs
+++ b/core/src/http.rs
@@ -1,3 +1,4 @@
+pub mod cached_client;
 pub mod client;
 pub mod error;
 pub mod reqwest_client;

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -136,7 +136,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn キャッシュヒット時はキャッシュされたデータを返すこと() {
         let client = CachedApiClient::<MockApiClient>::new();
         let response = client.fetch::<Value>("/endpoint").await.unwrap();
@@ -147,15 +148,18 @@ mod tests {
         assert_ne!(response.get("called_count").unwrap().as_u64(), Some(2));
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
-    #[tokio::test]
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn キャッシュミス時はfetchによるデータを返すこと() {
         let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
         let response = client.fetch::<Value>("/endpoint").await.unwrap();
         assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
 
         // 1秒待機
+        #[cfg(not(target_arch = "wasm32"))]
         tokio::time::sleep(Duration::from_secs(1)).await;
+        #[cfg(target_arch = "wasm32")]
+        gloo_timers::future::TimeoutFuture::new(1_000).await;
 
         let response = client.fetch::<Value>("/endpoint").await.unwrap();
         // TTL=1秒なのでキャッシュミスになるはず

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -1,0 +1,77 @@
+use crate::http::client::ApiClient;
+use crate::http::error::ApiClientError;
+use crate::util::inmemory_cache::InMemoryCache;
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+/// Wrapper of `ApiClient` that enables in-memory cache
+///
+/// ```rust
+/// use japanese_address_parser::http::cached_client::CachedApiClient;
+/// use japanese_address_parser::http::client::ApiClient;
+/// use japanese_address_parser::http::reqwest_client::ReqwestApiClient;
+///
+/// let client = CachedApiClient::<ReqwestApiClient>::new();
+/// ```
+pub struct CachedApiClient<C: ApiClient> {
+    client: C,
+    cache: InMemoryCache,
+}
+
+impl<C: ApiClient + Sync> ApiClient for CachedApiClient<C> {
+    fn new() -> Self {
+        Self {
+            client: C::new(),
+            cache: InMemoryCache::new(),
+        }
+    }
+
+    async fn fetch<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
+        // キャッシュが利用できる場合は、キャッシュからバイト列を取得してデシリアライズして利用する
+        if let Some(entry) = self.cache.get(url) {
+            return serde_json::from_slice::<T>(&entry.body).map_err(|e| {
+                ApiClientError::Deserialize {
+                    url: url.to_string(),
+                    message: e.to_string(),
+                }
+            });
+        }
+
+        // キャッシュが利用できない場合は、APIリクエストを行ないデータを取得、取得したデータをキャッシュに保存する
+        let response = self.client.fetch::<Value>(url).await?;
+        let bytes = serde_json::to_vec(&response).map_err(|e| ApiClientError::Deserialize {
+            url: url.to_string(),
+            message: e.to_string(),
+        })?;
+        self.cache.register(url, bytes.clone());
+        serde_json::from_slice::<T>(&bytes).map_err(|e| ApiClientError::Deserialize {
+            url: url.to_string(),
+            message: e.to_string(),
+        })
+    }
+
+    #[cfg(feature = "blocking")]
+    fn fetch_blocking<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
+        // キャッシュが利用できる場合は、キャッシュからバイト列を取得してデシリアライズして利用する
+        if let Some(entry) = self.cache.get(url) {
+            return serde_json::from_slice::<T>(&entry.body).map_err(|e| {
+                ApiClientError::Deserialize {
+                    url: url.to_string(),
+                    message: e.to_string(),
+                }
+            });
+        }
+
+        // キャッシュが利用できない場合は、APIリクエストを行ないデータを取得、取得したデータをキャッシュに保存する
+        let response = self.client.fetch_blocking::<Value>(url)?;
+        let bytes = serde_json::to_vec(&response).map_err(|e| ApiClientError::Deserialize {
+            url: url.to_string(),
+            message: e.to_string(),
+        })?;
+        self.cache.register(url, bytes.clone());
+        serde_json::from_slice::<T>(&bytes).map_err(|e| ApiClientError::Deserialize {
+            url: url.to_string(),
+            message: e.to_string(),
+        })
+    }
+}

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -3,6 +3,7 @@ use crate::http::error::ApiClientError;
 use crate::util::inmemory_cache::InMemoryCache;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+use std::time::Duration;
 
 /// Wrapper of `ApiClient` that enables in-memory cache
 ///
@@ -16,6 +17,16 @@ use serde_json::Value;
 pub struct CachedApiClient<C: ApiClient> {
     client: C,
     cache: InMemoryCache,
+}
+
+impl<C: ApiClient> CachedApiClient<C> {
+    #[allow(dead_code)]
+    fn with_config(ttl: Duration, max_entries: usize) -> Self {
+        Self {
+            client: C::new(),
+            cache: InMemoryCache::with_config(ttl, max_entries),
+        }
+    }
 }
 
 impl<C: ApiClient + Sync> ApiClient for CachedApiClient<C> {

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -86,3 +86,109 @@ impl<C: ApiClient + Sync> ApiClient for CachedApiClient<C> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::http::cached_client::CachedApiClient;
+    use crate::http::client::ApiClient;
+    use crate::http::error::ApiClientError;
+    use serde::de::DeserializeOwned;
+    use serde_json::Value;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    struct MockApiClient {
+        called_count: AtomicUsize,
+    }
+
+    impl MockApiClient {
+        fn generate_dummy_response<T: DeserializeOwned>(
+            &self,
+            _url: &str,
+        ) -> Result<T, ApiClientError> {
+            Ok(serde_json::from_str(&format!(
+                "{{\"called_count\": {}}}",
+                self.called_count.load(Ordering::SeqCst),
+            ))
+            .unwrap())
+        }
+
+        fn increment(&self) {
+            self.called_count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl ApiClient for MockApiClient {
+        fn new() -> Self {
+            Self {
+                called_count: 0.into(),
+            }
+        }
+
+        async fn fetch<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
+            self.increment();
+            self.generate_dummy_response(url)
+        }
+
+        #[cfg(feature = "blocking")]
+        fn fetch_blocking<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiClientError> {
+            self.increment();
+            self.generate_dummy_response(url)
+        }
+    }
+
+    #[tokio::test]
+    async fn キャッシュヒット時はキャッシュされたデータを返すこと() {
+        let client = CachedApiClient::<MockApiClient>::new();
+        let response = client.fetch::<Value>("/endpoint").await.unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+
+        let response = client.fetch::<Value>("/endpoint").await.unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+        assert_ne!(response.get("called_count").unwrap().as_u64(), Some(2));
+    }
+
+    #[tokio::test]
+    async fn キャッシュミス時はfetchによるデータを返すこと() {
+        let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
+        let response = client.fetch::<Value>("/endpoint").await.unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+
+        // 1秒待機
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let response = client.fetch::<Value>("/endpoint").await.unwrap();
+        // TTL=1秒なのでキャッシュミスになるはず
+        assert_ne!(response.get("called_count").unwrap().as_u64(), Some(1));
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(2));
+    }
+
+    #[test]
+    #[cfg(feature = "blocking")]
+    fn キャッシュヒット時はキャッシュされたデータを返すこと_blocking() {
+        let client = CachedApiClient::<MockApiClient>::new();
+        let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+
+        let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+        assert_ne!(response.get("called_count").unwrap().as_u64(), Some(2));
+    }
+
+    #[test]
+    #[cfg(feature = "blocking")]
+    fn キャッシュミス時はfetchによるデータを返すこと_blocking() {
+        let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
+        let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
+
+        // 1秒待機
+        sleep(Duration::from_secs(1));
+
+        let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
+        // TTL=1秒なのでキャッシュミスになるはず
+        assert_ne!(response.get("called_count").unwrap().as_u64(), Some(1));
+        assert_eq!(response.get("called_count").unwrap().as_u64(), Some(2));
+    }
+}

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -94,7 +94,6 @@ mod tests {
     use serde::de::DeserializeOwned;
     use serde_json::Value;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::thread::sleep;
     use std::time::Duration;
 
     struct MockApiClient {
@@ -148,6 +147,7 @@ mod tests {
         assert_ne!(response.get("called_count").unwrap().as_u64(), Some(2));
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn キャッシュミス時はfetchによるデータを返すこと() {
         let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
@@ -183,7 +183,7 @@ mod tests {
         assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
 
         // 1秒待機
-        sleep(Duration::from_secs(1));
+        std::thread::sleep(Duration::from_secs(1));
 
         let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
         // TTL=1秒なのでキャッシュミスになるはず

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -151,15 +151,16 @@ mod tests {
     #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     async fn キャッシュミス時はfetchによるデータを返すこと() {
-        let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
+        let client =
+            CachedApiClient::<MockApiClient>::with_config(Duration::from_millis(1_000), 10);
         let response = client.fetch::<Value>("/endpoint").await.unwrap();
         assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
 
-        // 1秒待機
+        // 1.1秒待機(TTL+0.1秒待機)
         #[cfg(not(target_arch = "wasm32"))]
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        tokio::time::sleep(Duration::from_millis(1_100)).await;
         #[cfg(target_arch = "wasm32")]
-        gloo_timers::future::TimeoutFuture::new(1_000).await;
+        gloo_timers::future::TimeoutFuture::new(1_100).await;
 
         let response = client.fetch::<Value>("/endpoint").await.unwrap();
         // TTL=1秒なのでキャッシュミスになるはず
@@ -182,12 +183,13 @@ mod tests {
     #[test]
     #[cfg(feature = "blocking")]
     fn キャッシュミス時はfetchによるデータを返すこと_blocking() {
-        let client = CachedApiClient::<MockApiClient>::with_config(Duration::from_secs(1), 10);
+        let client =
+            CachedApiClient::<MockApiClient>::with_config(Duration::from_millis(1_000), 10);
         let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
         assert_eq!(response.get("called_count").unwrap().as_u64(), Some(1));
 
-        // 1秒待機
-        std::thread::sleep(Duration::from_secs(1));
+        // 1.1秒待機(TTL+0.1秒待機)
+        std::thread::sleep(Duration::from_millis(1_100));
 
         let response = client.fetch_blocking::<Value>("/endpoint").unwrap();
         // TTL=1秒なのでキャッシュミスになるはず

--- a/core/src/http/cached_client.rs
+++ b/core/src/http/cached_client.rs
@@ -20,8 +20,7 @@ pub struct CachedApiClient<C: ApiClient> {
 }
 
 impl<C: ApiClient> CachedApiClient<C> {
-    #[allow(dead_code)]
-    fn with_config(ttl: Duration, max_entries: usize) -> Self {
+    pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
         Self {
             client: C::new(),
             cache: InMemoryCache::with_config(ttl, max_entries),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@
 //! - `city-name-correction`*(enabled by default)*: Enable autocorrection if ambiguous city name was typed
 //! - `format-house-number`: Enable normalization of addresses after town name
 //! - `eliminate-whitespaces`*(experimental)*: Enable elimination of whitespaces from given text
+//! - `enable-api-client-cache`: Enable In-Memory cache for api client
 //! - `fix-halfwidth-katakana`*(experimental)*: Enable fixing halfwidth katakana with fullwidth ones
 //! - `experimental`: Enable experimental module
 

--- a/core/src/parser.rs
+++ b/core/src/parser.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use crate::domain::common::token::Token;
 use crate::domain::geolonia::entity::Address;
 use crate::domain::geolonia::error::{Error, ParseErrorKind};
+#[cfg(feature = "enable-api-client-cache")]
+use crate::http::cached_client::CachedApiClient;
 use crate::http::reqwest_client::ReqwestApiClient;
 use crate::interactor::geolonia::{GeoloniaInteractor, GeoloniaInteractorImpl};
 use crate::tokenizer::{End, Tokenizer};
@@ -36,7 +38,10 @@ impl From<Tokenizer<End>> for Address {
 /// }
 /// ```
 pub struct Parser {
+    #[cfg(not(feature = "enable-api-client-cache"))]
     interactor: Arc<GeoloniaInteractorImpl<ReqwestApiClient>>,
+    #[cfg(feature = "enable-api-client-cache")]
+    interactor: Arc<GeoloniaInteractorImpl<CachedApiClient<ReqwestApiClient>>>,
 }
 
 impl Default for Parser {

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -1,4 +1,5 @@
 pub mod converter;
 pub(crate) mod extension;
+pub(crate) mod inmemory_cache;
 pub mod sequence_matcher;
 mod trimmer;

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -30,7 +30,6 @@ impl InMemoryCache {
     }
 
     /// キャッシュの初期化(カスタム)
-    #[allow(dead_code)]
     pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
         assert!(max_entries > 0, "max_entries must be greater than 0");
         Self {

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -59,7 +59,7 @@ impl InMemoryCache {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         // キャッシュの最大容量を超える場合は、キャッシュに登録した時刻が最も古いものが削除される
-        if store.len() == self.max_entries {
+        if store.len() == self.max_entries && !store.contains_key(key) {
             if let Some(oldest_key) = store
                 .iter()
                 .min_by_key(|(_, value)| value.registered_at)

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+#[derive(Clone)]
+pub(crate) struct CacheEntry {
+    /// データ
+    pub body: Vec<u8>,
+    /// キャッシュに登録した時刻
+    pub registered_at: Instant,
+}
+
+pub(crate) struct InMemoryCache {
+    /// キャッシュストア
+    store: Arc<RwLock<HashMap<String, CacheEntry>>>,
+    /// キャッシュの保持期間
+    ttl: Duration,
+}
+
+impl InMemoryCache {
+    /// キャッシュの初期化
+    pub fn new() -> Self {
+        Self {
+            store: Arc::new(RwLock::new(HashMap::new())),
+            ttl: Duration::from_secs(3600),
+        }
+    }
+
+    /// キャッシュデータの取得
+    pub fn get(&self, key: &str) -> Option<CacheEntry> {
+        let store = self.store.read().ok()?;
+        let entry = store.get(key).cloned()?;
+        if entry.registered_at.elapsed() < self.ttl {
+            Some(entry)
+        } else {
+            None
+        }
+    }
+
+    /// キャッシュデータの登録
+    pub fn register(&self, key: &str, value: Vec<u8>) {
+        let mut store = self
+            .store
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let entry = CacheEntry {
+            body: value,
+            registered_at: Instant::now(),
+        };
+        store.insert(key.to_string(), entry);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::inmemory_cache::InMemoryCache;
+    use std::ops::Add;
+    use std::time::Duration;
+
+    #[test]
+    fn キャッシュヒット時はキャッシュされたデータを返すこと() {
+        let cache = InMemoryCache::new();
+        cache.register("key1", vec![1, 2, 3, 4, 5]);
+
+        let result = cache.get("key1");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().body, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn キャッシュミス時は_noneを返すこと() {
+        let cache = InMemoryCache::new();
+        cache.register("key1", vec![4, 5, 6]);
+
+        let result = cache.get("invalid key");
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
+        let cache = InMemoryCache::new();
+        cache.register("key1", vec![1, 3, 5, 7, 9]);
+
+        let wait_time = cache.ttl.add(Duration::from_secs(1));
+        tokio::time::sleep(wait_time).await;
+
+        let result = cache.get("key1");
+        assert!(result.is_none());
+    }
+}

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -62,6 +62,9 @@ impl InMemoryCache {
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
+        // まず、期限切れのデータを一掃する
+        store.retain(|_, entry| entry.registered_at.elapsed() < self.ttl);
+
         // キャッシュの最大容量を超える場合は、キャッシュに登録した時刻が最も古いものが削除される
         if store.len() >= self.max_entries && !store.contains_key(key) {
             if let Some(oldest_key) = store

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use web_time::Instant;
 
 #[derive(Clone)]
 pub(crate) struct CacheEntry {
@@ -87,6 +88,7 @@ mod tests {
     use std::time::Duration;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn キャッシュヒット時はキャッシュされたデータを返すこと() {
         let cache = InMemoryCache::new();
         cache.register("key1", vec![1, 2, 3, 4, 5]);
@@ -97,6 +99,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn キャッシュミス時は_noneを返すこと() {
         let cache = InMemoryCache::new();
         cache.register("key1", vec![4, 5, 6]);
@@ -105,19 +108,24 @@ mod tests {
         assert!(result.is_none());
     }
 
-    #[test]
-    fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
+    #[cfg_attr(not(target_arch = "wasm32"), tokio::test)]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
+    async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
         let cache = InMemoryCache::with_config(Duration::from_nanos(1), 10);
         cache.register("key1", vec![1, 3, 5, 7, 9]);
 
-        let wait_time = cache.ttl.add(Duration::from_nanos(1));
-        std::thread::sleep(wait_time);
+        let wait_time = cache.ttl.add(Duration::from_secs(1));
+        #[cfg(not(target_arch = "wasm32"))]
+        tokio::time::sleep(wait_time).await;
+        #[cfg(target_arch = "wasm32")]
+        gloo_timers::future::TimeoutFuture::new(wait_time.as_millis() as u32).await;
 
         let result = cache.get("key1");
         assert!(result.is_none());
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test::wasm_bindgen_test)]
     fn キャッシュ最大容量を超えた場合は最古のエントリが削除されること() {
         let cache = InMemoryCache::with_config(Duration::from_secs(3600), 3);
         cache.register("key1", vec![1, 2, 3]);

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -102,13 +102,13 @@ mod tests {
         assert!(result.is_none());
     }
 
-    #[tokio::test]
-    async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
+    #[test]
+    fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
         let cache = InMemoryCache::with_config(Duration::from_nanos(1), 10);
         cache.register("key1", vec![1, 3, 5, 7, 9]);
 
         let wait_time = cache.ttl.add(Duration::from_nanos(1));
-        tokio::time::sleep(wait_time).await;
+        std::thread::sleep(wait_time);
 
         let result = cache.get("key1");
         assert!(result.is_none());

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -26,6 +26,14 @@ impl InMemoryCache {
         }
     }
 
+    /// キャッシュの初期化(カスタム)
+    pub fn with_config(ttl: Duration) -> Self {
+        Self {
+            store: Arc::new(RwLock::new(HashMap::new())),
+            ttl,
+        }
+    }
+
     /// キャッシュデータの取得
     pub fn get(&self, key: &str) -> Option<CacheEntry> {
         let store = self.store.read().ok()?;
@@ -78,10 +86,10 @@ mod tests {
 
     #[tokio::test]
     async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
-        let cache = InMemoryCache::new();
+        let cache = InMemoryCache::with_config(Duration::from_nanos(1));
         cache.register("key1", vec![1, 3, 5, 7, 9]);
 
-        let wait_time = cache.ttl.add(Duration::from_secs(1));
+        let wait_time = cache.ttl.add(Duration::from_nanos(1));
         tokio::time::sleep(wait_time).await;
 
         let result = cache.get("key1");

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -42,7 +42,11 @@ impl InMemoryCache {
 
     /// キャッシュデータの取得
     pub fn get(&self, key: &str) -> Option<CacheEntry> {
-        let store = self.store.read().ok()?;
+        let store = self
+            .store
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
         let entry = store.get(key).cloned()?;
         if entry.registered_at.elapsed() < self.ttl {
             Some(entry)

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -33,6 +33,7 @@ impl InMemoryCache {
 
     /// キャッシュの初期化(カスタム)
     pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
+        assert!(max_entries > 0, "max_entries must be greater than 0");
         Self {
             store: Arc::new(RwLock::new(HashMap::new())),
             ttl,
@@ -63,7 +64,7 @@ impl InMemoryCache {
             .unwrap_or_else(|poisoned| poisoned.into_inner());
 
         // キャッシュの最大容量を超える場合は、キャッシュに登録した時刻が最も古いものが削除される
-        if store.len() == self.max_entries && !store.contains_key(key) {
+        if store.len() >= self.max_entries && !store.contains_key(key) {
             if let Some(oldest_key) = store
                 .iter()
                 .min_by_key(|(_, value)| value.registered_at)

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
@@ -32,6 +30,7 @@ impl InMemoryCache {
     }
 
     /// キャッシュの初期化(カスタム)
+    #[allow(dead_code)]
     pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
         assert!(max_entries > 0, "max_entries must be greater than 0");
         Self {

--- a/core/src/util/inmemory_cache.rs
+++ b/core/src/util/inmemory_cache.rs
@@ -15,6 +15,8 @@ pub(crate) struct InMemoryCache {
     store: Arc<RwLock<HashMap<String, CacheEntry>>>,
     /// キャッシュの保持期間
     ttl: Duration,
+    /// キャッシュの最大容量
+    max_entries: usize,
 }
 
 impl InMemoryCache {
@@ -23,14 +25,16 @@ impl InMemoryCache {
         Self {
             store: Arc::new(RwLock::new(HashMap::new())),
             ttl: Duration::from_secs(3600),
+            max_entries: 100,
         }
     }
 
     /// キャッシュの初期化(カスタム)
-    pub fn with_config(ttl: Duration) -> Self {
+    pub fn with_config(ttl: Duration, max_entries: usize) -> Self {
         Self {
             store: Arc::new(RwLock::new(HashMap::new())),
             ttl,
+            max_entries,
         }
     }
 
@@ -51,6 +55,18 @@ impl InMemoryCache {
             .store
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        // キャッシュの最大容量を超える場合は、キャッシュに登録した時刻が最も古いものが削除される
+        if store.len() == self.max_entries {
+            if let Some(oldest_key) = store
+                .iter()
+                .min_by_key(|(_, value)| value.registered_at)
+                .map(|(key, _)| key.to_string())
+            {
+                store.remove(&oldest_key);
+            }
+        }
+
         let entry = CacheEntry {
             body: value,
             registered_at: Instant::now(),
@@ -86,7 +102,7 @@ mod tests {
 
     #[tokio::test]
     async fn キャッシュ保持期間を過ぎている場合は_noneを返すこと() {
-        let cache = InMemoryCache::with_config(Duration::from_nanos(1));
+        let cache = InMemoryCache::with_config(Duration::from_nanos(1), 10);
         cache.register("key1", vec![1, 3, 5, 7, 9]);
 
         let wait_time = cache.ttl.add(Duration::from_nanos(1));
@@ -94,5 +110,19 @@ mod tests {
 
         let result = cache.get("key1");
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn キャッシュ最大容量を超えた場合は最古のエントリが削除されること() {
+        let cache = InMemoryCache::with_config(Duration::from_secs(3600), 3);
+        cache.register("key1", vec![1, 2, 3]);
+        cache.register("key2", vec![4, 5, 6]);
+        cache.register("key3", vec![7, 8, 9]);
+
+        assert!(cache.get("key1").is_some());
+
+        cache.register("key4", vec![0, 0, 0]);
+        assert!(cache.get("key1").is_none());
+        assert!(cache.get("key4").is_some());
     }
 }

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.102"
 futures = "0.3.32"
-japanese-address-parser = { version = "0.3.4", path = "../core", features = ["experimental"] }
+japanese-address-parser = { version = "0.3.4", path = "../core", features = ["experimental", "enable-api-client-cache"] }
 rmcp = { version = "1.6.0", features = ["server", "transport-io"] }
 schemars = "1.2.1"
 serde.workspace = true

--- a/public/debug.html
+++ b/public/debug.html
@@ -59,10 +59,10 @@
     const inputTextArea = document.getElementById("input")
 
     init().then(() => {
+        const parser = new Parser();
         document.getElementById("exec").addEventListener("click", () => {
             const input = inputTextArea.value
             alert("input: " + input)
-            const parser = new Parser()
             parser.parse(input).then(result => {
                 document.getElementById("result").appendChild(
                     createRow(input, result)

--- a/public/index.html
+++ b/public/index.html
@@ -56,10 +56,10 @@
     const inputTextArea = document.getElementById("input")
 
     init().then(() => {
+        const parser = new Parser();
         document.getElementById("exec").addEventListener("click", () => {
             const input = inputTextArea.value
             alert("input: " + input)
-            const parser = new Parser()
             parser.parse(input).then(result => {
                 document.getElementById("result").appendChild(
                     createRow(input, result)

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,6 +16,6 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-japanese-address-parser = { path = "../core", features = ["blocking"] }
+japanese-address-parser = { path = "../core", features = ["blocking", "enable-api-client-cache"] }
 pyo3 = { version = "0.29.0", features = ["abi3-py310"] }
 pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }

--- a/wasm/Cargo.toml
+++ b/wasm/Cargo.toml
@@ -27,7 +27,7 @@ nightly = [
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-japanese-address-parser = { path = "../core" }
+japanese-address-parser = { path = "../core", features = ["enable-api-client-cache"] }
 serde-wasm-bindgen = "0.6.5"
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -62,6 +62,12 @@ init().then(() => {
 }
 ```
 
+## Tips
+
+Initialize the `Parser` instance once and reuse it across your application.
+Re-initializing the `Parser` frequently can lead to performance degradation, especially if API client caching is
+enabled, as the cache will be reset for each new instance.
+
 ## How it works
 
 The input string is basically read in order from the beginning to the end.


### PR DESCRIPTION
### 変更点
- #707 
- #708 
- #709 
- #710 
- #712 
- #714 

### 備考
- wasm版、python版、mcp版ではデフォルトでキャッシュが有効になるので、厳密には既存と挙動が変わる可能性があります。
- ただし、住所データは頻繁に変わるものではないので実際の使用上は問題ないと考えています。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional API response caching to improve performance and reduce network requests.

* **Performance Improvements**
  * Optimized Parser initialization for better efficiency during repeated operations.

* **Documentation**
  * Added usage tips for optimal Parser performance, recommending instance reuse over frequent re-initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->