### PR TITLE
表記揺れアルゴリズムのパフォーマンス改善

### DIFF
--- a/core/src/adapter/orthographical_variant_adapter.rs
+++ b/core/src/adapter/orthographical_variant_adapter.rs
@@ -123,18 +123,20 @@ pub struct OrthographicalVariantAdapter {
 
 impl OrthographicalVariantAdapter {
     pub fn apply(&self, input: &str, region_name: &str) -> Option<(String, String)> {
-        let variants = self.filter_variants(input);
+        // 必要最低限のパターンのみを選別する
+        let variants = self.filter_variants(region_name);
         if variants.is_empty() {
             return None;
         }
         self.match_with_variants(input, region_name, variants)
     }
 
-    fn filter_variants(&self, input: &str) -> Vec<&OrthographicalVariant> {
-        // 必要なパターンのみを選別する
+    /// マッチ候補の文字列(target)と表記揺れパターン(self.variant_list)を照らし合わせ、マッチ候補の文字列に含まれる文字のパターンのみを選別する
+    fn filter_variants(&self, target: &str) -> Vec<&OrthographicalVariant> {
+        // マッチ候補の文字列
         self.variant_list
             .iter()
-            .filter(|v| v.value().iter().any(|&c| input.contains(c)))
+            .filter(|v| v.value().iter().any(|&c| target.contains(c)))
             .collect()
     }
 

--- a/core/src/adapter/orthographical_variant_adapter.rs
+++ b/core/src/adapter/orthographical_variant_adapter.rs
@@ -186,9 +186,7 @@ fn modify_specific_character(text: &str, from: char, to: char) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::adapter::orthographical_variant_adapter::{
-        OrthographicalVariant, OrthographicalVariantAdapter,
-    };
+    use crate::adapter::orthographical_variant_adapter::OrthographicalVariant;
 
     #[test]
     fn permutations() {
@@ -210,33 +208,5 @@ mod tests {
                 ('ガ', 'が'),
             ]
         );
-    }
-
-    extern crate test;
-    use test::Bencher;
-
-    #[bench]
-    fn bench_orthographical_variant_performance_regression(b: &mut Bencher) {
-        let adapter = OrthographicalVariantAdapter {
-            variant_list: vec![
-                OrthographicalVariant::ケ,
-                OrthographicalVariant::崎,
-                OrthographicalVariant::塚,
-                OrthographicalVariant::渕,
-                OrthographicalVariant::嶋,
-                OrthographicalVariant::龍,
-                OrthographicalVariant::澤,
-                OrthographicalVariant::濱,
-                OrthographicalVariant::曾,
-                OrthographicalVariant::國,
-            ],
-        };
-
-        let input = "霞ヶ崎塚渕嶋竜沢浜曽国 １丁目";
-        let target = "霞ケ関";
-
-        b.iter(|| {
-            adapter.apply(input, target);
-        });
     }
 }

--- a/core/src/adapter/orthographical_variant_adapter.rs
+++ b/core/src/adapter/orthographical_variant_adapter.rs
@@ -117,13 +117,12 @@ impl OrthographicalVariant {
     }
 }
 
