### PR TITLE
正規表現の再コンパイルを抑制する

### DIFF
--- a/core/src/formatter/chome_with_arabic_numerals.rs
+++ b/core/src/formatter/chome_with_arabic_numerals.rs
@@ -1,4 +1,5 @@
 use crate::util::converter::JapaneseNumber;
+use std::sync::LazyLock;
 
 pub(crate) fn format_chome_with_arabic_numerals(target: &str) -> Option<String> {
     let chome = extract_chome(target)?;
@@ -8,13 +9,14 @@ pub(crate) fn format_chome_with_arabic_numerals(target: &str) -> Option<String> 
 
 fn extract_chome(target: &str) -> Option<String> {
     if cfg!(target_arch = "wasm32") {
-        js_sys::RegExp::new(r"\D+(\d+)丁目", "")
-            .exec(target)?
-            .get(1)
-            .as_string()
+        static REGEX: LazyLock<js_sys::RegExp> =
+            LazyLock::new(|| js_sys::RegExp::new(r"\D+(\d+)丁目", ""));
+        REGEX.exec(target)?.get(1).as_string()
     } else {
-        regex::Regex::new(r"\D+(?<chome>\d+)丁目")
-            .unwrap()
+        static REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+            regex::Regex::new(r"\D+(?<chome>\d+)丁目").expect("regex compile error")
+        });
+        REGEX
             .captures(target)?
             .name("chome")
             .map(|m| m.as_str().to_string())

--- a/core/src/formatter/house_number.rs
+++ b/core/src/formatter/house_number.rs
@@ -1,7 +1,12 @@
+use std::sync::LazyLock;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn format_house_number(input: &str) -> Result<String, &'static str> {
-    let captures = regex::Regex::new(r"(?<block_number>\d+)\D+(?<house_number>\d+)(?<rest>.*)$")
-        .unwrap()
+    static REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+        regex::Regex::new(r"(?<block_number>\d+)\D+(?<house_number>\d+)(?<rest>.*)$")
+            .expect("regex compile error")
+    });
+    let captures = REGEX
         .captures(input)
         .ok_or("マッチするものがありませんでした")?;
     let block_number = captures
@@ -24,12 +29,15 @@ pub(crate) fn format_house_number(input: &str) -> Result<String, &'static str> {
 
 #[cfg(target_arch = "wasm32")]
 pub(crate) fn format_house_number(input: &str) -> Result<String, &'static str> {
-    let captures = js_sys::RegExp::new(
-        r"(?<block_number>\d+)\D+(?<house_number>\d+)(?<rest>.*)$",
-        "",
-    )
-    .exec(input)
-    .ok_or("マッチするものがありませんでした")?;
+    static REGEX: LazyLock<js_sys::RegExp> = LazyLock::new(|| {
+        js_sys::RegExp::new(
+            r"(?<block_number>\d+)\D+(?<house_number>\d+)(?<rest>.*)$",
+            "",
+        )
+    });
+    let captures = REGEX
+        .exec(input)
+        .ok_or("マッチするものがありませんでした")?;
     let block_number = captures
         .get(1)
         .as_string()

--- a/core/src/formatter/informal_town_name_notation.rs
+++ b/core/src/formatter/informal_town_name_notation.rs
@@ -1,24 +1,35 @@
 use crate::util::converter::JapaneseNumber;
+use std::sync::LazyLock;
 
 /// 住居表示実施済みの住所でN丁目のNが算用数字の場合に漢数字に書き換えます
 pub(crate) fn format_informal_town_name_notation(target: &str) -> Option<String> {
     let (town_name, chome, rest) = if cfg!(target_arch = "wasm32") {
-        js_sys::RegExp::new(
-            r"^(\D+)(\d+)[\u002D\u2010\u2011\u2012\u2013\u2014\u2015\u2212\u30FC\uFF0D\uFF70]*(.*)$",
-            "",
-        ).exec(target).and_then(|captures| Some((
-            captures.get(1).as_string()?,
-            captures.get(2).as_string()?.parse::<i8>().ok()?,
-            captures.get(3).as_string()?,
-        )))?
+        static REGEX: LazyLock<js_sys::RegExp> = LazyLock::new(|| {
+            js_sys::RegExp::new(
+                r"^(\D+)(\d+)[\u002D\u2010\u2011\u2012\u2013\u2014\u2015\u2212\u30FC\uFF0D\uFF70]*(.*)$",
+                "",
+            )
+        });
+        REGEX.exec(target).and_then(|captures| {
+            Some((
+                captures.get(1).as_string()?,
+                captures.get(2).as_string()?.parse::<i8>().ok()?,
+                captures.get(3).as_string()?,
+            ))
+        })?
     } else {
-        regex::Regex::new(
-            r"^(?<town_name>\D+)(?<chome>\d+)[\u002D\u2010\u2011\u2012\u2013\u2014\u2015\u2212\u30FC\uFF0D\uFF70]*(?<rest>.*)$",
-        ).unwrap().captures(target).and_then(|captures| Some((
-            captures.name("town_name")?.as_str().to_string(),
-            captures.name("chome")?.as_str().parse::<i8>().ok()?,
-            captures.name("rest")?.as_str().to_string(),
-        )))?
+        static REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
+            regex::Regex::new(
+                r"^(?<town_name>\D+)(?<chome>\d+)[\u002D\u2010\u2011\u2012\u2013\u2014\u2015\u2212\u30FC\uFF0D\uFF70]*(?<rest>.*)$",
+            ).expect("regex compile error")
+        });
+        REGEX.captures(target).and_then(|captures| {
+            Some((
+                captures.name("town_name")?.as_str().to_string(),
+                captures.name("chome")?.as_str().parse::<i8>().ok()?,
+                captures.name("rest")?.as_str().to_string(),
+            ))
+        })?
     };
     // 帯広市西十九条四十二丁目の42が最大なので、43以上の値の場合はNoneを返すようにする
     if chome > 42 {


### PR DESCRIPTION
## 変更点
- 町名解析処理などで正規表現を用いている箇所があるが、関数呼び出しの度に正規表現のコンパイルが行なわれる書き方になっていたので修正します。
- https://docs.rs/regex/latest/regex/#avoid-re-compiling-regexes-especially-in-a-loop



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 住所の町名・丁目・番地の解析処理で、正規表現の初期化を使い回すようになり、繰り返し処理の効率が向上しました。
  * 同じ入力に対する変換処理の安定性が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->