### PR TITLE
wasm-packのインストールURLを最新のものに修正

### DIFF
--- a/.github/workflows/free-test.yaml
+++ b/.github/workflows/free-test.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install wasm-pack
         working-directory: wasm
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build wasm module
         working-directory: wasm
         run: wasm-pack build --target nodejs --scope toriyama

--- a/.github/workflows/ghpages.yaml
+++ b/.github/workflows/ghpages.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Unit Testing for Wasm module
         working-directory: core
         run: wasm-pack test --firefox --headless

--- a/.github/workflows/run-test.yaml
+++ b/.github/workflows/run-test.yaml
@@ -42,7 +42,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }} # mainブランチにコミットが追加された時のみキャッシュを保存する
           cache-provider: 'github'
       - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Run wasm-pack test for core(japanese-address-parser)
         working-directory: core
         run: wasm-pack test --firefox --headless

--- a/.github/workflows/upload-npmjs.yaml
+++ b/.github/workflows/upload-npmjs.yaml
@@ -28,7 +28,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: Setup wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        run: curl https://wasm-bindgen.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Build wasm module
         run: wasm-pack build --release --target web --scope toriyama --out-name japanese_address_parser


### PR DESCRIPTION
## 変更点
- fix: #705 
- wasm-packの所属するGitHub Organizationがrustwasmから(drager氏の個人プロジェクトになったのち)wasm-bindgenに変わったことによる変更

## 備考
- `wasm-pack`がrustwasmを離れる際、もう積極的には開発されないというアナウンスがあったが、どうなったのであろうか。
- もし方針が変わっていないのであれば、wasm-packに依存しない形に移行することを考える必要がある。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 一部の自動化ワークフローで、Wasm 関連ツールのセットアップ方法を最新の配布元に更新しました。
  * これにより、ビルド・テスト・デプロイ時の環境準備がより安定するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->