-#[derive(Clone)]
 pub struct OrthographicalVariantAdapter {
     pub variant_list: Vec<OrthographicalVariant>,
 }
 
 impl OrthographicalVariantAdapter {
-    pub fn apply(self, input: &str, region_name: &str) -> Option<(String, String)> {
+    pub fn apply(&self, input: &str, region_name: &str) -> Option<(String, String)> {
         let variants = self.filter_variants(input);
         if variants.is_empty() {
             return None;
@@ -235,7 +234,7 @@ mod tests {
         let target = "霞ケ関";
 
         b.iter(|| {
-            adapter.clone().apply(input, target);
+            adapter.apply(input, target);
         });
     }
 }

--- a/core/src/adapter/orthographical_variant_adapter.rs
+++ b/core/src/adapter/orthographical_variant_adapter.rs
@@ -117,6 +117,149 @@ impl OrthographicalVariant {
     }
 }
 
+struct TextCursor {
+    body: Vec<char>,
+    index: usize,
+}
+
+impl TextCursor {
+    fn advance(&mut self) {
+        self.index += 1;
+    }
+
+    fn current_char(&self) -> char {
+        self.body[self.index]
+    }
+
+    fn is_terminated(&self) -> bool {
+        self.index >= self.body.len()
+    }
+}
+
+struct OrthographicalVariantMatcher {
+    /// ユーザーから入力された文字列
+    input: TextCursor,
+    /// 比較対象となる文字列
+    target: TextCursor,
+    /// 表記揺れとして考慮する文字種のパターン群
+    variants: Vec<OrthographicalVariant>,
+}
+
+impl OrthographicalVariantMatcher {
+    pub fn new<T: Into<String>>(input: T, target: T, variants: Vec<OrthographicalVariant>) -> Self {
+        let input = input.into();
+        let target = target.into();
+        Self {
+            input: TextCursor {
+                body: input.chars().collect(),
+                index: 0,
+            },
+            target: TextCursor {
+                body: target.chars().collect(),
+                index: 0,
+            },
+            variants,
+        }
+    }
+
+    pub fn matches(&mut self) -> bool {
+        // targetを先頭から読み取っていく
+        'outer_loop: while !self.target.is_terminated() {
+            // targetには残りがあるのにinputを読み切ってしまった場合は、処理を終了する
+            if self.input.is_terminated() {
+                return false;
+            }
+
+            let input_char = self.input.current_char();
+            let target_char = self.target.current_char();
+
+            // 文字が一致する場合は、次の文字の評価に進む
+            if input_char == target_char {
+                self.input.advance();
+                self.target.advance();
+                continue;
+            }
+
+            // 文字が一致しない場合は、表記揺れの可能性を疑う
+            for variant in &self.variants {
+                // 同じ表記揺れパターンを共有している場合は、同じ文字であると評価して次の文字の評価に進む
+                if variant.value().contains(&input_char) && variant.value().contains(&target_char) {
+                    self.input.advance();
+                    self.target.advance();
+                    continue 'outer_loop;
+                }
+            }
+
+            // 表記揺れを考慮しても文字が一致しない場合は、マッチ失敗としてfalseを返す
+            return false;
+        }
+
+        // targetを最後まで読み切ったら、マッチ成功としてtrueを返す
+        true
+    }
+}
+
+#[cfg(test)]
+mod matcher_tests {
+    use crate::adapter::orthographical_variant_adapter::{
+        OrthographicalVariant, OrthographicalVariantMatcher,
+    };
+
+    #[test]
+    fn 比較対象より入力のほうが短い場合_falseを返す() {
+        let mut matcher = OrthographicalVariantMatcher::new("千駄ケ谷", "千駄ケ谷四丁目", vec![]);
+        assert_eq!(matcher.matches(), false);
+    }
+
+    #[test]
+    fn 比較対象が入力に対して前方一致する場合_trueを返す() {
+        let mut matcher =
+            OrthographicalVariantMatcher::new("千駄ケ谷四丁目1-1", "千駄ケ谷四丁目", vec![]);
+        assert_eq!(matcher.matches(), true);
+    }
+
+    #[test]
+    fn 表記揺れを考慮したうえで比較対象が入力に対して前方一致する場合_trueを返す() {
+        let mut matcher = OrthographicalVariantMatcher::new(
+            "千駄ヶ谷四丁目1-1",
+            "千駄ケ谷四丁目",
+            vec![OrthographicalVariant::ケ],
+        );
+        assert_eq!(matcher.matches(), true);
+    }
+
+    #[test]
+    fn 表記揺れを考慮しても文字が一致しない場合_falseを返す() {
+        let mut matcher = OrthographicalVariantMatcher::new(
+            "百駄ヶ谷四丁目1-1",
+            "千駄ケ谷四丁目",
+            vec![OrthographicalVariant::ケ],
+        );
+        assert_eq!(matcher.matches(), false);
+    }
+
+    #[test]
+    fn 表記揺れがあるがvariantsに何も指定されていない場合_falseを返す() {
+        let mut matcher =
+            OrthographicalVariantMatcher::new("千駄ヶ谷四丁目", "千駄ケ谷四丁目", vec![]);
+        assert_eq!(matcher.matches(), false);
+    }
+
+    #[test]
+    fn 複数個の表記揺れを考慮したうえで比較対象が入力に対して前方一致する場合_trueを返す() {
+        let mut matcher = OrthographicalVariantMatcher::new(
+            "松が﨑御所之内町",
+            "松ケ崎御所ノ内町",
+            vec![
+                OrthographicalVariant::崎,
+                OrthographicalVariant::の,
+                OrthographicalVariant::ケ,
+            ],
+        );
+        assert_eq!(matcher.matches(), true);
+    }
+}
+
 pub struct OrthographicalVariantAdapter {
     pub variant_list: Vec<OrthographicalVariant>,
 }

--- a/core/src/adapter/orthographical_variant_adapter.rs
+++ b/core/src/adapter/orthographical_variant_adapter.rs
@@ -117,6 +117,7 @@ impl OrthographicalVariant {
     }
 }
 
+#[derive(Clone)]
 pub struct OrthographicalVariantAdapter {
     pub variant_list: Vec<OrthographicalVariant>,
 }
@@ -184,7 +185,9 @@ fn modify_specific_character(text: &str, from: char, to: char) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::adapter::orthographical_variant_adapter::OrthographicalVariant;
+    use crate::adapter::orthographical_variant_adapter::{
+        OrthographicalVariant, OrthographicalVariantAdapter,
+    };
 
     #[test]
     fn permutations() {
@@ -206,5 +209,33 @@ mod tests {
                 ('ガ', 'が'),
             ]
         );
+    }
+
+    extern crate test;
+    use test::Bencher;
+
+    #[bench]
+    fn bench_orthographical_variant_performance_regression(b: &mut Bencher) {
+        let adapter = OrthographicalVariantAdapter {
+            variant_list: vec![
+                OrthographicalVariant::ケ,
+                OrthographicalVariant::崎,
+                OrthographicalVariant::塚,
+                OrthographicalVariant::渕,
+                OrthographicalVariant::嶋,
+                OrthographicalVariant::龍,
+                OrthographicalVariant::澤,
+                OrthographicalVariant::濱,
+                OrthographicalVariant::曾,
+                OrthographicalVariant::國,
+            ],
+        };
+
+        let input = "霞ヶ崎塚渕嶋竜沢浜曽国 １丁目";
+        let target = "霞ケ関";
+
+        b.iter(|| {
+            adapter.clone().apply(input, target);
+        });
     }
 }

--- a/core/src/adapter/orthographical_variant_adapter.rs
+++ b/core/src/adapter/orthographical_variant_adapter.rs
@@ -133,9 +133,13 @@ struct OrthographicalVariantMatcher {
 }
 
 impl OrthographicalVariantMatcher {
-    pub fn new<T: Into<String>>(input: T, target: T, variants: Vec<OrthographicalVariant>) -> Self {
-        let input = input.into();
-        let target = target.into();
+    pub fn new<I: AsRef<str>, T: AsRef<str>>(
+        input: I,
+        target: T,
+        variants: Vec<OrthographicalVariant>,
+    ) -> Self {
+        let input = input.as_ref();
+        let target = target.as_ref();
         Self {
             input: TextCursor {
                 body: input.chars().collect(),

--- a/core/src/adapter/orthographical_variant_adapter.rs
+++ b/core/src/adapter/orthographical_variant_adapter.rs
@@ -102,19 +102,6 @@ impl OrthographicalVariant {
             溪 => &['溪', '渓'],
         }
     }
-
-    fn permutations(&self) -> Vec<(char, char)> {
-        let characters = self.value();
-        let mut permutations = Vec::with_capacity(characters.len() * (characters.len() - 1));
-        for &a in characters {
-            for &b in characters {
-                if a != b {
-                    permutations.push((a, b));
-                }
-            }
-        }
-        permutations
-    }
 }
 
 struct TextCursor {
@@ -271,85 +258,25 @@ impl OrthographicalVariantAdapter {
         if variants.is_empty() {
             return None;
         }
-        self.match_with_variants(input, region_name, variants)
+
+        let mut matcher = OrthographicalVariantMatcher::new(input, region_name, variants);
+
+        if matcher.matches() {
+            return Some((
+                region_name.to_string(),
+                input.chars().skip(region_name.chars().count()).collect(),
+            ));
+        }
+        None
     }
 
     /// マッチ候補の文字列(target)と表記揺れパターン(self.variant_list)を照らし合わせ、マッチ候補の文字列に含まれる文字のパターンのみを選別する
-    fn filter_variants(&self, target: &str) -> Vec<&OrthographicalVariant> {
+    fn filter_variants(&self, target: &str) -> Vec<OrthographicalVariant> {
         // マッチ候補の文字列
         self.variant_list
             .iter()
             .filter(|v| v.value().iter().any(|&c| target.contains(c)))
+            .cloned()
             .collect()
-    }
-
-    fn match_with_variants(
-        &self,
-        input: &str,
-        target: &str,
-        variants: Vec<&OrthographicalVariant>,
-    ) -> Option<(String, String)> {
-        // マッチ候補を容れておくためのVector
-        let mut candidates = vec![target.to_string()];
-        // パターンを一つづつ検証していく
-        for variant in variants {
-            let mut semi_candidates = vec![];
-            // variantから順列を作成
-            // ["ケ", "ヶ", "が"] -> (ケ, ヶ), (ケ, が), (ヶ, ケ), (ヶ, が), (が, ケ), (が, ヶ)
-            for (a, b) in variant.permutations() {
-                for candidate in candidates.iter().filter(|x| x.contains(a)) {
-                    let modified_candidate = modify_specific_character(candidate, a, b);
-                    if input.starts_with(&modified_candidate) {
-                        // マッチすれば早期リターン
-                        return Some((
-                            target.to_string(),
-                            input
-                                .chars()
-                                .skip(modified_candidate.chars().count())
-                                .collect(),
-                        ));
-                    } else {
-                        // マッチしなければsemi_candidatesに置き換え後の文字列をpush
-                        semi_candidates.push(modified_candidate);
-                    }
-                }
-            }
-            candidates = semi_candidates;
-            candidates.push(target.to_string());
-        }
-        None
-    }
-}
-
-fn modify_specific_character(text: &str, from: char, to: char) -> String {
-    text.chars()
-        .map(|x| if x == from { to } else { x })
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::adapter::orthographical_variant_adapter::OrthographicalVariant;
-
-    #[test]
-    fn permutations() {
-        let variant = OrthographicalVariant::ケ;
-        assert_eq!(
-            variant.permutations(),
-            vec![
-                ('ケ', 'ヶ'),
-                ('ケ', 'が'),
-                ('ケ', 'ガ'),
-                ('ヶ', 'ケ'),
-                ('ヶ', 'が'),
-                ('ヶ', 'ガ'),
-                ('が', 'ケ'),
-                ('が', 'ヶ'),
-                ('が', 'ガ'),
-                ('ガ', 'ケ'),
-                ('ガ', 'ヶ'),
-                ('ガ', 'が'),
-            ]
-        );
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,9 @@
 //! - `experimental`: Enable experimental module
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![feature(test)]
+extern crate test;
+
 #[cfg(all(target_family = "wasm", feature = "blocking"))]
 compile_error! {
     "The `blocking` feature is not supported with wasm target."

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,9 +10,6 @@
 //! - `experimental`: Enable experimental module
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![feature(test)]
-extern crate test;
-
 #[cfg(all(target_family = "wasm", feature = "blocking"))]
 compile_error! {
     "The `blocking` feature is not supported with wasm target."


### PR DESCRIPTION
## 変更点
- `orthographical_variant_adapter.rs`で実装している、表記揺れを考慮して住所文字列のマッチングを行なうロジックを改良します。

## 背景
- 例えば「松ケ崎御所ノ内町」のように「ケ」「崎」「ノ」と複数の表記揺れの考慮が必要な地名の場合、従来の実装だと計算量が増大したり、Stringを複数回生成することでメモリ使用量が大きくなる懸念がありました。

## 備考
- 最終的な差分には含めていませんが、簡易的なベンチマークテストを行ない、処理速度について2.9倍の改善が見られました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **機能改善**
  * 表記揺れを含む前方一致の判定方法を見直し、より安定して一致を判定できるようになりました。
  * 一致した場合の返却結果が整理され、入力の残り部分を返す挙動が明確になりました。

* **バグ修正**
  * 一部の表記揺れパターンで一致判定が不安定になる問題を改善しました。
  * マッチング処理の検証を刷新し、判定の信頼性を高めました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->